### PR TITLE
Increase bandwidth coverage

### DIFF
--- a/block/header.go
+++ b/block/header.go
@@ -53,22 +53,6 @@ type headerBody struct {
 	Extension extension
 }
 
-func NewMockHeader() *Header {
-	return &Header{body: headerBody{
-		ParentID:        thor.Bytes32{1},
-		Timestamp:       1,
-		GasLimit:        100000,
-		Beneficiary:     thor.Address{1},
-		GasUsed:         11234,
-		TotalScore:      1,
-		TxsRootFeatures: txsRootFeatures{},
-		StateRoot:       thor.Bytes32{1},
-		ReceiptsRoot:    thor.Bytes32{1},
-		Signature:       []byte{1},
-		Extension:       extension{Alpha: []byte{1}, COM: true},
-	}}
-}
-
 // ParentID returns id of parent block.
 func (h *Header) ParentID() thor.Bytes32 {
 	return h.body.ParentID

--- a/block/header.go
+++ b/block/header.go
@@ -53,6 +53,22 @@ type headerBody struct {
 	Extension extension
 }
 
+func NewMockHeader() *Header {
+	return &Header{body: headerBody{
+		ParentID:        thor.Bytes32{1},
+		Timestamp:       1,
+		GasLimit:        100000,
+		Beneficiary:     thor.Address{1},
+		GasUsed:         11234,
+		TotalScore:      1,
+		TxsRootFeatures: txsRootFeatures{},
+		StateRoot:       thor.Bytes32{1},
+		ReceiptsRoot:    thor.Bytes32{1},
+		Signature:       []byte{1},
+		Extension:       extension{Alpha: []byte{1}, COM: true},
+	}}
+}
+
 // ParentID returns id of parent block.
 func (h *Header) ParentID() thor.Bytes32 {
 	return h.body.ParentID

--- a/cmd/thor/bandwidth/bandwidth_test.go
+++ b/cmd/thor/bandwidth/bandwidth_test.go
@@ -1,0 +1,64 @@
+package bandwidth
+
+import (
+	"crypto/rand"
+	"sync"
+	"testing"
+
+	"github.com/vechain/thor/v2/block"
+)
+
+func TestBandwidth(t *testing.T) {
+
+	bandwidth := Bandwidth{
+		value: 0,
+		lock:  sync.Mutex{},
+	}
+
+	val := bandwidth.Value()
+
+	if val != 0 {
+		t.Errorf("Expected 0, got %d", val)
+	}
+}
+
+func GetMockHeader(t *testing.T) *block.Header {
+	var sig [65]byte
+	rand.Read(sig[:])
+
+	block := new(block.Builder).Build().WithSignature(sig[:])
+	h := block.Header()
+	return h
+}
+
+func TestBandwithUpdate(t *testing.T) {
+
+	bandwidth := Bandwidth{
+		value: 0,
+		lock:  sync.Mutex{},
+	}
+
+	header := block.NewMockHeader()
+	bandwidth.Update(header, 1)
+	val := bandwidth.Value()
+
+	if val != 11234000000000 {
+		t.Errorf("Expected 0, got %d", val)
+	}
+}
+
+func TestBandwidthSuggestGasLimit(t *testing.T) {
+
+	bandwidth := Bandwidth{
+		value: 0,
+		lock:  sync.Mutex{},
+	}
+
+	header := block.NewMockHeader()
+	bandwidth.Update(header, 1)
+	val := bandwidth.SuggestGasLimit()
+
+	if val != 5617000000000 {
+		t.Errorf("Expected 0, got %d", val)
+	}
+}

--- a/cmd/thor/bandwidth/bandwidth_test.go
+++ b/cmd/thor/bandwidth/bandwidth_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/thor"
 )
@@ -60,7 +61,5 @@ func TestBandwidthSuggestGasLimit(t *testing.T) {
 	bandwidth.Update(header, 1)
 	val := bandwidth.SuggestGasLimit()
 
-	if val != 5617000000000 {
-		t.Errorf("Expected 5617000000000, got %d", val)
-	}
+	assert.Equal(t, uint64(5617000000000), val)
 }

--- a/cmd/thor/bandwidth/bandwidth_test.go
+++ b/cmd/thor/bandwidth/bandwidth_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2020 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
 package bandwidth
 
 import (
@@ -6,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/thor"
 )
 
 func TestBandwidth(t *testing.T) {
@@ -38,12 +44,14 @@ func TestBandwithUpdate(t *testing.T) {
 		lock:  sync.Mutex{},
 	}
 
-	header := block.NewMockHeader()
+	block := new(block.Builder).ParentID(thor.Bytes32{1}).Timestamp(1).GasLimit(100000).Beneficiary(thor.Address{1}).GasUsed(11234).TotalScore(1).StateRoot(thor.Bytes32{1}).ReceiptsRoot(thor.Bytes32{1}).Build()
+	header := block.Header()
+
 	bandwidth.Update(header, 1)
 	val := bandwidth.Value()
 
 	if val != 11234000000000 {
-		t.Errorf("Expected 0, got %d", val)
+		t.Errorf("Expected 11234000000000, got %d", val)
 	}
 }
 
@@ -54,7 +62,8 @@ func TestBandwidthSuggestGasLimit(t *testing.T) {
 		lock:  sync.Mutex{},
 	}
 
-	header := block.NewMockHeader()
+	block := new(block.Builder).ParentID(thor.Bytes32{1}).Timestamp(1).GasLimit(100000).Beneficiary(thor.Address{1}).GasUsed(11234).TotalScore(1).StateRoot(thor.Bytes32{1}).ReceiptsRoot(thor.Bytes32{1}).Build()
+	header := block.Header()
 	bandwidth.Update(header, 1)
 	val := bandwidth.SuggestGasLimit()
 

--- a/cmd/thor/bandwidth/bandwidth_test.go
+++ b/cmd/thor/bandwidth/bandwidth_test.go
@@ -22,9 +22,7 @@ func TestBandwidth(t *testing.T) {
 
 	val := bandwidth.Value()
 
-	if val != 0 {
-		t.Errorf("Expected 0, got %d", val)
-	}
+	assert.Equal(t, uint64(0), val)
 }
 
 func GetMockHeader(t *testing.T) *block.Header {

--- a/cmd/thor/bandwidth/bandwidth_test.go
+++ b/cmd/thor/bandwidth/bandwidth_test.go
@@ -48,9 +48,7 @@ func TestBandwithUpdate(t *testing.T) {
 	bandwidth.Update(header, 1)
 	val := bandwidth.Value()
 
-	if val != 11234000000000 {
-		t.Errorf("Expected 11234000000000, got %d", val)
-	}
+	assert.Equal(t, uint64(11234000000000), val)
 }
 
 func TestBandwidthSuggestGasLimit(t *testing.T) {

--- a/cmd/thor/bandwidth/bandwidth_test.go
+++ b/cmd/thor/bandwidth/bandwidth_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The VeChainThor developers
+// Copyright (c) 2024 The VeChainThor developers
 
 // Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
 // file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
@@ -15,7 +15,6 @@ import (
 )
 
 func TestBandwidth(t *testing.T) {
-
 	bandwidth := Bandwidth{
 		value: 0,
 		lock:  sync.Mutex{},
@@ -38,7 +37,6 @@ func GetMockHeader(t *testing.T) *block.Header {
 }
 
 func TestBandwithUpdate(t *testing.T) {
-
 	bandwidth := Bandwidth{
 		value: 0,
 		lock:  sync.Mutex{},
@@ -56,7 +54,6 @@ func TestBandwithUpdate(t *testing.T) {
 }
 
 func TestBandwidthSuggestGasLimit(t *testing.T) {
-
 	bandwidth := Bandwidth{
 		value: 0,
 		lock:  sync.Mutex{},

--- a/cmd/thor/bandwidth/bandwidth_test.go
+++ b/cmd/thor/bandwidth/bandwidth_test.go
@@ -65,6 +65,6 @@ func TestBandwidthSuggestGasLimit(t *testing.T) {
 	val := bandwidth.SuggestGasLimit()
 
 	if val != 5617000000000 {
-		t.Errorf("Expected 0, got %d", val)
+		t.Errorf("Expected 5617000000000, got %d", val)
 	}
 }


### PR DESCRIPTION
Increases `bandwith.go` coverage to 84%. Relevant [issue](https://github.com/vechain/protocol-board-repo/issues/184).