### PR TITLE
feat: remove account + delegation limit

### DIFF
--- a/api/node/node_test.go
+++ b/api/node/node_test.go
@@ -46,9 +46,8 @@ func initCommServer(t *testing.T) {
 	}
 	repo, _ := chain.NewRepository(db, b)
 	comm := comm.New(repo, txpool.New(repo, stater, txpool.Options{
-		Limit:           10000,
-		LimitPerAccount: 16,
-		MaxLifetime:     10 * time.Minute,
+		Limit:       10000,
+		MaxLifetime: 10 * time.Minute,
 	}))
 	router := mux.NewRouter()
 	node.New(comm).Mount(router, "/node")

--- a/api/subscriptions/block_reader_test.go
+++ b/api/subscriptions/block_reader_test.go
@@ -75,9 +75,8 @@ func initChain(t *testing.T) (*chain.Repository, []*block.Block, *txpool.TxPool)
 	repo, _ := chain.NewRepository(db, b)
 
 	txPool := txpool.New(repo, stater, txpool.Options{
-		Limit:           100,
-		LimitPerAccount: 16,
-		MaxLifetime:     time.Hour,
+		Limit:       100,
+		MaxLifetime: time.Hour,
 	})
 
 	addr := thor.BytesToAddress([]byte("to"))

