### PR TITLE
Update NTP Server in node.go

### DIFF
--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -332,7 +332,7 @@ branch:   %v  %v`, fork.Ancestor,
 }
 
 func checkClockOffset() {
-	resp, err := ntp.Query("ap.pool.ntp.org")
+	resp, err := ntp.Query("pool.ntp.org")
 	if err != nil {
 		log.Debug("failed to access NTP", "err", err)
 		return


### PR DESCRIPTION
NTP Server ap.pool.ntp.org does not exist, so thor node cannot check NTP time.