### PR TITLE
Adds test for DeriveRoot function in trie

### DIFF
--- a/trie/derive_root_test.go
+++ b/trie/derive_root_test.go
@@ -1,9 +1,10 @@
 package trie
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/vechain/thor/v2/thor"
-	"testing"
 )
 
 type MockDerivableList struct {

--- a/trie/derive_root_test.go
+++ b/trie/derive_root_test.go
@@ -1,0 +1,36 @@
+package trie
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/vechain/thor/v2/thor"
+	"testing"
+)
+
+type MockDerivableList struct {
+	Elements [][]byte
+}
+
+func (m *MockDerivableList) Len() int {
+	return len(m.Elements)
+}
+
+func (m *MockDerivableList) GetRlp(i int) []byte {
+	if i >= len(m.Elements) {
+		return nil
+	}
+	return m.Elements[i]
+}
+
+func TestDeriveRoot(t *testing.T) {
+	mockList := &MockDerivableList{
+		Elements: [][]byte{
+			{1, 2, 3, 4},
+			{1, 2, 3, 4, 5, 6},
+		},
+	}
+
+	root := DeriveRoot(mockList)
+
+	assert.Equal(t, "0x154227caf1172839284ce29cd6eaaee115af0993d5a5a4a08d9bb19ed18edae7", root.String())
+	assert.NotEqual(t, thor.Bytes32{}, root, "The root hash should not be empty")
+}


### PR DESCRIPTION
# Description

Adds a test for DeriveRoot function of the trie package


## Type of change
Adds a test for DeriveRoot using a self generated KAT(Known Answer Test). Given that our implementation differs only in the hash function from Ethereum we assume its correctness.

# How Has This Been Tested?

`make test`

**Test Configuration**:
* Go Version: 1.21.8
* Hardware: darwin/amd64
* Docker Version: - 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
