### PR TITLE
cmd: add genesis flag to solo, allow specifying a custom genesis file…

### DIFF
--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -142,4 +142,8 @@ var (
 		Value: 16,
 		Usage: "set tx limit per account in pool",
 	}
+	soloGenesisFlag = cli.StringFlag{
+		Name:  "genesis",
+		Usage: "path to genesis file, if not set, the default devnet genesis will be used",
+	}
 )

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -64,7 +64,6 @@ var (
 		Value: int(log15.LvlInfo),
 		Usage: "log verbosity (0-9)",
 	}
-
 	maxPeersFlag = cli.IntFlag{
 		Name:  "max-peers",
 		Usage: "maximum number of P2P network peers (P2P network disabled if set to 0)",
@@ -80,18 +79,10 @@ var (
 		Value: "any",
 		Usage: "port mapping mechanism (any|none|upnp|pmp|extip:<IP>)",
 	}
-	onDemandFlag = cli.BoolFlag{
-		Name:  "on-demand",
-		Usage: "create new block when there is pending transaction",
-	}
-	persistFlag = cli.BoolFlag{
-		Name:  "persist",
-		Usage: "blockchain data storage option, if set data will be saved to disk",
-	}
-	gasLimitFlag = cli.IntFlag{
-		Name:  "gas-limit",
-		Value: 10000000,
-		Usage: "block gas limit(adaptive if set to 0)",
+
+	bootNodeFlag = cli.StringFlag{
+		Name:  "bootnode",
+		Usage: "comma separated list of bootnode IDs",
 	}
 	importMasterKeyFlag = cli.BoolFlag{
 		Name:  "import",
@@ -105,10 +96,6 @@ var (
 		Name:  "target-gas-limit",
 		Value: 0,
 		Usage: "target block gas limit (adaptive if set to 0)",
-	}
-	bootNodeFlag = cli.StringFlag{
-		Name:  "bootnode",
-		Usage: "comma separated list of bootnode IDs",
 	}
 	pprofFlag = cli.BoolFlag{
 		Name:  "pprof",
@@ -132,6 +119,20 @@ var (
 		Name:  "disable-pruner",
 		Usage: "disable state pruner to keep all history",
 	}
+	// solo mode only flags
+	onDemandFlag = cli.BoolFlag{
+		Name:  "on-demand",
+		Usage: "create new block when there is pending transaction",
+	}
+	persistFlag = cli.BoolFlag{
+		Name:  "persist",
+		Usage: "blockchain data storage option, if set data will be saved to disk",
+	}
+	gasLimitFlag = cli.IntFlag{
+		Name:  "gas-limit",
+		Value: 10000000,
+		Usage: "block gas limit(adaptive if set to 0)",
+	}
 	txPoolLimitFlag = cli.IntFlag{
 		Name:  "txpool-limit",
 		Value: 10000,
@@ -142,7 +143,7 @@ var (
 		Value: 16,
 		Usage: "set tx limit per account in pool",
 	}
-	soloGenesisFlag = cli.StringFlag{
+	genesisFlag = cli.StringFlag{
 		Name:  "genesis",
 		Usage: "path to genesis file, if not set, the default devnet genesis will be used",
 	}

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -94,6 +94,7 @@ func main() {
 				Name:  "solo",
 				Usage: "client runs in solo mode for test & dev",
 				Flags: []cli.Flag{
+					soloGenesisFlag,
 					dataDirFlag,
 					cacheFlag,
 					apiAddrFlag,
@@ -246,9 +247,22 @@ func soloAction(ctx *cli.Context) error {
 	defer func() { log.Info("exited") }()
 
 	initLogger(ctx)
-	gene := genesis.NewDevnet()
-	// Solo forks from the start
-	forkConfig := thor.ForkConfig{}
+
+	var (
+		gene       *genesis.Genesis
+		forkConfig thor.ForkConfig
+	)
+
+	if ctx.String(soloGenesisFlag.Name) == "" {
+		gene = genesis.NewDevnet()
+		forkConfig = thor.ForkConfig{} // Devnet forks from the start
+	} else {
+		var err error
+		gene, forkConfig, err = parseGenesisFile(ctx.String(soloGenesisFlag.Name))
+		if err != nil {
+			return err
+		}
+	}
 
 	var mainDB *muxdb.MuxDB
 	var logDB *logdb.LogDB

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -94,7 +94,7 @@ func main() {
 				Name:  "solo",
 				Usage: "client runs in solo mode for test & dev",
 				Flags: []cli.Flag{
-					soloGenesisFlag,
+					genesisFlag,
 					dataDirFlag,
 					cacheFlag,
 					apiAddrFlag,
@@ -253,12 +253,13 @@ func soloAction(ctx *cli.Context) error {
 		forkConfig thor.ForkConfig
 	)
 
-	if ctx.String(soloGenesisFlag.Name) == "" {
+	flagGenesis := ctx.String(genesisFlag.Name)
+	if flagGenesis == "" {
 		gene = genesis.NewDevnet()
 		forkConfig = thor.ForkConfig{} // Devnet forks from the start
 	} else {
 		var err error
-		gene, forkConfig, err = parseGenesisFile(ctx.String(soloGenesisFlag.Name))
+		gene, forkConfig, err = parseGenesisFile(flagGenesis)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
… to solo

# Description

This PR added a new flag `--genesis` to solo, allowing specifying a custom genesis file for starting a solo instance. If not, the default devnet genesis will be applied. 

If there is a custom genesis applied to solo, built-in dev accounts will not be funded and the mnemonic words will not be displayed.

Builtin Contract Authority's state will be ignored, solo will use a default master key proposing blocks.

Fixes vechain/protocol-board-repo#158

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Start with `thor solo --genesis <file-to-genesis.json>` observe the log, test with API

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
