### PR TITLE
Add builtin tests

### DIFF
--- a/builtin/energy/energy_test.go
+++ b/builtin/energy/energy_test.go
@@ -35,11 +35,83 @@ func TestEnergy(t *testing.T) {
 		{M(eng.Get(acc)), M(big.NewInt(10), nil)},
 		{M(eng.Sub(acc, big.NewInt(5))), M(true, nil)},
 		{M(eng.Sub(acc, big.NewInt(6))), M(false, nil)},
+		{eng.Add(acc, big.NewInt(0)), nil},
+		{M(eng.Sub(acc, big.NewInt(0))), M(true, nil)},
 	}
 
 	for _, tt := range tests {
 		assert.Equal(t, tt.expected, tt.ret)
 	}
+}
+
+func TestInitialSupply(t *testing.T) {
+	db := muxdb.NewMem()
+	st := state.New(db, thor.Bytes32{}, 0, 0, 0)
+
+	eng := New(thor.BytesToAddress([]byte("eng")), st, 0)
+
+	eng.SetInitialSupply(big.NewInt(123), big.NewInt(456))
+
+	supply, err := eng.getInitialSupply()
+
+	assert.Nil(t, err)
+	assert.Equal(t, supply, initialSupply{Token: big.NewInt(123), Energy: big.NewInt(456), BlockTime: 0x0})
+}
+
+func TestInitialSupplyError(t *testing.T) {
+	db := muxdb.NewMem()
+	st := state.New(db, thor.Bytes32{}, 0, 0, 0)
+
+	eng := New(thor.BytesToAddress([]byte("a1")), st, 0)
+
+	eng.SetInitialSupply(big.NewInt(0), big.NewInt(0))
+
+	supply, err := eng.getInitialSupply()
+
+	assert.Nil(t, err)
+	assert.Equal(t, supply, initialSupply{Token: big.NewInt(0), Energy: big.NewInt(0), BlockTime: 0x0})
+}
+
+func TestTotalSupply(t *testing.T) {
+	db := muxdb.NewMem()
+	st := state.New(db, thor.Bytes32{}, 0, 0, 0)
+
+	eng := New(thor.BytesToAddress([]byte("eng")), st, 0)
+
+	eng.SetInitialSupply(big.NewInt(123), big.NewInt(456))
+
+	totalSupply, err := eng.TotalSupply()
+
+	assert.Nil(t, err)
+	assert.Equal(t, totalSupply, big.NewInt(456))
+}
+
+func TestTokenTotalSupply(t *testing.T) {
+	db := muxdb.NewMem()
+	st := state.New(db, thor.Bytes32{}, 0, 0, 0)
+
+	eng := New(thor.BytesToAddress([]byte("eng")), st, 0)
+
+	eng.SetInitialSupply(big.NewInt(123), big.NewInt(456))
+
+	totalTokenSupply, err := eng.TokenTotalSupply()
+
+	assert.Nil(t, err)
+	assert.Equal(t, totalTokenSupply, big.NewInt(123))
+}
+
+func TestTotalBurned(t *testing.T) {
+	db := muxdb.NewMem()
+	st := state.New(db, thor.Bytes32{}, 0, 0, 0)
+
+	eng := New(thor.BytesToAddress([]byte("eng")), st, 0)
+
+	eng.SetInitialSupply(big.NewInt(123), big.NewInt(456))
+
+	totalBurned, err := eng.TotalBurned()
+
+	assert.Nil(t, err)
+	assert.Equal(t, totalBurned, big.NewInt(0))
 }
 
 func TestEnergyGrowth(t *testing.T) {

--- a/builtin/energy/energy_test.go
+++ b/builtin/energy/energy_test.go
@@ -50,10 +50,14 @@ func TestInitialSupply(t *testing.T) {
 
 	eng := New(thor.BytesToAddress([]byte("eng")), st, 0)
 
+	// get initial supply before set should return 0
+	supply, err := eng.getInitialSupply()
+	assert.Nil(t, err)
+	assert.Equal(t, supply, initialSupply{Token: big.NewInt(0), Energy: big.NewInt(0), BlockTime: 0x0})
+
 	eng.SetInitialSupply(big.NewInt(123), big.NewInt(456))
 
-	supply, err := eng.getInitialSupply()
-
+	supply, err = eng.getInitialSupply()
 	assert.Nil(t, err)
 	assert.Equal(t, supply, initialSupply{Token: big.NewInt(123), Energy: big.NewInt(456), BlockTime: 0x0})
 }


### PR DESCRIPTION
This PR addresses this [issue](https://github.com/vechainfoundation/protocol-board-repo/issues/31). Tests have been added for `energy.go` to increase coverage from 49.15 to 79.7%. The reason for not having above 80% coverage is uncoverable code. For example see the snippet below:


```golang
func (e *Energy) getInitialSupply() (init initialSupply, err error) {
	err = e.state.DecodeStorage(e.addr, initialSupplyKey, func(raw []byte) error {
		if len(raw) == 0 {
			init = initialSupply{&big.Int{}, &big.Int{}, 0}
			return nil
		}
		return rlp.DecodeBytes(raw, &init)
	})
	return
}
```

In the snippet above we want to cover the path inside the `if len(raw) == 0` path. The issue is that this is only (to my understanding) affected by the `initialSupplyKey` which is hardcoded and cannot be passed as argument. Other uncovered code relies on this snippet to return error thus leaving enough uncovered code to not reach 80%. 

Another way we could reach the code is to allow the `New` function in `state.go` to take the function we pass in `stackedMap.New()` as argument. Thus we can pass a function that always errors. 