### PR TITLE
VIP-215

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ package.json
 /vendor/
 
 .fake_gopath_suffix
+.idea/

--- a/api/transactions/types.go
+++ b/api/transactions/types.go
@@ -7,9 +7,13 @@ package transactions
 
 import (
 	"fmt"
+	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/vechain/thor/block"
 	"github.com/vechain/thor/thor"
@@ -60,6 +64,20 @@ type Transaction struct {
 	DependsOn    *thor.Bytes32       `json:"dependsOn"`
 	Size         uint32              `json:"size"`
 	Meta         *TxMeta             `json:"meta"`
+}
+
+// VIP-215
+// LegacyTx is the transaction data of regular Ethereum transactions.
+type EthTransaction struct {
+	Nonce    uint64          `json:"nonce"` // nonce of sender account
+	ChainID	 *big.Int        `json:"chainId"` // chain id of the network
+	GasPrice *big.Int        // wei per gas
+	Gas      uint64          `json:"gasLimit"` // gas limit
+	To       *common.Address `json:"to"` // nil means contract creation
+	Value    *big.Int        `json:"value"`// wei amount
+	Data     []byte          // contract invocation input data
+	V 	  	 byte            `json:"v"` // signature
+	R, S     *big.Int        // signature values
 }
 
 type RawTx struct {

--- a/tx/features.go
+++ b/tx/features.go
@@ -6,6 +6,7 @@ type Features uint32
 const (
 	// DelegationFeature See VIP-191 for more detail. (https://github.com/vechain/VIPs/blob/master/vips/VIP-191.md)
 	DelegationFeature Features = 1
+	EthTxnFeature     Features = 2
 )
 
 // IsDelegated returns whether tx is delegated.
@@ -19,5 +20,19 @@ func (f *Features) SetDelegated(flag bool) {
 		*f |= DelegationFeature
 	} else {
 		*f &= (^DelegationFeature)
+	}
+}
+
+// IsEthTransaction returns whether tx is delegated.
+func (f Features) IsEthTransaction() bool {
+	return (f & EthTxnFeature) == EthTxnFeature
+}
+
+// SetDelegated set tx delegated flag.
+func (f *Features) SetEthTransaction(flag bool) {
+	if flag {
+		*f |= EthTxnFeature
+	} else {
+		*f &= (^EthTxnFeature)
 	}
 }


### PR DESCRIPTION
## Disclaimer
The following PR code should be treated as experimental pseudocode with the intention of proving the VIP possible and to assist any developers should the wish to implement the aforementioned. 

## Approach
In this pull request, we extended the API `/transaction` end point to take a JSON object that represents at typical Ethereum transaction.

## Mapping to native transaction schema
We implemented two factory functions to cast the Ethereum style transaction to the VeChain style transaction.  While not all fields have been mapped, the pseudocode should be ample to show the intent.

## Other considerations
Verifying the Eth signed transaction using the Eth implemented cryptographic functions, naminly Keccak-256 & secp256k1 have not been fully tested, but we are confident signature verification can be achieved by inspection of the `/crypto` module.