### PR TITLE
feat: update base gas price on solo

### DIFF
--- a/cmd/thor/solo/solo.go
+++ b/cmd/thor/solo/solo.go
@@ -87,6 +87,8 @@ func (s *Solo) Run(ctx context.Context) error {
 		goes.Wait()
 	}()
 
+	log.Info("prepared to pack block")
+
 	if err := s.init(); err != nil {
 		return err
 	}
@@ -94,8 +96,6 @@ func (s *Solo) Run(ctx context.Context) error {
 	goes.Go(func() {
 		s.loop(ctx)
 	})
-
-	log.Info("prepared to pack block")
 
 	return nil
 }
@@ -239,7 +239,12 @@ func (s *Solo) init() error {
 		return err
 	}
 
-	return s.txPool.Add(baseGasePriceTx)
+	if !s.onDemand {
+		// wait for the next block interval if not on-demand
+		time.Sleep(time.Duration(10-time.Now().Unix()%10) * time.Second)
+	}
+
+	return s.packing(tx.Transactions{baseGasePriceTx}, false)
 }
 
 // newTx builds and signs a new transaction from the given clauses

--- a/cmd/thor/solo/solo_test.go
+++ b/cmd/thor/solo/solo_test.go
@@ -9,12 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vechain/thor/v2/builtin"
-
-	"github.com/vechain/thor/v2/tx"
-
 	"github.com/stretchr/testify/assert"
-
+	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/genesis"
 	"github.com/vechain/thor/v2/logdb"
@@ -39,20 +35,11 @@ func newSolo() *Solo {
 func TestInitSolo(t *testing.T) {
 	solo := newSolo()
 
-	// init solo -> this should add the tx to the pool
+	// init solo -> this should mine a block with the gas price tx
 	err := solo.init()
 	assert.Nil(t, err)
 
-	// get the tx from the pool (not available from solo.txPool.Executables())
-	txChan := make(chan *txpool.TxEvent)
-	solo.txPool.SubscribeTxEvent(txChan)
-	txEvent := <-txChan
-
-	// force the tx to get mined
-	err = solo.packing(tx.Transactions{txEvent.Tx}, false)
-	assert.Nil(t, err)
-
-	// check that the base gas price is correct
+	// check the gas price
 	best := solo.repo.BestBlockSummary()
 	newState := solo.stater.NewState(best.Header.StateRoot(), best.Header.Number(), best.Conflicts, best.SteadyNum)
 	currentBGP, err := builtin.Params.Native(newState).Get(thor.KeyBaseGasPrice)


### PR DESCRIPTION
# Description

This PR sets the base gas price for solo in the first block. It is instantly mined in the first block so the genesis remains unaffected.

VET Transaction:
- Solo (Before change): **21 VTHO**
- Testnet: **0.21 VTHO**
- Solo (With changes): **0.21 VTHO**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
