### PR TITLE
Fix flaky test - TestConvertBlockWithBadSignature

### DIFF
--- a/api/subscriptions/types_test.go
+++ b/api/subscriptions/types_test.go
@@ -6,6 +6,7 @@
 package subscriptions
 
 import (
+	"bytes"
 	"crypto/rand"
 	"math/big"
 	"testing"
@@ -26,12 +27,11 @@ import (
 
 func TestConvertBlockWithBadSignature(t *testing.T) {
 	// Arrange
-	var sig [65]byte
-	rand.Read(sig[:])
+	badSig := bytes.Repeat([]byte{0xf}, 65)
 
 	b := new(block.Builder).
 		Build().
-		WithSignature(sig[:])
+		WithSignature(badSig[:])
 
 	extendedBlock := &chain.ExtendedBlock{Block: b, Obsolete: false}
 

--- a/api/subscriptions/types_test.go
+++ b/api/subscriptions/types_test.go
@@ -7,7 +7,6 @@ package subscriptions
 
 import (
 	"crypto/rand"
-	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/genesis"

--- a/api/subscriptions/types_test.go
+++ b/api/subscriptions/types_test.go
@@ -7,7 +7,6 @@ package subscriptions
 
 import (
 	"bytes"
-	"crypto/rand"
 	"math/big"
 	"testing"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/genesis"
@@ -147,9 +145,7 @@ func TestConvertTransfer(t *testing.T) {
 
 func TestConvertEventWithBadSignature(t *testing.T) {
 	// Arrange
-	var sig [65]byte
-	_, err := rand.Read(sig[:])
-	require.NoErrorf(t, err, "unable to read data - %x", sig)
+	badSig := bytes.Repeat([]byte{0xf}, 65)
 
 	// New tx
 	transaction := new(tx.Builder).
@@ -160,7 +156,7 @@ func TestConvertEventWithBadSignature(t *testing.T) {
 		Nonce(1).
 		BlockRef(tx.NewBlockRef(0)).
 		Build().
-		WithSignature(sig[:])
+		WithSignature(badSig[:])
 
 	// New block
 	blk := new(block.Builder).

--- a/api/subscriptions/types_test.go
+++ b/api/subscriptions/types_test.go
@@ -7,6 +7,7 @@ package subscriptions
 
 import (
 	"crypto/rand"
+	"github.com/stretchr/testify/require"
 	"math/big"
 	"testing"
 
@@ -147,7 +148,8 @@ func TestConvertTransfer(t *testing.T) {
 func TestConvertEventWithBadSignature(t *testing.T) {
 	// Arrange
 	var sig [65]byte
-	rand.Read(sig[:])
+	_, err := rand.Read(sig[:])
+	require.NoErrorf(t, err, "unable to read data - %x", sig)
 
 	// New tx
 	transaction := new(tx.Builder).


### PR DESCRIPTION
# Description

Changed TestConvertBlockWithBadSignature to always use the same broken signature instead of randomly generating a sig on-the-fly

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
