### PR TITLE
Bandwidth coverage

### DIFF
--- a/block/header.go
+++ b/block/header.go
@@ -53,6 +53,22 @@ type headerBody struct {
 	Extension extension
 }
 
+func NewMockHeader() *Header {
+	return &Header{body: headerBody{
+		ParentID:        thor.Bytes32{1},
+		Timestamp:       1,
+		GasLimit:        100000,
+		Beneficiary:     thor.Address{1},
+		GasUsed:         11234,
+		TotalScore:      1,
+		TxsRootFeatures: txsRootFeatures{},
+		StateRoot:       thor.Bytes32{1},
+		ReceiptsRoot:    thor.Bytes32{1},
+		Signature:       []byte{1},
+		Extension:       extension{Alpha: []byte{1}, COM: true},
+	}}
+}
+
 // ParentID returns id of parent block.
 func (h *Header) ParentID() thor.Bytes32 {
 	return h.body.ParentID

--- a/cmd/thor/bandwidth/bandwidth_test.go
+++ b/cmd/thor/bandwidth/bandwidth_test.go
@@ -1,0 +1,64 @@
+package bandwidth
+
+import (
+	"crypto/rand"
+	"sync"
+	"testing"
+
+	"github.com/vechain/thor/v2/block"
+)
+
+func TestBandwidth(t *testing.T) {
+
+	bandwidth := Bandwidth{
+		value: 0,
+		lock:  sync.Mutex{},
+	}
+
+	val := bandwidth.Value()
+
+	if val != 0 {
+		t.Errorf("Expected 0, got %d", val)
+	}
+}
+
+func GetMockHeader(t *testing.T) *block.Header {
+	var sig [65]byte
+	rand.Read(sig[:])
+
+	block := new(block.Builder).Build().WithSignature(sig[:])
+	h := block.Header()
+	return h
+}
+
+func TestBandwithUpdate(t *testing.T) {
+
+	bandwidth := Bandwidth{
+		value: 0,
+		lock:  sync.Mutex{},
+	}
+
+	header := block.NewMockHeader()
+	bandwidth.Update(header, 1)
+	val := bandwidth.Value()
+
+	if val != 11234000000000 {
+		t.Errorf("Expected 0, got %d", val)
+	}
+}
+
+func TestBandwidthSuggestGasLimit(t *testing.T) {
+
+	bandwidth := Bandwidth{
+		value: 0,
+		lock:  sync.Mutex{},
+	}
+
+	header := block.NewMockHeader()
+	bandwidth.Update(header, 1)
+	val := bandwidth.SuggestGasLimit()
+
+	if val != 5617000000000 {
+		t.Errorf("Expected 0, got %d", val)
+	}
+}

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -128,6 +128,11 @@ var (
 		Name:  "on-demand",
 		Usage: "create new block when there is pending transaction",
 	}
+	blockInterval = cli.IntFlag{
+		Name:  "block-interval",
+		Value: 10,
+		Usage: "choose a custom block interval for solo mode",
+	}
 	persistFlag = cli.BoolFlag{
 		Name:  "persist",
 		Usage: "blockchain data storage option, if set data will be saved to disk",

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -105,6 +105,7 @@ func main() {
 					apiBacktraceLimitFlag,
 					apiAllowCustomTracerFlag,
 					onDemandFlag,
+					blockInterval,
 					persistFlag,
 					gasLimitFlag,
 					verbosityFlag,
@@ -343,6 +344,7 @@ func soloAction(ctx *cli.Context) error {
 		txPool,
 		uint64(ctx.Int(gasLimitFlag.Name)),
 		ctx.Bool(onDemandFlag.Name),
+		ctx.Uint64(blockInterval.Name),
 		skipLogs,
 		forkConfig).Run(exitSignal)
 }


### PR DESCRIPTION
The following PR increases the `bandwith.go` file's coverage to 84%. Relevant [Issue](https://github.com/vechain/protocol-board-repo/issues/184).