### PR TITLE
Upgrade ecvrf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ dep:| go_version_check
 
 go_version_check:
 	@if test $(MAJOR) -lt 1; then \
-		echo "Go 1.13 or higher required"; \
+		echo "Go 1.16 or higher required"; \
 		exit 1; \
 	else \
-		if test $(MAJOR) -eq 1 -a $(MINOR) -lt 13; then \
-			echo "Go 1.13 or higher required"; \
+		if test $(MAJOR) -eq 1 -a $(MINOR) -lt 16; then \
+			echo "Go 1.16 or higher required"; \
 			exit 1; \
 		fi \
 	fi

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A general purpose blockchain highly compatible with Ethereum's ecosystem.
 
 This is the first implementation written in golang.
 
-[![Go](https://img.shields.io/badge/golang-%3E%3D1.13-orange.svg)](https://golang.org)
+[![Go](https://img.shields.io/badge/golang-%3E%3D1.16-orange.svg)](https://golang.org)
 [![Go Report Card](https://goreportcard.com/badge/github.com/vechain/thor)](https://goreportcard.com/report/github.com/vechain/thor)
 [![Travis](https://travis-ci.org/vechain/thor.svg?branch=master)](https://travis-ci.org/vechain/thor)
 [![License](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://github.com/vechain/thor/blob/master/LICENSE)
@@ -30,7 +30,7 @@ This is the first implementation written in golang.
 
 ### Requirements
 
-Thor requires `Go` 1.13+ and `C` compiler to build. To install `Go`, follow this [link](https://golang.org/doc/install).
+Thor requires `Go` 1.16+ and `C` compiler to build. To install `Go`, follow this [link](https://golang.org/doc/install).
 
 ### Getting the source
 

--- a/block/header.go
+++ b/block/header.go
@@ -227,7 +227,7 @@ func (h *Header) Beta() (beta []byte, err error) {
 		return
 	}
 
-	return ecvrf.NewSecp256k1Sha256Tai().Verify(pub, h.body.Extension.Alpha, ComplexSignature(h.body.Signature).Proof())
+	return ecvrf.Secp256k1Sha256Tai.Verify(pub, h.body.Extension.Alpha, ComplexSignature(h.body.Signature).Proof())
 }
 
 // EncodeRLP implements rlp.Encoder

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -164,7 +164,7 @@ func (tc *testConsensus) signWithKey(builder *block.Builder, pk *ecdsa.PrivateKe
 			}
 			alpha = beta
 		}
-		_, proof, err := ecvrf.NewSecp256k1Sha256Tai().Prove(pk, alpha)
+		_, proof, err := ecvrf.Secp256k1Sha256Tai.Prove(pk, alpha)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vechain/thor
 
-go 1.13
+go 1.16
 
 require (
 	github.com/aristanetworks/goarista v0.0.0-20180222005525-c41ed3986faa // indirect
@@ -35,7 +35,7 @@ require (
 	github.com/rjeczalik/notify v0.9.1 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
-	github.com/vechain/go-ecvrf v0.0.0-20200326080414-5b7e9ee61906
+	github.com/vechain/go-ecvrf v0.0.0-20220525125849-96fa0442e765
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
 	gopkg.in/cheggaaa/pb.v1 v1.0.28

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,9 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/elastic/gosigar v0.10.5 h1:GzPQ+78RaAb4J63unidA/JavQRKrB6s8IOzN6Ib59jo=
 github.com/elastic/gosigar v0.10.5/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
@@ -94,6 +97,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/vechain/go-ecvrf v0.0.0-20200326080414-5b7e9ee61906 h1:llHjJ24ov25y8DtT+Aw5uJl7HCRWoJHRmhH7Y9/TYQI=
 github.com/vechain/go-ecvrf v0.0.0-20200326080414-5b7e9ee61906/go.mod h1:HM7kygiu1D0CdotRa2u8z4I8AW9sRShPSjpLuIw0kyE=
+github.com/vechain/go-ecvrf v0.0.0-20220525125849-96fa0442e765 h1:jvr+TSivjObZmOKVdqlgeLtRhaDG27gE39PMuE2IJ24=
+github.com/vechain/go-ecvrf v0.0.0-20220525125849-96fa0442e765/go.mod h1:cwnTMgAVzMb30xMKnGI1LdU1NjMiPllYb7i3ibj/fzE=
 github.com/vechain/goleveldb v1.0.1-0.20220107084823-eb292ce39601 h1:aVghsG74P5IPh0l2JDjg8WmshVJDrlNGJkBxH4mKPIE=
 github.com/vechain/goleveldb v1.0.1-0.20220107084823-eb292ce39601/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/packer/flow.go
+++ b/packer/flow.go
@@ -193,7 +193,7 @@ func (f *Flow) Pack(privateKey *ecdsa.PrivateKey, newBlockConflicts uint32) (*bl
 			return nil, nil, nil, err
 		}
 
-		_, proof, err := ecvrf.NewSecp256k1Sha256Tai().Prove(privateKey, alpha)
+		_, proof, err := ecvrf.Secp256k1Sha256Tai.Prove(privateKey, alpha)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/poa/seed_test.go
+++ b/poa/seed_test.go
@@ -131,7 +131,7 @@ func TestSeeder_Generate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, proof, err := ecvrf.NewSecp256k1Sha256Tai().Prove(priv, parentBeta)
+		_, proof, err := ecvrf.Secp256k1Sha256Tai.Prove(priv, parentBeta)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
faster and less allocs

```
benchstat master.txt pr.txt 
name                                old time/op    new time/op    delta
VRF/secp256k1sha256tai-proving-8       483µs ±19%     281µs ± 9%  -41.97%  (p=0.008 n=5+5)
VRF/secp256k1sha256tai-verifying-8     645µs ± 7%     411µs ± 2%  -36.28%  (p=0.008 n=5+5)
VRF/p256sha256tai-proving-8            257µs ±11%     192µs ± 0%  -25.36%  (p=0.008 n=5+5)
VRF/p256sha256tai-verifying-8          353µs ± 8%     302µs ± 0%  -14.26%  (p=0.008 n=5+5)

name                                old alloc/op   new alloc/op   delta
VRF/secp256k1sha256tai-proving-8      15.5kB ±49%     4.9kB ± 0%  -68.42%  (p=0.008 n=5+5)
VRF/secp256k1sha256tai-verifying-8    15.8kB ±31%     5.0kB ± 0%  -68.24%  (p=0.016 n=5+4)
VRF/p256sha256tai-proving-8           12.0kB ±22%     9.1kB ± 0%  -24.10%  (p=0.008 n=5+5)
VRF/p256sha256tai-verifying-8         18.7kB ±12%    19.5kB ± 0%     ~     (p=0.127 n=5+5)

name                                old allocs/op  new allocs/op  delta
VRF/secp256k1sha256tai-proving-8        512 ±100%        95 ± 0%  -81.45%  (p=0.008 n=5+5)
VRF/secp256k1sha256tai-verifying-8       526 ±62%       114 ± 0%  -78.34%  (p=0.008 n=5+5)
VRF/p256sha256tai-proving-8              383 ±45%       294 ± 0%     ~     (p=0.127 n=5+5)
VRF/p256sha256tai-verifying-8            498 ±30%       515 ± 0%     ~     (p=0.683 n=5+5)
```