### PR TITLE
chain: improve tx/receipt persistence

### DIFF
--- a/api/accounts/accounts.go
+++ b/api/accounts/accounts.go
@@ -320,14 +320,14 @@ func (a *Accounts) handleRevision(revision string) (*block.Header, error) {
 		if err != nil {
 			return nil, utils.BadRequest(errors.WithMessage(err, "revision"))
 		}
-		h, _, err := a.repo.GetBlockHeader(blockID)
+		summary, err := a.repo.GetBlockSummary(blockID)
 		if err != nil {
 			if a.repo.IsNotFound(err) {
 				return nil, utils.BadRequest(errors.WithMessage(err, "revision"))
 			}
 			return nil, err
 		}
-		return h, nil
+		return summary.Header, nil
 	}
 	n, err := strconv.ParseUint(revision, 0, 0)
 	if err != nil {

--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/vechain/thor/api/utils"
-	"github.com/vechain/thor/block"
 	"github.com/vechain/thor/chain"
 	"github.com/vechain/thor/thor"
 )
@@ -33,18 +32,18 @@ func (b *Blocks) handleGetBlock(w http.ResponseWriter, req *http.Request) error 
 	if err != nil {
 		return utils.BadRequest(errors.WithMessage(err, "revision"))
 	}
-	block, err := b.getBlock(revision)
+	summary, err := b.getBlockSummary(revision)
 	if err != nil {
 		if b.repo.IsNotFound(err) {
 			return utils.WriteJSON(w, nil)
 		}
 		return err
 	}
-	isTrunk, err := b.isTrunk(block.Header().ID(), block.Header().Number())
+	isTrunk, err := b.isTrunk(summary.Header.ID(), summary.Header.Number())
 	if err != nil {
 		return err
 	}
-	blk, err := convertBlock(block, isTrunk)
+	blk, err := convertBlock(summary, isTrunk)
 	if err != nil {
 		return err
 	}
@@ -72,15 +71,21 @@ func (b *Blocks) parseRevision(revision string) (interface{}, error) {
 	return uint32(n), err
 }
 
