### PR TITLE
docker container runs thor under new user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,11 @@ RUN make all
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
-COPY --from=builder /go/thor/bin/thor /usr/local/bin/
-COPY --from=builder /go/thor/bin/disco /usr/local/bin/
+RUN adduser -D -s /bin/ash thor
+USER thor
+ENV PATH="$PATH:/home/thor"
+COPY --from=builder /go/thor/bin/thor /home/thor
+COPY --from=builder /go/thor/bin/disco /home/thor
 
 EXPOSE 8669 11235 11235/udp 55555/udp
 ENTRYPOINT ["thor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ RUN make all
 FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
+COPY --from=builder /go/thor/bin/thor /usr/local/bin/
+COPY --from=builder /go/thor/bin/disco /usr/local/bin/
 RUN adduser -D -s /bin/ash thor
 USER thor
-ENV PATH="$PATH:/home/thor"
-COPY --from=builder /go/thor/bin/thor /home/thor
-COPY --from=builder /go/thor/bin/disco /home/thor
 
 EXPOSE 8669 11235 11235/udp 55555/udp
 ENTRYPOINT ["thor"]


### PR DESCRIPTION
docker runs the node though a new `thor` user, following [the slowmist security guidelines](https://github.com/slowmist/vechain-core-nodes-security-checklist/blob/master/README-en.md#23-avoid-using-root-to-run-thor), instead of the current implementation, which runs it under `root`