### PR TITLE
added opcode, not activated

### DIFF
--- a/vm/README.md
+++ b/vm/README.md
@@ -1,1 +1,13 @@
+2018-12-31
 based on github.com/ethereum/go-ethereum/core/vm v1.8.10 tag
+
+2019-06-17
+based on github.com/ethereum/go-ethereum/core/vm v1.8.27 tag
+Due to thor project dependencies on v1.8.14, Some functions are rewritten:
+
+ - crypto.CreateAddress2 is now CreateAddress2 in patch.go file.
+
+Due to structure differences, some features are not supported:
+ - readOnly property in interpreter.go
+ - WASM interpreter in interpreter.go
+ - func gasSStore() in gas_table.go

--- a/vm/instructions.go
+++ b/vm/instructions.go
@@ -496,6 +496,45 @@ func opExtCodeCopy(pc *uint64, evm *EVM, contract *Contract, memory *Memory, sta
 	return nil, nil
 }
 
+// opExtCodeHash returns the code hash of a specified account.
+// There are several cases when the function is called, while we can relay everything
+// to `state.GetCodeHash` function to ensure the correctness.
+//   (1) Caller tries to get the code hash of a normal contract account, state
+// should return the relative code hash and set it as the result.
+//
+//   (2) Caller tries to get the code hash of a non-existent account, state should
+// return common.Hash{} and zero will be set as the result.
+//
+//   (3) Caller tries to get the code hash for an account without contract code,
+// state should return emptyCodeHash(0xc5d246...) as the result.
+//
+//   (4) Caller tries to get the code hash of a precompiled account, the result
+// should be zero or emptyCodeHash.
+//
+// It is worth noting that in order to avoid unnecessary create and clean,
+// all precompile accounts on mainnet have been transferred 1 wei, so the return
+// here should be emptyCodeHash.
+// If the precompile account is not transferred any amount on a private or
+// customized chain, the return value will be zero.
+//
+//   (5) Caller tries to get the code hash for an account which is marked as suicided
+// in the current transaction, the code hash of this account should be returned.
+//
+//   (6) Caller tries to get the code hash for an account which is marked as deleted,
+// this account should be regarded as a non-existent account and zero should be returned.
+func opExtCodeHash(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+	slot := stack.peek()
+	address := common.BigToAddress(slot)
+	if evm.StateDB.Empty(address) {
+		slot.SetUint64(0)
+	} else if codeHash := evm.StateDB.GetCodeHash(address); codeHash == (common.Hash{}) {
+		slot.SetBytes(emptyCodeHash.Bytes())
+	} else {
+		slot.SetBytes(codeHash.Bytes())
+	}
+	return nil, nil
+}
+
 func opGasprice(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	stack.push(evm.interpreter.intPool.get().Set(evm.GasPrice))
 	return nil, nil
@@ -556,7 +595,7 @@ func opMload(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *St
 func opMstore(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
 	// pop value of the stack
 	mStart, val := stack.pop(), stack.pop()
-	memory.Set(mStart.Uint64(), 32, math.PaddedBigBytes(val, 32))
+	memory.Set32(mStart.Uint64(), val)
 
 	evm.interpreter.intPool.put(mStart, val)
 	return nil, nil
@@ -658,6 +697,34 @@ func opCreate(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *S
 	}
 	contract.Gas += returnGas
 	evm.interpreter.intPool.put(value, offset, size)
+
+	if suberr == errExecutionReverted {
+		return res, nil
+	}
+	return nil, nil
+}
+
+func opCreate2(pc *uint64, evm *EVM, contract *Contract, memory *Memory, stack *Stack) ([]byte, error) {
+	var (
+		endowment    = stack.pop()
+		offset, size = stack.pop(), stack.pop()
+		salt         = stack.pop()
+		input        = memory.Get(offset.Int64(), size.Int64())
+		gas          = contract.Gas
+	)
+
+	// Apply EIP150
+	gas -= gas / 64
+	contract.UseGas(gas)
+	res, addr, returnGas, suberr := evm.Create2(contract, input, gas, endowment, salt)
+	// Push item on the stack based on the returned error.
+	if suberr != nil {
+		stack.push(evm.interpreter.intPool.getZero())
+	} else {
+		stack.push(addr.Big())
+	}
+	contract.Gas += returnGas
+	evm.interpreter.intPool.put(endowment, offset, size, salt)
 
 	if suberr == errExecutionReverted {
 		return res, nil

--- a/vm/instructions_test.go
+++ b/vm/instructions_test.go
@@ -17,10 +17,12 @@
 package vm
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -424,4 +426,81 @@ func BenchmarkOpSAR(b *testing.B) {
 func BenchmarkOpIsZero(b *testing.B) {
 	x := "FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"
 	opBenchmark(b, opIszero, x)
+}
+
+func TestCreate2Addreses(t *testing.T) {
+	type testcase struct {
+		origin   string
+		salt     string
+		code     string
+		expected string
+	}
+
+	for i, tt := range []testcase{
+		{
+			origin:   "0x0000000000000000000000000000000000000000",
+			salt:     "0x0000000000000000000000000000000000000000",
+			code:     "0x00",
+			expected: "0x4d1a2e2bb4f88f0250f26ffff098b0b30b26bf38",
+		},
+		{
+			origin:   "0xdeadbeef00000000000000000000000000000000",
+			salt:     "0x0000000000000000000000000000000000000000",
+			code:     "0x00",
+			expected: "0xB928f69Bb1D91Cd65274e3c79d8986362984fDA3",
+		},
+		{
+			origin:   "0xdeadbeef00000000000000000000000000000000",
+			salt:     "0xfeed000000000000000000000000000000000000",
+			code:     "0x00",
+			expected: "0xD04116cDd17beBE565EB2422F2497E06cC1C9833",
+		},
+		{
+			origin:   "0x0000000000000000000000000000000000000000",
+			salt:     "0x0000000000000000000000000000000000000000",
+			code:     "0xdeadbeef",
+			expected: "0x70f2b2914A2a4b783FaEFb75f459A580616Fcb5e",
+		},
+		{
+			origin:   "0x00000000000000000000000000000000deadbeef",
+			salt:     "0xcafebabe",
+			code:     "0xdeadbeef",
+			expected: "0x60f3f640a8508fC6a86d45DF051962668E1e8AC7",
+		},
+		{
+			origin:   "0x00000000000000000000000000000000deadbeef",
+			salt:     "0xcafebabe",
+			code:     "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+			expected: "0x1d8bfDC5D46DC4f61D6b6115972536eBE6A8854C",
+		},
+		{
+			origin:   "0x0000000000000000000000000000000000000000",
+			salt:     "0x0000000000000000000000000000000000000000",
+			code:     "0x",
+			expected: "0xE33C0C7F7df4809055C3ebA6c09CFe4BaF1BD9e0",
+		},
+	} {
+
+		origin := common.BytesToAddress(common.FromHex(tt.origin))
+		salt := common.BytesToHash(common.FromHex(tt.salt))
+		code := common.FromHex(tt.code)
+		codeHash := crypto.Keccak256(code)
+		// THOR: Cannot use crypto.CreateAddress2 function.
+		// v1.8.14 -> v1.8.27 depedency issue. See patch.go file.
+		address := CreateAddress2(origin, salt, codeHash)
+		/*
+			stack          := newstack()
+			// salt, but we don't need that for this test
+			stack.push(big.NewInt(int64(len(code)))) //size
+			stack.push(big.NewInt(0)) // memstart
+			stack.push(big.NewInt(0)) // value
+			gas, _ := gasCreate2(params.GasTable{}, nil, nil, stack, nil, 0)
+			fmt.Printf("Example %d\n* address `0x%x`\n* salt `0x%x`\n* init_code `0x%x`\n* gas (assuming no mem expansion): `%v`\n* result: `%s`\n\n", i,origin, salt, code, gas, address.String())
+		*/
+		expected := common.BytesToAddress(common.FromHex(tt.expected))
+		if !bytes.Equal(expected.Bytes(), address.Bytes()) {
+			t.Errorf("test %d: expected %s, got %s", i, expected.String(), address.String())
+		}
+
+	}
 }

--- a/vm/jump_table.go
+++ b/vm/jump_table.go
@@ -80,6 +80,21 @@ func NewConstantinopleInstructionSet() [256]operation {
 		validateStack: makeStackFunc(2, 1),
 		valid:         true,
 	}
+	instructionSet[EXTCODEHASH] = operation{
+		execute:       opExtCodeHash,
+		gasCost:       gasExtCodeHash,
+		validateStack: makeStackFunc(1, 1),
+		valid:         true,
+	}
+	instructionSet[CREATE2] = operation{
+		execute:       opCreate2,
+		gasCost:       gasCreate2,
+		validateStack: makeStackFunc(4, 1),
+		memorySize:    memoryCreate2,
+		valid:         true,
+		writes:        true,
+		returns:       true,
+	}
 	return instructionSet
 }
 

--- a/vm/memory.go
+++ b/vm/memory.go
@@ -16,7 +16,12 @@
 
 package vm
 
-import "fmt"
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/math"
+)
 
 // Memory implements a simple memory model for the ethereum virtual machine.
 type Memory struct {
@@ -24,23 +29,39 @@ type Memory struct {
 	lastGasCost uint64
 }
 
+// NewMemory returns a new memory memory model.
 func NewMemory() *Memory {
 	return &Memory{}
 }
 
 // Set sets offset + size to value
+// change in v1.8.14 = v1.8.27
 func (m *Memory) Set(offset, size uint64, value []byte) {
-	// length of store may never be less than offset + size.
-	// The store should be resized PRIOR to setting the memory
-	if size > uint64(len(m.store)) {
-		panic("INVALID memory: store empty")
-	}
-
 	// It's possible the offset is greater than 0 and size equals 0. This is because
 	// the calcMemSize (common.go) could potentially return 0 when size is zero (NO-OP)
 	if size > 0 {
+		// length of store may never be less than offset + size.
+		// The store should be resized PRIOR to setting the memory
+		if offset+size > uint64(len(m.store)) {
+			panic("invalid memory: store empty")
+		}
 		copy(m.store[offset:offset+size], value)
 	}
+}
+
+// Set32 sets the 32 bytes starting at offset to the value of val, left-padded with zeroes to
+// 32 bytes.
+// new in v1.8.14 = v1.8.27
+func (m *Memory) Set32(offset uint64, val *big.Int) {
+	// length of store may never be less than offset + size.
+	// The store should be resized PRIOR to setting the memory
+	if offset+32 > uint64(len(m.store)) {
+		panic("invalid memory: store empty")
+	}
+	// Zero the memory area
+	copy(m.store[offset:offset+32], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+	// Fill in relevant bits
+	math.ReadBits(val, m.store[offset:offset+32])
 }
 
 // Resize resizes the memory to size

--- a/vm/memory_table.go
+++ b/vm/memory_table.go
@@ -58,6 +58,10 @@ func memoryCreate(stack *Stack) *big.Int {
 	return calcMemSize(stack.Back(1), stack.Back(2))
 }
 
+func memoryCreate2(stack *Stack) *big.Int {
+	return calcMemSize(stack.Back(1), stack.Back(2))
+}
+
 func memoryCall(stack *Stack) *big.Int {
 	x := calcMemSize(stack.Back(5), stack.Back(6))
 	y := calcMemSize(stack.Back(3), stack.Back(4))
@@ -65,12 +69,9 @@ func memoryCall(stack *Stack) *big.Int {
 	return math.BigMax(x, y)
 }
 
-func memoryCallCode(stack *Stack) *big.Int {
-	x := calcMemSize(stack.Back(5), stack.Back(6))
-	y := calcMemSize(stack.Back(3), stack.Back(4))
+// Dependency change: v1.8.10 -> v1.8.14 = v1.8.27
+// func memoryCall() deleted.
 
-	return math.BigMax(x, y)
-}
 func memoryDelegateCall(stack *Stack) *big.Int {
 	x := calcMemSize(stack.Back(4), stack.Back(5))
 	y := calcMemSize(stack.Back(2), stack.Back(3))

--- a/vm/opcodes.go
+++ b/vm/opcodes.go
@@ -23,6 +23,7 @@ import (
 // OpCode is an EVM opcode
 type OpCode byte
 
+// IsPush specifies if an opcode is a PUSH opcode.
 func (op OpCode) IsPush() bool {
 	switch op {
 	case PUSH1, PUSH2, PUSH3, PUSH4, PUSH5, PUSH6, PUSH7, PUSH8, PUSH9, PUSH10, PUSH11, PUSH12, PUSH13, PUSH14, PUSH15, PUSH16, PUSH17, PUSH18, PUSH19, PUSH20, PUSH21, PUSH22, PUSH23, PUSH24, PUSH25, PUSH26, PUSH27, PUSH28, PUSH29, PUSH30, PUSH31, PUSH32:
@@ -31,12 +32,13 @@ func (op OpCode) IsPush() bool {
 	return false
 }
 
+// IsStaticJump specifies if an opcode is JUMP.
 func (op OpCode) IsStaticJump() bool {
 	return op == JUMP
 }
 
+// 0x0 range - arithmetic ops.
 const (
-	// 0x0 range - arithmetic ops
 	STOP OpCode = iota
 	ADD
 	MUL
@@ -51,6 +53,7 @@ const (
 	SIGNEXTEND
 )
 
+// 0x10 range - comparison ops.
 const (
 	LT OpCode = iota + 0x10
 	GT
@@ -70,8 +73,8 @@ const (
 	SHA3 = 0x20
 )
 
+// 0x30 range - closure state.
 const (
-	// 0x30 range - closure state
 	ADDRESS OpCode = 0x30 + iota
 	BALANCE
 	ORIGIN
@@ -87,10 +90,11 @@ const (
 	EXTCODECOPY
 	RETURNDATASIZE
 	RETURNDATACOPY
+	EXTCODEHASH
 )
 
+// 0x40 range - block operations.
 const (
-	// 0x40 range - block operations
 	BLOCKHASH OpCode = 0x40 + iota
 	COINBASE
 	TIMESTAMP
@@ -99,8 +103,8 @@ const (
 	GASLIMIT
 )
 
+// 0x50 range - 'storage' and execution.
 const (
-	// 0x50 range - 'storage' and execution
 	POP OpCode = 0x50 + iota
 	MLOAD
 	MSTORE
@@ -115,8 +119,8 @@ const (
 	JUMPDEST
 )
 
+// 0x60 range.
 const (
-	// 0x60 range
 	PUSH1 OpCode = 0x60 + iota
 	PUSH2
 	PUSH3
@@ -183,6 +187,7 @@ const (
 	SWAP16
 )
 
+// 0xa0 range - logging ops.
 const (
 	LOG0 OpCode = 0xa0 + iota
 	LOG1
@@ -191,29 +196,30 @@ const (
 	LOG4
 )
 
-// unofficial opcodes used for parsing
+// unofficial opcodes used for parsing.
 const (
 	PUSH OpCode = 0xb0 + iota
 	DUP
 	SWAP
 )
 
+// 0xf0 range - closures.
 const (
-	// 0xf0 range - closures
 	CREATE OpCode = 0xf0 + iota
 	CALL
 	CALLCODE
 	RETURN
 	DELEGATECALL
+	CREATE2
 	STATICCALL = 0xfa
 
 	REVERT       = 0xfd
 	SELFDESTRUCT = 0xff
 )
 
-// Since the opcodes aren't all in order we can't use a regular slice
+// Since the opcodes aren't all in order we can't use a regular slice.
 var opCodeToString = map[OpCode]string{
-	// 0x0 range - arithmetic ops
+	// 0x0 range - arithmetic ops.
 	STOP:       "STOP",
 	ADD:        "ADD",
 	MUL:        "MUL",
@@ -232,7 +238,7 @@ var opCodeToString = map[OpCode]string{
 	ISZERO:     "ISZERO",
 	SIGNEXTEND: "SIGNEXTEND",
 
-	// 0x10 range - bit ops
+	// 0x10 range - bit ops.
 	AND:    "AND",
 	OR:     "OR",
 	XOR:    "XOR",
@@ -243,10 +249,10 @@ var opCodeToString = map[OpCode]string{
 	ADDMOD: "ADDMOD",
 	MULMOD: "MULMOD",
 
-	// 0x20 range - crypto
+	// 0x20 range - crypto.
 	SHA3: "SHA3",
 
-	// 0x30 range - closure state
+	// 0x30 range - closure state.
 	ADDRESS:        "ADDRESS",
 	BALANCE:        "BALANCE",
 	ORIGIN:         "ORIGIN",
@@ -262,8 +268,9 @@ var opCodeToString = map[OpCode]string{
 	EXTCODECOPY:    "EXTCODECOPY",
 	RETURNDATASIZE: "RETURNDATASIZE",
 	RETURNDATACOPY: "RETURNDATACOPY",
+	EXTCODEHASH:    "EXTCODEHASH",
 
-	// 0x40 range - block operations
+	// 0x40 range - block operations.
 	BLOCKHASH:  "BLOCKHASH",
 	COINBASE:   "COINBASE",
 	TIMESTAMP:  "TIMESTAMP",
@@ -271,7 +278,7 @@ var opCodeToString = map[OpCode]string{
 	DIFFICULTY: "DIFFICULTY",
 	GASLIMIT:   "GASLIMIT",
 
-	// 0x50 range - 'storage' and execution
+	// 0x50 range - 'storage' and execution.
 	POP: "POP",
 	//DUP:     "DUP",
 	//SWAP:    "SWAP",
@@ -287,7 +294,7 @@ var opCodeToString = map[OpCode]string{
 	GAS:      "GAS",
 	JUMPDEST: "JUMPDEST",
 
-	// 0x60 range - push
+	// 0x60 range - push.
 	PUSH1:  "PUSH1",
 	PUSH2:  "PUSH2",
 	PUSH3:  "PUSH3",
@@ -360,12 +367,13 @@ var opCodeToString = map[OpCode]string{
 	LOG3:   "LOG3",
 	LOG4:   "LOG4",
 
-	// 0xf0 range
+	// 0xf0 range.
 	CREATE:       "CREATE",
 	CALL:         "CALL",
 	RETURN:       "RETURN",
 	CALLCODE:     "CALLCODE",
 	DELEGATECALL: "DELEGATECALL",
+	CREATE2:      "CREATE2",
 	STATICCALL:   "STATICCALL",
 	REVERT:       "REVERT",
 	SELFDESTRUCT: "SELFDESTRUCT",
@@ -429,6 +437,7 @@ var stringToOp = map[string]OpCode{
 	"EXTCODECOPY":    EXTCODECOPY,
 	"RETURNDATASIZE": RETURNDATASIZE,
 	"RETURNDATACOPY": RETURNDATACOPY,
+	"EXTCODEHASH":    EXTCODEHASH,
 	"BLOCKHASH":      BLOCKHASH,
 	"COINBASE":       COINBASE,
 	"TIMESTAMP":      TIMESTAMP,
@@ -517,6 +526,7 @@ var stringToOp = map[string]OpCode{
 	"LOG3":           LOG3,
 	"LOG4":           LOG4,
 	"CREATE":         CREATE,
+	"CREATE2":        CREATE2,
 	"CALL":           CALL,
 	"RETURN":         RETURN,
 	"CALLCODE":       CALLCODE,
@@ -524,6 +534,7 @@ var stringToOp = map[string]OpCode{
 	"SELFDESTRUCT":   SELFDESTRUCT,
 }
 
+// StringToOp finds the opcode whose name is stored in `str`.
 func StringToOp(str string) OpCode {
 	return stringToOp[str]
 }

--- a/vm/patch.go
+++ b/vm/patch.go
@@ -1,0 +1,21 @@
+// Tale of two dependencies.
+// Reason:
+// Currently, thor depends on v1.8.14 of go-ethereum project.
+// However, Constantinople upgrade requires v1.8.27 go-ethereum dependency.
+// Solution:
+// This patch exists to temporarily reflect the change of library before
+// thor finally upgrades fully to dependency v1.8.27.
+
+package vm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// CreateAddress2 creates an ethereum address given the address bytes, initial
+// contract code hash and a salt.
+// v1.8.27
+func CreateAddress2(b common.Address, salt [32]byte, inithash []byte) common.Address {
+	return common.BytesToAddress(crypto.Keccak256([]byte{0xff}, b.Bytes(), salt[:], inithash)[12:])
+}


### PR DESCRIPTION
Upgraded EVM from v1.8.14 to v1.8.27

Features:
- opcode `create2`
- opcode `extcodehash`

Not implemented:

Due to dependency limitation, some features require a mass scale of dependency change, which is not implemented. See `vm/README.md`.

Solo Testing:
Test code: [thor-create2-test](https://github.com/laalaguer/thor-create2-test) 
- `create2` external test passed. 
- `extcodehash` external test passed.

Testnet Testing:
- `testnet` syncing test passed till latest.