--- a/api/subscriptions/pending_tx_test.go
+++ b/api/subscriptions/pending_tx_test.go
@@ -59,9 +59,8 @@ func TestPendingTx_DispatchLoop(t *testing.T) {
 	repo, _ := chain.NewRepository(db, b0)
 
 	txPool := txpool.New(repo, state.NewStater(db), txpool.Options{
-		Limit:           100,
-		LimitPerAccount: 16,
-		MaxLifetime:     time.Hour,
+		Limit:       100,
+		MaxLifetime: time.Hour,
 	})
 	p := newPendingTx(txPool)
 

--- a/api/transactions/transactions_test.go
+++ b/api/transactions/transactions_test.go
@@ -336,7 +336,7 @@ func initTransactionServer(t *testing.T) {
 	router := mux.NewRouter()
 
 	// Add a tx to the mempool to have both pending and non-pending transactions
-	mempool := txpool.New(repo, stater, txpool.Options{Limit: 10000, LimitPerAccount: 16, MaxLifetime: 10 * time.Minute})
+	mempool := txpool.New(repo, stater, txpool.Options{Limit: 10000, MaxLifetime: 10 * time.Minute})
 	e := mempool.Add(mempoolTx)
 	if e != nil {
 		t.Fatal(e)

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -138,11 +138,6 @@ var (
 		Value: 10000,
 		Usage: "set tx limit in pool",
 	}
-	txPoolLimitPerAccountFlag = cli.IntFlag{
-		Name:  "txpool-limit-per-account",
-		Value: 16,
-		Usage: "set tx limit per account in pool",
-	}
 	genesisFlag = cli.StringFlag{
 		Name:  "genesis",
 		Usage: "path to genesis file, if not set, the default devnet genesis will be used",

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -45,9 +45,8 @@ var (
 	log           = log15.New()
 
 	defaultTxPoolOptions = txpool.Options{
-		Limit:           10000,
-		LimitPerAccount: 16,
-		MaxLifetime:     20 * time.Minute,
+		Limit:       10000,
+		MaxLifetime: 20 * time.Minute,
 	}
 )
 
@@ -111,7 +110,6 @@ func main() {
 					verifyLogsFlag,
 					skipLogsFlag,
 					txPoolLimitFlag,
-					txPoolLimitPerAccountFlag,
 					disablePrunerFlag,
 				},
 				Action: soloAction,
@@ -303,7 +301,6 @@ func soloAction(ctx *cli.Context) error {
 
 	txPoolOption := defaultTxPoolOptions
 	txPoolOption.Limit = ctx.Int(txPoolLimitFlag.Name)
-	txPoolOption.LimitPerAccount = ctx.Int(txPoolLimitPerAccountFlag.Name)
 
 	txPool := txpool.New(repo, state.NewStater(mainDB), txPoolOption)
 	defer func() { log.Info("closing tx pool..."); txPool.Close() }()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,17 +74,17 @@ docker run -d\
   --name thor-node vechain/thor --network test
 ```
 
-
-Notes: 
+Notes:
 
 - Add the `--api-addr 0.0.0.0:8669` flag if you want other containers and/or hosts to have access to the
-RESTful API. `Thor` binds to `localhost` by default and it will not accept requests outside the container itself without
-the flag._
+  RESTful API. `Thor` binds to `localhost` by default and it will not accept requests outside the container itself
+  without
+  the flag._
 
 - Release [v2.0.4](https://github.com/vechain/thor/releases/tag/v2.0.4) changed the default user from `root` (UID: 0)
-to `thor` (UID: 1000). Ensure that UID 1000 has `rwx` permissions on the data directory of the docker host. You can do
-that with ACL `sudo setfacl -R -m u:1000:rwx {path-to-your-data-directory}`, or update ownership
-with `sudo chown -R 1000:1000 {path-to-your-data-directory}`.
+  to `thor` (UID: 1000). Ensure that UID 1000 has `rwx` permissions on the data directory of the docker host. You can do
+  that with ACL `sudo setfacl -R -m u:1000:rwx {path-to-your-data-directory}`, or update ownership
+  with `sudo chown -R 1000:1000 {path-to-your-data-directory}`.
 
 ___
 
@@ -183,14 +183,13 @@ bin/thor -h
 
 #### Thor Solo Flags
 
-| Flag                         | Description                                        |
-|------------------------------|----------------------------------------------------|
-| `--genesis`                  | Path to genesis file(default: builtin devnet)            |
-| `--on-demand`                | Create new block when there is pending transaction |
-| `--persist`                  | Save blockchain data to disk(default to memory)    |
-| `--gas-limit`                | Gas limit for each block                           |
-| `--txpool-limit`             | Transaction pool size limit                        |
-| `--txpool-limit-per-account` | Transaction pool size limit per account            |
+| Flag             | Description                                        |
+|------------------|----------------------------------------------------|
+| `--genesis`      | Path to genesis file(default: builtin devnet)      |
+| `--on-demand`    | Create new block when there is pending transaction |
+| `--persist`      | Save blockchain data to disk(default to memory)    |
+| `--gas-limit`    | Gas limit for each block                           |
+| `--txpool-limit` | Transaction pool size limit                        |
 
 #### Discovery Node Flags
 

--- a/txpool/tx_object_map_test.go
+++ b/txpool/tx_object_map_test.go
@@ -6,7 +6,6 @@
 package txpool
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,8 +29,8 @@ func TestGetByID(t *testing.T) {
 
 	// Creating a new txObjectMap and adding transactions
 	m := newTxObjectMap()
-	assert.Nil(t, m.Add(txObj1, 1))
-	assert.Nil(t, m.Add(txObj2, 1))
+	assert.Nil(t, m.Add(txObj1))
+	assert.Nil(t, m.Add(txObj2))
 
 	// Testing GetByID
 	retrievedTxObj1 := m.GetByID(txObj1.ID())
@@ -91,23 +90,23 @@ func TestTxObjMap(t *testing.T) {
 	m := newTxObjectMap()
 	assert.Zero(t, m.Len())
 
-	assert.Nil(t, m.Add(txObj1, 1))
-	assert.Nil(t, m.Add(txObj1, 1), "should no error if exists")
+	assert.Nil(t, m.Add(txObj1))
+	assert.Nil(t, m.Add(txObj1), "should no error if exists")
 	assert.Equal(t, 1, m.Len())
 
-	assert.Equal(t, errors.New("account quota exceeded"), m.Add(txObj2, 1))
-	assert.Equal(t, 1, m.Len())
-
-	assert.Nil(t, m.Add(txObj3, 1))
+	assert.Nil(t, m.Add(txObj2))
 	assert.Equal(t, 2, m.Len())
 
+	assert.Nil(t, m.Add(txObj3))
+	assert.Equal(t, 3, m.Len())
+
 	assert.True(t, m.ContainsHash(tx1.Hash()))
-	assert.False(t, m.ContainsHash(tx2.Hash()))
+	assert.True(t, m.ContainsHash(tx2.Hash()))
 	assert.True(t, m.ContainsHash(tx3.Hash()))
 
 	assert.True(t, m.RemoveByHash(tx1.Hash()))
 	assert.False(t, m.ContainsHash(tx1.Hash()))
-	assert.False(t, m.RemoveByHash(tx2.Hash()))
+	assert.True(t, m.RemoveByHash(tx2.Hash()))
 
 	assert.Equal(t, []*txObject{txObj3}, m.ToTxObjects())
 	assert.Equal(t, tx.Transactions{tx3}, m.ToTxs())
@@ -126,11 +125,11 @@ func TestLimitByDelegator(t *testing.T) {
 	txObj3, _ := resolveTx(tx3, false)
 
 	m := newTxObjectMap()
-	assert.Nil(t, m.Add(txObj1, 1))
-	assert.Nil(t, m.Add(txObj3, 1))
+	assert.Nil(t, m.Add(txObj1))
+	assert.Nil(t, m.Add(txObj3))
 
 	m = newTxObjectMap()
-	assert.Nil(t, m.Add(txObj2, 1))
-	assert.Equal(t, errors.New("delegator quota exceeded"), m.Add(txObj3, 1))
-	assert.Equal(t, errors.New("account quota exceeded"), m.Add(txObj1, 1))
+	assert.Nil(t, m.Add(txObj2))
+	assert.Nil(t, m.Add(txObj2))
+	assert.Nil(t, m.Add(txObj3))
 }

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -36,7 +36,6 @@ var (
 // Options options for tx pool.
 type Options struct {
 	Limit                  int
-	LimitPerAccount        int
 	MaxLifetime            time.Duration
 	BlocklistCacheFilePath string
 	BlocklistFetchURL      string
@@ -253,7 +252,7 @@ func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmi
 		}
 
 		txObj.executable = executable
-		if err := p.all.Add(txObj, p.options.LimitPerAccount); err != nil {
+		if err := p.all.Add(txObj); err != nil {
 			return txRejectedError{err.Error()}
 		}
 
@@ -268,7 +267,7 @@ func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmi
 			return txRejectedError{"pool is full"}
 		}
 
-		if err := p.all.Add(txObj, p.options.LimitPerAccount); err != nil {
+		if err := p.all.Add(txObj); err != nil {
 			return txRejectedError{err.Error()}
 		}
 		log.Debug("tx added", "id", newTx.ID())


### PR DESCRIPTION
# Description

This PR removes the account & delegators transaction limit in the pool

https://github.com/vechain/protocol-board-repo/issues/144

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Unit Tests
- [ ] E2E Tests
- [x] Manually - See JS script below

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code


```javascript
const {ThorClient} = require('@vechain/sdk-network');
const {HDNode} = require('@vechain/sdk-core');

const client = ThorClient.fromUrl("http://localhost:8669");
const words = "denial kitchen pet squirrel other broom bar gas better priority spoil cross";
const hdNode = HDNode.fromMnemonic(words.split(" "));
const account1 = hdNode.derive(1);

const clauses = [
    {
        to: '0x7567d83b7b8d80addcb281a71d54fc7b3364ffed',
        value: 1,
        data: '0x'
    }
]

const start = async () => {
    const rawTransactions = [];

    for (let index = 0; index < 100; index++) {
    
        const gas = await client.gas.estimateGas(clauses)
        const txBody = await client.transactions.buildTransactionBody(clauses, gas.totalGas, {expiration: 1000})
        const signedTx = await client.transactions.signTransaction(txBody, account1.privateKey)
        rawTransactions.push(`0x${signedTx.encoded.toString('hex')}`)
    }

    const startBlock = await client.blocks.getBestBlockCompressed();
    console.log("Start block: ", startBlock.number + 1)

    
    // Wait for a block to get mined so we have a full 10 seconds to send all the transactions
    await client.blocks.waitForBlockCompressed(startBlock.number + 1)

    const txIds = await Promise.all(rawTransactions.map(async (rawTx) => {
        return (await client.transactions.sendRawTransaction(rawTx)).id
    }));

    const txsSentBlock = await client.blocks.getBestBlockCompressed();
    console.log("All TXs Sent: ", txsSentBlock.number)

    const receipts = await Promise.all(txIds.map(async (txId) => {
        return await client.transactions.waitForTransaction(txId)
    }));

    // Record<blockNumber, TX Count>
    const txCounts = {}
    for (const receipt of receipts) {
        const block = `block-${receipt.meta.blockNumber}`
        if (txCounts[block]) {
            txCounts[block] += 1
        } else {
            txCounts[block] = 1
        }
    }

    console.table(txCounts)
}

start()


/**
0x435933c8064b4Ae76bE665428e0307eF2cCFBD68
Start block:  13
All TXs Sent:  13
┌──────────┬────────┐
│ (index)  │ Values │
├──────────┼────────┤
│ block-14 │ 100    │
└──────────┴────────┘
*/
```