-func (b *Blocks) getBlock(revision interface{}) (*block.Block, error) {
+func (b *Blocks) getBlockSummary(revision interface{}) (s *chain.BlockSummary, err error) {
+	var id thor.Bytes32
 	switch revision.(type) {
 	case thor.Bytes32:
-		return b.repo.GetBlock(revision.(thor.Bytes32))
+		id = revision.(thor.Bytes32)
+		return b.repo.GetBlockSummary(revision.(thor.Bytes32))
 	case uint32:
-		return b.repo.NewBestChain().GetBlock(revision.(uint32))
+		id, err = b.repo.NewBestChain().GetBlockID(revision.(uint32))
+		if err != nil {
+			return
+		}
 	default:
-		return b.repo.BestBlock(), nil
+		id = b.repo.BestBlock().Header().ID()
 	}
+	return b.repo.GetBlockSummary(id)
 }
 
 func (b *Blocks) isTrunk(blkID thor.Bytes32, blkNum uint32) (bool, error) {

--- a/api/blocks/types.go
+++ b/api/blocks/types.go
@@ -6,7 +6,7 @@
 package blocks
 
 import (
-	"github.com/vechain/thor/block"
+	"github.com/vechain/thor/chain"
 	"github.com/vechain/thor/thor"
 )
 
@@ -30,21 +30,14 @@ type Block struct {
 	Transactions []thor.Bytes32 `json:"transactions"`
 }
 
-func convertBlock(b *block.Block, isTrunk bool) (*Block, error) {
-	if b == nil {
-		return nil, nil
-	}
-	signer, err := b.Header().Signer()
+func convertBlock(summary *chain.BlockSummary, isTrunk bool) (*Block, error) {
+	header := summary.Header
+
+	signer, err := header.Signer()
 	if err != nil {
 		return nil, err
 	}
-	txs := b.Transactions()
-	txIds := make([]thor.Bytes32, len(txs))
-	for i, tx := range txs {
-		txIds[i] = tx.ID()
-	}
 
-	header := b.Header()
 	return &Block{
 		Number:       header.Number(),
 		ID:           header.ID(),
@@ -55,12 +48,12 @@ func convertBlock(b *block.Block, isTrunk bool) (*Block, error) {
 		GasUsed:      header.GasUsed(),
 		Beneficiary:  header.Beneficiary(),
 		Signer:       signer,
-		Size:         uint32(b.Size()),
+		Size:         uint32(summary.Size),
 		StateRoot:    header.StateRoot(),
 		ReceiptsRoot: header.ReceiptsRoot(),
 		TxsRoot:      header.TxsRoot(),
 		TxsFeatures:  uint32(header.TxsFeatures()),
 		IsTrunk:      isTrunk,
-		Transactions: txIds,
+		Transactions: summary.Txs,
 	}, nil
 }

--- a/api/transactions/transactions.go
+++ b/api/transactions/transactions.go
@@ -40,7 +40,7 @@ func (t *Transactions) getRawTransaction(txID thor.Bytes32, head thor.Bytes32) (
 		return nil, err
 	}
 
-	header, _, err := t.repo.GetBlockHeader(meta.BlockID)
+	summary, err := t.repo.GetBlockSummary(meta.BlockID)
 	if err != nil {
 		return nil, err
 	}
@@ -51,9 +51,9 @@ func (t *Transactions) getRawTransaction(txID thor.Bytes32, head thor.Bytes32) (
 	return &rawTransaction{
 		RawTx: RawTx{hexutil.Encode(raw)},
 		Meta: TxMeta{
-			BlockID:        header.ID(),
-			BlockNumber:    header.Number(),
-			BlockTimestamp: header.Timestamp(),
+			BlockID:        summary.Header.ID(),
+			BlockNumber:    summary.Header.Number(),
+			BlockTimestamp: summary.Header.Timestamp(),
 		},
 	}, nil
 }
@@ -67,11 +67,11 @@ func (t *Transactions) getTransactionByID(txID thor.Bytes32, head thor.Bytes32) 
 		return nil, err
 	}
 
-	h, _, err := t.repo.GetBlockHeader(meta.BlockID)
+	summary, err := t.repo.GetBlockSummary(meta.BlockID)
 	if err != nil {
 		return nil, err
 	}
-	return convertTransaction(tx, h)
+	return convertTransaction(tx, summary.Header)
 }
 
 //GetTransactionReceiptByID get tx's receipt
@@ -90,12 +90,12 @@ func (t *Transactions) getTransactionReceiptByID(txID thor.Bytes32, head thor.By
 		return nil, err
 	}
 
-	h, _, err := t.repo.GetBlockHeader(meta.BlockID)
+	summary, err := t.repo.GetBlockSummary(meta.BlockID)
 	if err != nil {
 		return nil, err
 	}
 
-	return convertReceipt(receipt, h, tx)
+	return convertReceipt(receipt, summary.Header, tx)
 }
 func (t *Transactions) handleSendTransaction(w http.ResponseWriter, req *http.Request) error {
 	var rawTx *RawTx
@@ -131,7 +131,7 @@ func (t *Transactions) handleGetTransactionByID(w http.ResponseWriter, req *http
 	if err != nil {
 		return utils.BadRequest(errors.WithMessage(err, "head"))
 	}
-	if _, _, err := t.repo.GetBlockHeader(head); err != nil {
+	if _, err := t.repo.GetBlockSummary(head); err != nil {
 		if t.repo.IsNotFound(err) {
 			return utils.BadRequest(errors.WithMessage(err, "head"))
 		}
@@ -167,7 +167,7 @@ func (t *Transactions) handleGetTransactionReceiptByID(w http.ResponseWriter, re
 		return utils.BadRequest(errors.WithMessage(err, "head"))
 	}
 
-	if _, _, err := t.repo.GetBlockHeader(head); err != nil {
+	if _, err := t.repo.GetBlockSummary(head); err != nil {
 		if t.repo.IsNotFound(err) {
 			return utils.BadRequest(errors.WithMessage(err, "head"))
 		}

--- a/chain/block_reader_test.go
+++ b/chain/block_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/vechain/thor/block"
 	"github.com/vechain/thor/chain"
 )
 
@@ -46,7 +47,10 @@ func TestBlockReader(t *testing.T) {
 
 	}
 
-	assert.Equal(t, []*chain.ExtendedBlock{{b3, false}, {b4, false}}, blks)
+	assert.Equal(t, []*chain.ExtendedBlock{
+		{block.Compose(b3.Header(), b3.Transactions()), false},
+		{block.Compose(b4.Header(), b4.Transactions()), false}},
+		blks)
 }
 
 func TestBlockReaderFork(t *testing.T) {
@@ -86,5 +90,10 @@ func TestBlockReaderFork(t *testing.T) {
 		blks = append(blks, r...)
 	}
 
-	assert.Equal(t, []*chain.ExtendedBlock{{b2x, true}, {b2, false}, {b3, false}, {b4, false}}, blks)
+	assert.Equal(t, []*chain.ExtendedBlock{
+		{block.Compose(b2x.Header(), b2x.Transactions()), true},
+		{block.Compose(b2.Header(), b2.Transactions()), false},
+		{block.Compose(b3.Header(), b3.Transactions()), false},
+		{block.Compose(b4.Header(), b4.Transactions()), false}},
+		blks)
 }

--- a/chain/cache.go
+++ b/chain/cache.go
@@ -7,7 +7,6 @@ package chain
 
 import (
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/vechain/thor/thor"
 )
 
 type cache struct {
@@ -19,14 +18,14 @@ func newCache(maxSize int) *cache {
 	return &cache{c}
 }
 
-func (c *cache) GetOrLoad(id thor.Bytes32, load func() (interface{}, error)) (interface{}, error) {
-	if value, ok := c.Get(id); ok {
+func (c *cache) GetOrLoad(key interface{}, load func() (interface{}, error)) (interface{}, error) {
+	if value, ok := c.Get(key); ok {
 		return value, nil
 	}
 	value, err := load()
 	if err != nil {
 		return nil, err
 	}
-	c.Add(id, value)
+	c.Add(key, value)
 	return value, nil
 }

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -6,12 +6,14 @@
 package chain_test
 
 import (
+	"testing"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
+	"github.com/vechain/thor/block"
 	"github.com/vechain/thor/chain"
 	"github.com/vechain/thor/thor"
 	"github.com/vechain/thor/tx"
-	"testing"
 )
 
 func newTx() *tx.Transaction {
@@ -45,7 +47,7 @@ func TestChain(t *testing.T) {
 	assert.Equal(t, b3.Header().ID(), c.HeadID())
 	assert.Equal(t, M(b3.Header().ID(), nil), M(c.GetBlockID(3)))
 	assert.Equal(t, M(b3.Header(), nil), M(c.GetBlockHeader(3)))
-	assert.Equal(t, M(b3, nil), M(c.GetBlock(3)))
+	assert.Equal(t, M(block.Compose(b3.Header(), b3.Transactions()), nil), M(c.GetBlock(3)))
 
 	_, err := c.GetBlockID(4)
 	assert.True(t, c.IsNotFound(err))

--- a/cmd/thor/pruner/pruner.go
+++ b/cmd/thor/pruner/pruner.go
@@ -167,21 +167,25 @@ func (p *Pruner) archiveIndexTrie(pruner *muxdb.TriePruner, n1, n2 uint32) (node
 	var (
 		bestChain              = p.repo.NewBestChain()
 		id1, id2, root1, root2 thor.Bytes32
+		s1, s2                 *chain.BlockSummary
 	)
 
 	if id1, err = bestChain.GetBlockID(n1); err != nil {
 		return
 	}
-	if _, root1, err = p.repo.GetBlockHeader(id1); err != nil {
+	if s1, err = p.repo.GetBlockSummary(id1); err != nil {
 		return
 	}
+	root1 = s1.IndexRoot
 
 	if id2, err = bestChain.GetBlockID(n2); err != nil {
 		return
 	}
-	if _, root2, err = p.repo.GetBlockHeader(id2); err != nil {
+	if s2, err = p.repo.GetBlockSummary(id2); err != nil {
 		return
 	}
+	root2 = s2.IndexRoot
+
 	if n1 == 0 && n2 == 0 {
 		root1 = thor.Bytes32{}
 	}

--- a/cmd/thor/sync_logdb.go
+++ b/cmd/thor/sync_logdb.go
@@ -128,10 +128,11 @@ func seekLogDBSyncPosition(repo *chain.Repository, logDB *logdb.LogDB) (uint32, 
 			break
 		}
 
-		header, _, err = repo.GetBlockHeader(header.ParentID())
+		summary, err := repo.GetBlockSummary(header.ParentID())
 		if err != nil {
 			return 0, err
 		}
+		header = summary.Header
 	}
 	return block.Number(header.ID()) + 1, nil
 

--- a/comm/announcement_loop.go
+++ b/comm/announcement_loop.go
@@ -59,7 +59,7 @@ func (c *Communicator) announcementLoop() {
 }
 
 func (c *Communicator) fetchBlockByID(peer *Peer, newBlockID thor.Bytes32) {
-	if _, _, err := c.repo.GetBlockHeader(newBlockID); err != nil {
+	if _, err := c.repo.GetBlockSummary(newBlockID); err != nil {
 		if !c.repo.IsNotFound(err) {
 			peer.logger.Error("failed to get block header", "err", err)
 		}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -46,7 +46,7 @@ func New(repo *chain.Repository, stater *state.Stater, forkConfig thor.ForkConfi
 func (c *Consensus) Process(blk *block.Block, nowTimestamp uint64) (*state.Stage, tx.Receipts, error) {
 	header := blk.Header()
 
-	if _, _, err := c.repo.GetBlockHeader(header.ID()); err != nil {
+	if _, err := c.repo.GetBlockSummary(header.ID()); err != nil {
 		if !c.repo.IsNotFound(err) {
 			return nil, nil, err
 		}
@@ -54,7 +54,7 @@ func (c *Consensus) Process(blk *block.Block, nowTimestamp uint64) (*state.Stage
 		return nil, nil, errKnownBlock
 	}
 
-	parentHeader, _, err := c.repo.GetBlockHeader(header.ParentID())
+	parentSummary, err := c.repo.GetBlockSummary(header.ParentID())
 	if err != nil {
 		if !c.repo.IsNotFound(err) {
 			return nil, nil, err
@@ -62,7 +62,7 @@ func (c *Consensus) Process(blk *block.Block, nowTimestamp uint64) (*state.Stage
 		return nil, nil, errParentMissing
 	}
 
-	state := c.stater.NewState(parentHeader.StateRoot())
+	state := c.stater.NewState(parentSummary.Header.StateRoot())
 
 	vip191 := c.forkConfig.VIP191
 	if vip191 == 0 {
@@ -84,7 +84,7 @@ func (c *Consensus) Process(blk *block.Block, nowTimestamp uint64) (*state.Stage
 		return nil, nil, consensusError(fmt.Sprintf("block txs features invalid: want %v, have %v", features, header.TxsFeatures()))
 	}
 
-	stage, receipts, err := c.validate(state, blk, parentHeader, nowTimestamp)
+	stage, receipts, err := c.validate(state, blk, parentSummary.Header, nowTimestamp)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -97,16 +97,16 @@ func (c *Consensus) NewRuntimeForReplay(header *block.Header, skipPoA bool) (*ru
 	if err != nil {
 		return nil, err
 	}
-	parentHeader, _, err := c.repo.GetBlockHeader(header.ParentID())
+	parentSummary, err := c.repo.GetBlockSummary(header.ParentID())
 	if err != nil {
 		if !c.repo.IsNotFound(err) {
 			return nil, err
 		}
 		return nil, errParentMissing
 	}
-	state := c.stater.NewState(parentHeader.StateRoot())
+	state := c.stater.NewState(parentSummary.Header.StateRoot())
 	if !skipPoA {
-		if _, err := c.validateProposer(header, parentHeader, state); err != nil {
+		if _, err := c.validateProposer(header, parentSummary.Header, state); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
- introduce BlockSummary for block header persistence
- store one tx/receipt per record instead of bundle
- optimize tx/receipt cache
- optimize /blocks query API (without need to query block body)