### PR TITLE
Typo in if statement

### DIFF
--- a/genesis/customnet.go
+++ b/genesis/customnet.go
@@ -35,7 +35,7 @@ type CustomGenesis struct {
 func NewCustomNet(gen *CustomGenesis) (*Genesis, error) {
 	launchTime := gen.LaunchTime
 
-	if gen.GasLimit < 0 {
+	if gen.GasLimit <= 0 {
 		return nil, errors.New("gasLimit must not be 0")
 	}
 	var executor thor.Address


### PR DESCRIPTION
golangci-lint said:
`genesis/customnet.go:38:5: SA4003: unsigned values are never < 0 (staticcheck)`

`if gen.GasLimit < 0 {
    return nil, errors.New("gasLimit must not be 0")
}`
Seems like a typo for me.