### PR TITLE
cmd/thor: set default cache size to 4GB

### DIFF
--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -126,7 +126,7 @@ var (
 	cacheFlag = cli.IntFlag{
 		Name:  "cache",
 		Usage: "megabytes of ram allocated to trie nodes cache",
-		Value: 2048,
+		Value: 4096,
 	}
 	disablePrunerFlag = cli.BoolFlag{
 		Name:  "disable-pruner",

--- a/cmd/thor/node/packer_loop.go
+++ b/cmd/thor/node/packer_loop.go
@@ -19,7 +19,7 @@ import (
 )
 
 // gasLimitSoftLimit is the soft limit of the adaptive block gaslimit.
-const gasLimitSoftLimit uint64 = 30_000_000
+const gasLimitSoftLimit uint64 = 40_000_000
 
 func (n *Node) packerLoop(ctx context.Context) {
 	log.Debug("enter packer loop")


### PR DESCRIPTION
Salute to Apple's New 8GB MacBook Pro.