### PR TITLE
Fixes #90. Adds proper handling and tests when block id does not exists

### DIFF
--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -43,7 +43,7 @@ func (b *Blocks) handleGetBlock(w http.ResponseWriter, req *http.Request) error 
 	summary, err := b.getBlockSummary(revision)
 	if err != nil {
 		if b.repo.IsNotFound(err) {
-			return utils.WriteJSON(w, nil)
+			return utils.HTTPError(errors.WithMessage(errors.New("Not Found"), "Block"), 404)
 		}
 		return err
 	}

--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -43,7 +43,7 @@ func (b *Blocks) handleGetBlock(w http.ResponseWriter, req *http.Request) error 
 	summary, err := b.getBlockSummary(revision)
 	if err != nil {
 		if b.repo.IsNotFound(err) {
-			return utils.HTTPError(errors.WithMessage(errors.New("Not Found"), "Block"), 404)
+			return utils.HTTPError(errors.WithMessage(errors.New("Not Found"), "Block"), http.StatusNotFound)
 		}
 		return err
 	}

--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -43,7 +43,7 @@ func (b *Blocks) handleGetBlock(w http.ResponseWriter, req *http.Request) error 
 	summary, err := b.getBlockSummary(revision)
 	if err != nil {
 		if b.repo.IsNotFound(err) {
-			return utils.HTTPError(errors.WithMessage(errors.New("Not Found"), "Block"), http.StatusNotFound)
+			return utils.HTTPError(errors.New("Block id not found"), http.StatusNotFound)
 		}
 		return err
 	}

--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -43,7 +43,7 @@ func (b *Blocks) handleGetBlock(w http.ResponseWriter, req *http.Request) error 
 	summary, err := b.getBlockSummary(revision)
 	if err != nil {
 		if b.repo.IsNotFound(err) {
-			return utils.HTTPError(errors.New("Block id not found"), http.StatusNotFound)
+			return utils.NotFound(errors.WithMessage(errors.New("not found"), "Block ID"))
 		}
 		return err
 	}

--- a/api/blocks/blocks_test.go
+++ b/api/blocks/blocks_test.go
@@ -49,6 +49,9 @@ func TestBlock(t *testing.T) {
 	res, statusCode = httpGet(t, ts.URL+"/blocks/"+invalidNumberRevision)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 
+	res, statusCode = httpGet(t, ts.URL+"/blocks/"+"0x00fe588ccb338a0980cbead20783f8c6746b9d21261a93873b235c4f5662b67f")
+	assert.Equal(t, http.StatusNotFound, statusCode)
+
 	res, statusCode = httpGet(t, ts.URL+"/blocks/"+blk.Header().ID().String())
 	rb := new(JSONCollapsedBlock)
 	if err := json.Unmarshal(res, rb); err != nil {

--- a/api/utils/http.go
+++ b/api/utils/http.go
@@ -28,6 +28,14 @@ func HTTPError(cause error, status int) error {
 	}
 }
 
+// NotFound convenience method to create http not found error.
+func NotFound(cause error) error {
+	return &httpError{
+		cause:  cause,
+		status: http.StatusNotFound,
+	}
+}
+
 // BadRequest convenience method to create http bad request error.
 func BadRequest(cause error) error {
 	return &httpError{


### PR DESCRIPTION
# Description

When a particular block id is requested from the API and does not exists we return a Status Not Found(404) Error whereas previously we were returning a Status OK with a null body.

Fixes https://github.com/vechainfoundation/protocol-board-repo/issues/90

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added a new test in `blocks_test.go`

`make test`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
