### PR TITLE
Add custom thor solo block interval

### DIFF
--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -131,7 +131,7 @@ var (
 	blockInterval = cli.IntFlag{
 		Name:  "block-interval",
 		Value: 10,
-		Usage: "choose a custom block interval for solo mode",
+		Usage: "choose a custom block interval for solo mode (seconds)",
 	}
 	persistFlag = cli.BoolFlag{
 		Name:  "persist",

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -128,6 +128,11 @@ var (
 		Name:  "on-demand",
 		Usage: "create new block when there is pending transaction",
 	}
+	blockInterval = cli.IntFlag{
+		Name:  "block-interval",
+		Value: 10,
+		Usage: "choose a custom block interval for solo mode",
+	}
 	persistFlag = cli.BoolFlag{
 		Name:  "persist",
 		Usage: "blockchain data storage option, if set data will be saved to disk",

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -105,6 +105,7 @@ func main() {
 					apiBacktraceLimitFlag,
 					apiAllowCustomTracerFlag,
 					onDemandFlag,
+					blockInterval,
 					persistFlag,
 					gasLimitFlag,
 					verbosityFlag,
@@ -343,6 +344,7 @@ func soloAction(ctx *cli.Context) error {
 		txPool,
 		uint64(ctx.Int(gasLimitFlag.Name)),
 		ctx.Bool(onDemandFlag.Name),
+		ctx.Uint64(blockInterval.Name),
 		skipLogs,
 		forkConfig).Run(exitSignal)
 }

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -333,6 +333,12 @@ func soloAction(ctx *cli.Context) error {
 	}
 	defer func() { log.Info("stopping API server..."); srvCloser() }()
 
+	blockInterval := ctx.Int(blockInterval.Name)
+	if blockInterval == 0 {
+		blockInterval = 10
+		log.Info("block-interval cannot be zero. Setting it to default value:", "blockInterval", blockInterval)
+	}
+
 	printSoloStartupMessage(gene, repo, instanceDir, apiURL, forkConfig)
 
 	optimizer := optimizer.New(mainDB, repo, !ctx.Bool(disablePrunerFlag.Name))
@@ -344,7 +350,7 @@ func soloAction(ctx *cli.Context) error {
 		txPool,
 		uint64(ctx.Int(gasLimitFlag.Name)),
 		ctx.Bool(onDemandFlag.Name),
-		ctx.Uint64(blockInterval.Name),
+		uint64(blockInterval),
 		skipLogs,
 		forkConfig).Run(exitSignal)
 }


### PR DESCRIPTION
Tackles the following [issue](https://github.com/orgs/vechain/projects/22/views/1?filterQuery=label%3A%22App%3A+Thor%22%2C%22App%3A+VIP%22%2C%22App%3A+Thorest%22++solo&pane=issue&itemId=53228366). In this PR I basically added the option to use a command-line argument specifically for solo to allow the developer to choose a custom block interval with a minimum value of 1. I tested it and it looks like its working fine for 1 second block intervals as well as larger intervals like 100 seconds.