### PR TITLE
Faster trie node encode

### DIFF
--- a/lowrlp/encoder.go
+++ b/lowrlp/encoder.go
@@ -9,7 +9,6 @@ package lowrlp
 
 import (
 	"io"
-	"sync"
 )
 
 // Encoder is the low-level rlp encoder.
@@ -20,26 +19,11 @@ type Encoder struct {
 	sizebuf [9]byte    // auxiliary buffer for uint encoding
 }
 
-var pool = sync.Pool{
-	New: func() interface{} { return &Encoder{} },
-}
-
-func NewEncoder() *Encoder {
-	w := pool.Get().(*Encoder)
-	w.Reset()
-	return w
-}
-
 // Reset reset the encoder state.
 func (w *Encoder) Reset() {
 	w.lhsize = 0
 	w.str = w.str[:0]
 	w.lheads = w.lheads[:0]
-}
-
-// Release puts back the inner state into pool.
-func (w *Encoder) Release() {
-	pool.Put(w)
 }
 
 // EncodeString encodes the string value.

--- a/state/state.go
+++ b/state/state.go
@@ -462,13 +462,12 @@ func (s *State) Stage(newBlockNum, newBlockConflicts uint32) (*Stage, error) {
 			c.storage[key.key] = v.(rlp.RawValue)
 			if len(c.meta.StorageID) == 0 {
 				// generate storage id for the new storage trie.
-				enc := lowrlp.NewEncoder()
+				var enc lowrlp.Encoder
 				enc.EncodeUint(uint64(newBlockNum))
 				enc.EncodeUint(uint64(newBlockConflicts))
 				enc.EncodeUint(uint64(storageTrieCreationCount))
 				storageTrieCreationCount++
 				c.meta.StorageID = enc.ToBytes()
-				enc.Release()
 			}
 		case storageBarrierKey:
 			if c, jerr = getChanged(thor.Address(key)); jerr != nil {

--- a/trie/fast_node_encoder.go
+++ b/trie/fast_node_encoder.go
@@ -6,87 +6,66 @@
 package trie
 
 import (
-	"io"
-
 	"github.com/vechain/thor/lowrlp"
 )
 
-// fastNodeEncoder is the fast node encoder using low-level rlp encoder.
-type fastNodeEncoder struct{}
+// implements node.encode and node.encodeTrailing
 
-var frlp fastNodeEncoder
-
-// Encode writes the RLP encoding of node to w.
-func (fastNodeEncoder) Encode(w io.Writer, node node, nonCrypto bool) error {
-	enc := lowrlp.NewEncoder()
-	defer enc.Release()
-
-	fastEncodeNode(enc, node, nonCrypto)
-	return enc.ToWriter(w)
-}
-
-// EncodeToBytes returns the RLP encoding of node.
-func (fastNodeEncoder) EncodeToBytes(collapsed node, nonCrypto bool) []byte {
-	enc := lowrlp.NewEncoder()
-	defer enc.Release()
-
-	fastEncodeNode(enc, collapsed, nonCrypto)
-	return enc.ToBytes()
-}
-
-func (fastNodeEncoder) EncodeTrailing(w io.Writer, collapsed node) error {
-	enc := lowrlp.NewEncoder()
-	defer enc.Release()
-	fastEncodeNodeTrailing(enc, collapsed)
-	return enc.ToWriter(w)
-}
-
-func fastEncodeNode(w *lowrlp.Encoder, collapsed node, nonCrypto bool) {
-	switch n := collapsed.(type) {
-	case *fullNode:
-		offset := w.List()
-		for _, c := range n.Children {
-			if c != nil {
-				fastEncodeNode(w, c, nonCrypto)
-			} else {
-				w.EncodeEmptyString()
-			}
-		}
-		w.ListEnd(offset)
-	case *shortNode:
-		offset := w.List()
-		w.EncodeString(n.Key)
-		if n.Val != nil {
-			fastEncodeNode(w, n.Val, nonCrypto)
+func (n *fullNode) encode(e *lowrlp.Encoder, nonCrypto bool) {
+	off := e.List()
+	for _, c := range n.Children {
+		if c != nil {
+			c.encode(e, nonCrypto)
 		} else {
-			w.EncodeEmptyString()
+			e.EncodeEmptyString()
 		}
-		w.ListEnd(offset)
-	case *hashNode:
-		if nonCrypto {
-			w.EncodeString(nonCryptoNodeHashPlaceholder)
-		} else {
-			w.EncodeString(n.Hash[:])
+	}
+	e.ListEnd(off)
+}
+
+func (n *fullNode) encodeTrailing(e *lowrlp.Encoder) {
+	for _, c := range n.Children {
+		if c != nil {
+			c.encodeTrailing(e)
 		}
-	case *valueNode:
-		w.EncodeString(n.Value)
 	}
 }
 
-func fastEncodeNodeTrailing(w *lowrlp.Encoder, collapsed node) {
-	switch n := collapsed.(type) {
-	case *shortNode:
-		fastEncodeNodeTrailing(w, n.Val)
-	case *fullNode:
-		for _, c := range n.Children {
-			fastEncodeNodeTrailing(w, c)
-		}
-	case *valueNode:
-		// skip empty node
-		if len(n.Value) > 0 {
-			w.EncodeString(n.meta)
-		}
-	case *hashNode:
-		w.EncodeUint(n.seq)
+func (n *shortNode) encode(e *lowrlp.Encoder, nonCrypto bool) {
+	off := e.List()
+	e.EncodeString(n.Key)
+	if n.Val != nil {
+		n.Val.encode(e, nonCrypto)
+	} else {
+		e.EncodeEmptyString()
+	}
+	e.ListEnd(off)
+}
+
+func (n *shortNode) encodeTrailing(e *lowrlp.Encoder) {
+	if n.Val != nil {
+		n.Val.encodeTrailing(e)
+	}
+}
+
+func (n *hashNode) encode(e *lowrlp.Encoder, nonCrypto bool) {
+	if nonCrypto {
+		e.EncodeString(nonCryptoNodeHashPlaceholder)
+	} else {
+		e.EncodeString(n.Hash[:])
+	}
+}
+
+func (n *hashNode) encodeTrailing(e *lowrlp.Encoder) {
+	e.EncodeUint(n.seq)
+}
+
+func (n *valueNode) encode(e *lowrlp.Encoder, nonCrypto bool) {
+	e.EncodeString(n.Value)
+}
+
+func (n *valueNode) encodeTrailing(e *lowrlp.Encoder) {
+	if len(n.Value) > 0 {
+		e.EncodeString(n.meta)
 	}
 }

--- a/trie/node.go
+++ b/trie/node.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/vechain/thor/lowrlp"
 	"github.com/vechain/thor/thor"
 )
 
@@ -36,6 +37,8 @@ type node interface {
 	fstring(string) string
 	cache() (*hashNode, bool, uint16)
 	seqNum() uint64
+	encode(e *lowrlp.Encoder, nonCrypto bool)
+	encodeTrailing(*lowrlp.Encoder)
 }
 
 type (

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -75,14 +75,17 @@ func BenchmarkEncodeFullNode(b *testing.B) {
 }
 
 func BenchmarkFastEncodeFullNode(b *testing.B) {
-	var buf sliceBuffer
 	f := &fullNode{}
 	for i := 0; i < len(f.Children); i++ {
 		f.Children[i] = &hashNode{Hash: thor.BytesToBytes32(randBytes(32))}
 	}
 
+	h := newHasher(0, 0)
+
 	for i := 0; i < b.N; i++ {
-		buf.Reset()
-		frlp.Encode(&buf, f, false)
+		h.enc.Reset()
+		f.encode(&h.enc, false)
+		h.tmp.Reset()
+		h.enc.ToWriter(&h.tmp)
 	}
 }

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -76,11 +76,14 @@ func (t *Trie) Prove(key []byte, fromLevel uint, proofDb DatabaseWriter) error {
 			if fromLevel > 0 {
 				fromLevel--
 			} else {
-				enc := frlp.EncodeToBytes(n, false)
+				hasher.enc.Reset()
+				n.encode(&hasher.enc, hasher.nonCrypto)
+				hasher.tmp.Reset()
+				hasher.enc.ToWriter(&hasher.tmp)
 				if ok {
-					proofDb.Put(hash.Hash[:], enc)
+					proofDb.Put(hash.Hash[:], hasher.tmp)
 				} else {
-					proofDb.Put(thor.Blake2b(enc).Bytes(), enc)
+					proofDb.Put(thor.Blake2b(hasher.tmp).Bytes(), hasher.tmp)
 				}
 			}
 		}


### PR DESCRIPTION
In this PR, lowrlp.Encoder is not pooled, instead the encoder is cached in hasher object( saves pool.Get/Put callings).

benchmarks:

```bash
$ benchstat before.txt after.txt 
name                  old time/op  new time/op  delta
FastEncodeFullNode-8   216ns ± 1%   180ns ± 0%  -16.97%  (p=0.008 n=5+5)
```
