### PR TITLE
cmd(thor): improve handle exit signal

### DIFF
--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -117,14 +117,12 @@ func homeDir() string {
 func handleExitSignal() context.Context {
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		exitSignalCh := make(chan os.Signal)
-		signal.Notify(exitSignalCh, os.Interrupt, os.Kill, syscall.SIGTERM)
+		exitSignalCh := make(chan os.Signal, 1)
+		signal.Notify(exitSignalCh, os.Interrupt, syscall.SIGTERM)
 
-		select {
-		case sig := <-exitSignalCh:
-			log.Info("exit signal received", "signal", sig)
-			cancel()
-		}
+		sig := <-exitSignalCh
+		log.Info("exit signal received", "signal", sig)
+		cancel()
 	}()
 	return ctx
 }


### PR DESCRIPTION
the channel used with signal.Notify should be buffered (SA1017)
os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)
should use a simple channel send/receive instead of select with a single case (S1000)