### PR TITLE
Add cmd tests to increase coverage

### DIFF
--- a/cmd/thor/node/master_test.go
+++ b/cmd/thor/node/master_test.go
@@ -1,0 +1,31 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/vechain/thor/v2/thor"
+)
+
+func TestAddress(t *testing.T) {
+	// Generate a new private key
+	privateKey, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("Failed to generate private key: %v", err)
+	}
+
+	// Create a new Master instance
+	master := &Master{
+		PrivateKey: privateKey,
+	}
+
+	// Compute the expected address
+	expectedAddress := thor.Address(crypto.PubkeyToAddress(privateKey.PublicKey))
+
+	// Use the Address method
+	resultAddress := master.Address()
+
+	// Assert that the computed address is correct
+	assert.Equal(t, expectedAddress, resultAddress, "The computed address does not match the expected address")
+}

--- a/cmd/thor/node/stats_test.go
+++ b/cmd/thor/node/stats_test.go
@@ -1,0 +1,48 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/mclock"
+	"github.com/stretchr/testify/assert"
+	"github.com/vechain/thor/v2/block"
+)
+
+func TestUpdateProcessed(t *testing.T) {
+	var s blockStats
+
+	n := 10
+	txs := 5
+	exec := mclock.AbsTime(100)
+	commit := mclock.AbsTime(200)
+	real := mclock.AbsTime(300)
+	usedGas := uint64(5000)
+
+	s.UpdateProcessed(n, txs, exec, commit, real, usedGas)
+
+	assert.Equal(t, 10, s.processed, "processed count mismatch")
+	assert.Equal(t, 5, s.txs, "txs count mismatch")
+	assert.Equal(t, mclock.AbsTime(100), s.exec, "exec time mismatch")
+	assert.Equal(t, mclock.AbsTime(200), s.commit, "commit time mismatch")
+	assert.Equal(t, mclock.AbsTime(300), s.real, "real time mismatch")
+	assert.Equal(t, uint64(5000), s.usedGas, "usedGas mismatch")
+}
+
+func TestLogContext(t *testing.T) {
+	var s blockStats
+	// Initialize blockStats with some data
+	s.txs = 10
+	s.usedGas = 5000000 // 5 million gas
+	s.exec = mclock.AbsTime(2000)
+	s.commit = mclock.AbsTime(1000)
+	s.real = mclock.AbsTime(3000)
+
+	// Mock block header
+	var mockHeader block.Header
+
+	logContext := s.LogContext(&mockHeader)
+
+	// Verify the log context elements
+	assert.Equal(t, 10, logContext[1], "txs count mismatch")
+	assert.Equal(t, 5.0, logContext[3], "used gas in mgas mismatch")
+}

--- a/cmd/thor/node/worker_test.go
+++ b/cmd/thor/node/worker_test.go
@@ -1,0 +1,86 @@
+package node
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestWorkerTaskExecution checks if tasks are being executed.
+func TestWorkerTaskExecution(t *testing.T) {
+	w := newWorker()
+	defer w.Close()
+
+	executed := false
+	task := func() error {
+		executed = true
+		return nil
+	}
+
+	w.Run(task)
+	w.Sync()
+
+	if !executed {
+		t.Errorf("Task was not executed")
+	}
+}
+
+// TestWorkerOrderOfExecution checks if tasks are executed in the correct order.
+func TestWorkerOrderOfExecution(t *testing.T) {
+	w := newWorker()
+	defer w.Close()
+
+	var order []int
+	task1 := func() error {
+		order = append(order, 1)
+		return nil
+	}
+	task2 := func() error {
+		order = append(order, 2)
+		return nil
+	}
+
+	w.Run(task1)
+	w.Run(task2)
+	w.Sync()
+
+	if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+		t.Errorf("Tasks were executed in the wrong order")
+	}
+}
+
+// TestWorkerErrorHandling checks how the worker handles task errors.
+func TestWorkerErrorHandling(t *testing.T) {
+	w := newWorker()
+	defer w.Close()
+
+	expectedError := errors.New("error")
+	task := func() error {
+		return expectedError
+	}
+
+	w.Run(task)
+	err := w.Sync()
+
+	if err != expectedError {
+		t.Errorf("Expected error %v, got %v", expectedError, err)
+	}
+}
+
+// TestWorkerClosure checks if the worker stops correctly on closure.
+func TestWorkerClosure(t *testing.T) {
+	w := newWorker()
+
+	closed := make(chan struct{})
+	go func() {
+		w.Close()
+		close(closed)
+	}()
+
+	select {
+	case <-closed:
+		// Success
+	case <-time.After(time.Second):
+		t.Errorf("Worker did not close in time")
+	}
+}


### PR DESCRIPTION
Adding tests to increase coverage of `master.go`, `stats.go` and `worker.go` over 80%. This PR addresses the following [issue](https://github.com/vechainfoundation/protocol-board-repo/issues/18).