### PR TITLE
Makefile: set thor as default and help as fallback for none matched t…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ MAJOR = $(shell go version | cut -d' ' -f3 | cut -b 3- | cut -d. -f1)
 MINOR = $(shell go version | cut -d' ' -f3 | cut -b 3- | cut -d. -f2)
 export GO111MODULE=on
 
+.DEFAULT_GOAL := thor
 .PHONY: thor disco all clean test
 
 help:
@@ -59,3 +60,6 @@ lint_command_check:
 
 lint: | go_version_check lint_command_check #@ Run 'golangci-lint'
 	@golangci-lint run --config .golangci.yml
+
+.DEFAULT:
+	@$(MAKE) help


### PR DESCRIPTION
…arget

# Description

We used to set `thor` as the default target of Makefile, simply running `make` will by default make thor. PR #646 changes `help` as default. This PR set `thor` as the default and set `help` as the fallback.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `make` should make thor
- [x] `make x` should display help
- [x] `make help` should display help

**Test Configuration**:
* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
