### PR TITLE
Add API call for public access to the pending transaction pool

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -166,6 +166,36 @@ paths:
               schema:
                 $ref: '#/components/schemas/Storage'
 
+  /transactions/pending:
+    parameters:
+      - $ref: '#/components/parameters/RawInQuery'
+      - $ref: '#/components/parameters/ExpandedTxInQuery'
+    get:
+      tags:
+        - Transactions
+      summary: Retrieve pending transactions
+      description: |
+        represents the current transaction pool
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:                        
+                  oneOf:
+                    - allOf:
+                      - $ref: '#/components/schemas/Tx'
+                      properties:
+                        meta:
+                          required: false
+                          $ref: '#/components/schemas/TxMeta'
+                    - allOf:
+                      - $ref: '#/components/schemas/RawTx'
+                      description: raw transaction
+                example: ['0x4de71f2d588aa8a1ea00fe8312d92966da424d9939a511fc0be81e65fad52af8']
+
   /transactions/{id}:
     parameters:
       - $ref: '#/components/parameters/TxIDInPath'
@@ -1411,5 +1441,14 @@ components:
       required: false
       description: |
         whether to return tx, even it's pending
+      schema:
+        type: boolean
+
+    ExpandedTxInQuery:
+      name: expanded
+      in: query
+      required: false
+      description: |
+        whether to return tx details
       schema:
         type: boolean

--- a/api/transactions/transactions.go
+++ b/api/transactions/transactions.go
@@ -226,18 +226,18 @@ func (t *Transactions) getAllTxIDsFromTxpool() ([]string, error) {
 
 func (t *Transactions) handleGetAllTxIDsFromTxPool(w http.ResponseWriter, req *http.Request) error {
     raw := req.URL.Query().Get("raw")
-    detailed := req.URL.Query().Get("detailed")
+    expanded := req.URL.Query().Get("expanded")
 
     if raw != "" && raw != "false" && raw != "true" {
         return utils.BadRequest(errors.New("raw should be boolean"))
     }
 
-    if detailed != "" && detailed != "false" && detailed != "true" {
-        return utils.BadRequest(errors.New("detailed should be boolean"))
+    if expanded != "" && expanded != "false" && expanded != "true" {
+        return utils.BadRequest(errors.New("expanded should be boolean"))
     }
 
     rawBool := raw == "true"
-    detailedBool := detailed == "true"
+    expandedBool := expanded == "true"
 
     txs := t.pool.Executables()
     if rawBool {
@@ -250,7 +250,7 @@ func (t *Transactions) handleGetAllTxIDsFromTxPool(w http.ResponseWriter, req *h
             rawTxs = append(rawTxs, RawTx{hexutil.Encode(raw)})
         }
         return utils.WriteJSON(w, rawTxs)
-    } else if detailedBool {
+    } else if expandedBool {
         detailedTxs := make([]*Transaction, 0, len(txs))
         for _, tx := range txs {
             detailedTxs = append(detailedTxs, convertTransaction(tx, nil))
@@ -269,7 +269,7 @@ func (t *Transactions) Mount(root *mux.Router, pathPrefix string) {
 	sub := root.PathPrefix(pathPrefix).Subrouter()
 
 	sub.Path("").Methods("POST").HandlerFunc(utils.WrapHandlerFunc(t.handleSendTransaction))
+	sub.Path("/pending").Methods("GET").HandlerFunc(utils.WrapHandlerFunc(t.handleGetAllTxIDsFromTxPool))
 	sub.Path("/{id}").Methods("GET").HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionByID))
 	sub.Path("/{id}/receipt").Methods("GET").HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionReceiptByID))
-    	sub.Path("/txpool/txids").Methods("GET").HandlerFunc(utils.WrapHandlerFunc(t.handleGetAllTxIDsFromTxPool))
 }


### PR DESCRIPTION
Currently there is no direct way to access the transaction pool through the API. Adding this functionality will enable users to query information about transactions in the tx pool. Currently the information is only available through modified nodes and providing a public access will make it available to everyone. It is a common function on other EVM based networks as well.

Changes:
1. Added functionality to `transaction.go` for handling the API request and retrieving all pending transactions from the tx pool.
  - New RESTful API endpoint with query parameters: 
    - /transactions/pending: Returns transaction IDs from the tx pool.
    - /transactions/pending?raw=true: Returns raw transactions from the tx pool.
    - /transactions/pending?expanded=true: Returns detailed transactions from the tx pool.
2. Implemented tests for pending transactions.
3. Added documentation for querying the tx pool with swagger

Note: `thor.yaml` has been extended but needs to be compiled as a binary version into `bindata.go` to make the updated documentation available.
