### PR TITLE
test: add tests for shanghai new opcodes

### DIFF
--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -346,10 +346,8 @@ func TestEVMFunction(t *testing.T) {
 			abi:        "",
 			methodName: "",
 			testFunc: func(ctx *context, t *testing.T) {
-				// 0x48 is BASEFEE opCode
-				codeData := []byte{0x48, 0x00}
 				exec, _ := runtime.New(ctx.chain, ctx.state, &xenv.BlockContext{}, thor.NoFork).
-					PrepareClause(tx.NewClause(&target).WithData(codeData), 0, math.MaxUint64, &xenv.TransactionContext{})
+					PrepareClause(tx.NewClause(&target), 0, math.MaxUint64, &xenv.TransactionContext{})
 				out, _, err := exec()
 				assert.Nil(t, err)
 				assert.NotNil(t, out.VMErr)
@@ -362,10 +360,8 @@ func TestEVMFunction(t *testing.T) {
 			abi:        "",
 			methodName: "",
 			testFunc: func(ctx *context, t *testing.T) {
-				// 0x48 is BASEFEE opCode
-				codeData := []byte{0x48, 0x00}
 				exec, _ := runtime.New(ctx.chain, ctx.state, &xenv.BlockContext{}, thor.ForkConfig{}).
-					PrepareClause(tx.NewClause(&target).WithData(codeData), 0, math.MaxUint64, &xenv.TransactionContext{})
+					PrepareClause(tx.NewClause(&target), 0, math.MaxUint64, &xenv.TransactionContext{})
 				out, _, err := exec()
 				assert.Nil(t, err)
 				assert.Nil(t, out.VMErr)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -106,7 +106,6 @@ func TestEVMFunction(t *testing.T) {
 				bal, _ := new(big.Int).SetString("1000000000000000000000000000", 10)
 				assert.Equal(t, M(new(big.Int).Add(bal, big.NewInt(200)), nil), M(ctx.state.GetBalance(origin)))
 				assert.Equal(t, M(new(big.Int).Add(bal, big.NewInt(100)), nil), M(ctx.state.GetEnergy(origin, time)))
-
 			},
 		},
 		{
@@ -229,7 +228,6 @@ func TestEVMFunction(t *testing.T) {
 
 				assert.Equal(t, thor.MustParseBytes32("ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1"), thor.Bytes32(hashes[0]))
 				assert.Equal(t, thor.MustParseBytes32("7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923"), thor.Bytes32(hashes[1]))
-
 			},
 		},
 		{
@@ -254,15 +252,18 @@ func TestEVMFunction(t *testing.T) {
 			abi:        "",
 			methodName: "",
 			testFunc: func(ctx *context, t *testing.T) {
-				code, _ := hex.DecodeString("60ef60005360016000f3")
+				failingCalldata := []string{"60ef60005360016000f3", "60ef60005360026000f3", "60ef60005360036000f3", "60ef60005360206000f3"}
+				for _, calldata := range failingCalldata {
+					code, _ := hex.DecodeString(calldata)
 
-				exec, _ := runtime.New(ctx.chain, ctx.state, &xenv.BlockContext{}, thor.ForkConfig{}).
-					PrepareClause(tx.NewClause(nil).WithData(code), 0, math.MaxUint64, &xenv.TransactionContext{})
-				out, _, err := exec()
+					exec, _ := runtime.New(ctx.chain, ctx.state, &xenv.BlockContext{}, thor.ForkConfig{}).
+						PrepareClause(tx.NewClause(nil).WithData(code), 0, math.MaxUint64, &xenv.TransactionContext{})
+					out, _, err := exec()
 
-				assert.Nil(t, err)
-				assert.NotNil(t, out.VMErr)
-				assert.Equal(t, out.VMErr.Error(), "invalid code: must not begin with 0xef")
+					assert.Nil(t, err)
+					assert.NotNil(t, out.VMErr)
+					assert.Equal(t, "invalid code: must not begin with 0xef", out.VMErr.Error())
+				}
 			},
 		},
 		{
@@ -299,7 +300,7 @@ func TestEVMFunction(t *testing.T) {
 
 				assert.Nil(t, err)
 				assert.NotNil(t, out.VMErr)
-				assert.Equal(t, out.VMErr.Error(), "invalid opcode 0x5f")
+				assert.Equal(t, "invalid opcode 0x5f", out.VMErr.Error())
 			},
 		},
 		{
@@ -323,54 +324,54 @@ func TestEVMFunction(t *testing.T) {
 			},
 		},
 		{
-			name:       "pre ETH_SH basefee",
-			code:       "6080604052348015600e575f80fd5b50600436106026575f3560e01c80635cf2496914602a575b5f80fd5b60306044565b604051603b91906061565b60405180910390f35b5f48905090565b5f819050919050565b605b81604b565b82525050565b5f60208201905060725f8301846054565b9291505056fea2646970667358221220cbae2729fc31c76b30a14b2a0f61fdad920cb3c0ef1f7f5166e48d836d91cc6a64736f6c63430008180033",
-			abi:        `[{"inputs":[],"name":"basefee","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]`,
-			methodName: "basefee",
+			name:       "ETH_SH PUSH0 gas cost",
+			code:       "",
+			abi:        "",
+			methodName: "",
 			testFunc: func(ctx *context, t *testing.T) {
-				// pragma solidity >=0.7.0 <0.9.0;
-				// contract TestBaseFee {
-				//     function basefee() public view returns (uint256) {
-				//         return block.basefee;
-				//     }
-				// }
-				methodData, err := ctx.method.EncodeInput()
-				if err != nil {
-					t.Fatal(err)
-				}
+				// 0x5f is PUSH0 opCode
+				codeData := []byte{0x5f, 0x00}
+				exec, _ := runtime.New(ctx.chain, ctx.state, &xenv.BlockContext{}, thor.ForkConfig{}).
+					PrepareClause(tx.NewClause(nil).WithData(codeData), 0, math.MaxUint64, &xenv.TransactionContext{})
+				out, _, err := exec()
 
+				assert.Nil(t, err)
+				assert.Nil(t, out.VMErr)
+				assert.Equal(t, uint64(2), math.MaxUint64-out.LeftOverGas)
+			},
+		},
+		{
+			name:       "pre ETH_SH basefee",
+			code:       "4800",
+			abi:        "",
+			methodName: "",
+			testFunc: func(ctx *context, t *testing.T) {
+				// 0x48 is BASEFEE opCode
+				codeData := []byte{0x48, 0x00}
 				exec, _ := runtime.New(ctx.chain, ctx.state, &xenv.BlockContext{}, thor.NoFork).
-					PrepareClause(tx.NewClause(&target).WithData(methodData), 0, math.MaxUint64, &xenv.TransactionContext{})
+					PrepareClause(tx.NewClause(&target).WithData(codeData), 0, math.MaxUint64, &xenv.TransactionContext{})
 				out, _, err := exec()
 				assert.Nil(t, err)
 				assert.NotNil(t, out.VMErr)
-				assert.Equal(t, out.VMErr.Error(), "invalid opcode 0x5f")
+				assert.Equal(t, "invalid opcode 0x48", out.VMErr.Error())
 			},
 		},
 		{
 			name:       "ETH_SH basefee",
-			code:       "6080604052348015600e575f80fd5b50600436106026575f3560e01c80635cf2496914602a575b5f80fd5b60306044565b604051603b91906061565b60405180910390f35b5f48905090565b5f819050919050565b605b81604b565b82525050565b5f60208201905060725f8301846054565b9291505056fea2646970667358221220cbae2729fc31c76b30a14b2a0f61fdad920cb3c0ef1f7f5166e48d836d91cc6a64736f6c63430008180033",
-			abi:        `[{"inputs":[],"name":"basefee","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]`,
-			methodName: "basefee",
+			code:       "4800",
+			abi:        "",
+			methodName: "",
 			testFunc: func(ctx *context, t *testing.T) {
-				// pragma solidity >=0.7.0 <0.9.0;
-				// contract TestBaseFee {
-				//     function basefee() public view returns (uint256) {
-				//         return block.basefee;
-				//     }
-				// }
-				methodData, err := ctx.method.EncodeInput()
-				if err != nil {
-					t.Fatal(err)
-				}
-
+				// 0x48 is BASEFEE opCode
+				codeData := []byte{0x48, 0x00}
 				exec, _ := runtime.New(ctx.chain, ctx.state, &xenv.BlockContext{}, thor.ForkConfig{}).
-					PrepareClause(tx.NewClause(&target).WithData(methodData), 0, math.MaxUint64, &xenv.TransactionContext{})
+					PrepareClause(tx.NewClause(&target).WithData(codeData), 0, math.MaxUint64, &xenv.TransactionContext{})
 				out, _, err := exec()
 				assert.Nil(t, err)
 				assert.Nil(t, out.VMErr)
 
 				assert.True(t, new(big.Int).SetBytes(out.Data).Cmp(big.NewInt(0)) == 0)
+				assert.Equal(t, uint64(2), math.MaxUint64-out.LeftOverGas)
 			},
 		},
 		{

--- a/thor/fork_config_test.go
+++ b/thor/fork_config_test.go
@@ -14,6 +14,7 @@ func TestForkConfigString(t *testing.T) {
 		ETH_IST:   math.MaxUint32,
 		VIP214:    math.MaxUint32,
 		FINALITY:  math.MaxUint32,
+		ETH_SH:    math.MaxUint32,
 	}
 
 	expectedStr := "VIP191: #1, BLOCKLIST: #2"

--- a/vm/jump_table_test.go
+++ b/vm/jump_table_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package vm
+
+import (
+	"testing"
+
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPush0OpCode(t *testing.T) {
+	// Arrange
+	mockStack := newstack()
+	jt := NewShanghaiInstructionSet()
+	push0 := jt[PUSH0]
+
+	// Check the stack is empty before executing PUSH0
+	assert.Equal(t, 0, mockStack.len())
+
+	// Act
+	push0.execute(nil, nil, nil, nil, mockStack)
+
+	// Assert
+	// Check the stack has one zero element after executing PUSH0
+	assert.Equal(t, 1, mockStack.len())
+
+	expectedValueOnStack := new(uint256.Int)
+	assert.Equal(t, expectedValueOnStack, mockStack.peek())
+}


### PR DESCRIPTION
# Description

This PR integrates some tests for the Shanghai version. In details:

- basefee: takes the [EIP-3198](https://eips.ethereum.org/EIPS/eip-3198) test cases to isolate the basefee opCode pre and after shanghai fork activation;
- contract starting with 0xEF: takes the [EIP-3541](https://eips.ethereum.org/EIPS/eip-3541) test cases; tested pre and after shanghai fork activation;
- push0: unit test checking a zero value is pushed on top of the stack.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
