### PR TITLE
fix: use the peer with the highest score when syncing

### DIFF
--- a/comm/communicator.go
+++ b/comm/communicator.go
@@ -94,12 +94,9 @@ func (c *Communicator) Sync(ctx context.Context, handler HandleBlockStream) {
 			log.Debug("synchronization start")
 
 			best := c.repo.BestBlockSummary().Header
-			// choose peer which has the head block with higher total score
-			peer := c.peerSet.Slice().Find(func(peer *Peer) bool {
-				_, totalScore := peer.Head()
-				return totalScore >= best.TotalScore()
-			})
-			if peer == nil {
+			peer, score := c.peerSet.WithBestScore()
+
+			if peer == nil || score < best.TotalScore() {
 				if c.peerSet.Len() < 3 {
 					log.Debug("no suitable peer to sync")
 					break

--- a/comm/peer.go
+++ b/comm/peer.go
@@ -193,6 +193,21 @@ func (ps *PeerSet) Slice() Peers {
 	return ret
 }
 
+// WithBestScore returns the peer with the highest total score.
+func (ps *PeerSet) WithBestScore() (*Peer, uint64) {
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+
+	var best *Peer
+	for _, peer := range ps.m {
+		if best == nil || peer.head.totalScore > best.head.totalScore {
+			best = peer
+		}
+	}
+
+	return best, best.head.totalScore
+}
+
 // Len returns length of set.
 func (ps *PeerSet) Len() int {
 	ps.lock.Lock()

--- a/comm/peer_test.go
+++ b/comm/peer_test.go
@@ -1,0 +1,44 @@
+package comm
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/vechain/thor/v2/thor"
+
+	"github.com/ethereum/go-ethereum/p2p/discover"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makePeerWithScore(score uint64) *Peer {
+	return &Peer{
+		head: struct {
+			sync.Mutex
+			id         thor.Bytes32
+			totalScore uint64
+		}{
+			totalScore: score,
+		},
+	}
+}
+
+func TestWithBestScore(t *testing.T) {
+
+	peer1 := makePeerWithScore(100)
+	peer2 := makePeerWithScore(200)
+	peer3 := makePeerWithScore(150)
+
+	peerSet := &PeerSet{
+		m: map[discover.NodeID]*Peer{
+			discover.NodeID{1}: peer1,
+			discover.NodeID{2}: peer2,
+			discover.NodeID{3}: peer3,
+		},
+	}
+
+	peer, score := peerSet.WithBestScore()
+	assert.NotNil(t, peer)
+	assert.Equal(t, peer2.head.id, peer.head.id)
+	assert.Equal(t, peer2.head.totalScore, score)
+}


### PR DESCRIPTION
# Description

This changes the behaviour when choosing a peer to sync with. It picks the peer with the highest score, rather than the peer with a higher score
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] - Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
