### PR TITLE
add field clause in EventMessage

### DIFF
--- a/api/subscriptions/event_reader.go
+++ b/api/subscriptions/event_reader.go
@@ -37,10 +37,10 @@ func (er *eventReader) Read() ([]interface{}, bool, error) {
 		}
 		txs := block.Transactions()
 		for i, receipt := range receipts {
-			for _, output := range receipt.Outputs {
+			for clause, output := range receipt.Outputs {
 				for _, event := range output.Events {
 					if er.filter.Match(event) {
-						msg, err := convertEvent(block.Header(), txs[i], event, block.Obsolete)
+						msg, err := convertEvent(block.Header(), txs[i], event, block.Obsolete, clause)
 						if err != nil {
 							return nil, false, err
 						}

--- a/api/subscriptions/types.go
+++ b/api/subscriptions/types.go
@@ -109,9 +109,10 @@ type EventMessage struct {
 	Data     string         `json:"data"`
 	Meta     LogMeta        `json:"meta"`
 	Obsolete bool           `json:"obsolete"`
+	Clause   int            `json:"clause"`
 }
 
-func convertEvent(header *block.Header, tx *tx.Transaction, event *tx.Event, obsolete bool) (*EventMessage, error) {
+func convertEvent(header *block.Header, tx *tx.Transaction, event *tx.Event, obsolete bool, whichClause int) (*EventMessage, error) {
 	signer, err := tx.Signer()
 	if err != nil {
 		return nil, err
@@ -128,6 +129,7 @@ func convertEvent(header *block.Header, tx *tx.Transaction, event *tx.Event, obs
 		},
 		Topics:   event.Topics,
 		Obsolete: obsolete,
+		Clause: whichClause,
 	}, nil
 }
 


### PR DESCRIPTION
I try add the field ```clause``` in the EventMessage,  I don't add ```clause``` in the struct of LogMeta , because Its changes are too big.  It needs take more time to test.

刚才看了一下事件订阅的接口实现， 在事件订阅的返回结果中追加了clause字段。 不过对于transfer的订阅没有追加， 我觉得```/subscriptions
/event/```是包含```/subscriptions/transfer```功能的.

本来想在```/log/events```返回的结果中也添加上clause字段， 但是发现使用的是sqlite，从代码上来看似乎是没有保存这个字段的信息， 扩展起来对以往数据兼容又有问题。暂时作罢。  不知理解是否正确。