### PR TITLE
fix: relative links don't work with a proxy

### DIFF
--- a/api/doc/stoplight-ui/index.html
+++ b/api/doc/stoplight-ui/index.html
@@ -5,9 +5,9 @@
     <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
     <title>Thor API</title>
     <!-- Embed elements Elements via Web Component -->
-    <script src="./web-components.min.js"></script>
-    <script charset="UTF-8" src="./window-observer.js"> </script>
-    <link href="./styles.min.css" rel="stylesheet">
+    <script src="/doc/stoplight-ui/web-components.min.js"></script>
+    <script charset="UTF-8" src="/doc/stoplight-ui/window-observer.js"> </script>
+    <link href="/doc/stoplight-ui/styles.min.css" rel="stylesheet">
     <link href="/doc/icons/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png" />
     <link href="/doc/icons/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png" />
     <link href="/doc/icons/favicon-96x96.png" rel="icon" sizes="96x96" type="image/png" />

--- a/api/doc/swagger-ui/index.html
+++ b/api/doc/swagger-ui/index.html
@@ -3,16 +3,16 @@
 <head>
     <meta charset="utf-8" />
     <title>Thor Swagger</title>
-    <link href="./swagger-ui.css" rel="stylesheet" />
+    <link href="/doc/swagger-ui/swagger-ui.css" rel="stylesheet" />
     <link href="/doc/icons/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png" />
     <link href="/doc/icons/favicon-16x16.png" rel="icon" sizes="16x16" type="image/png" />
     <link href="/doc/icons/favicon-96x96.png" rel="icon" sizes="96x96" type="image/png" />
 </head>
 <body>
 <div id="swagger-ui"></div>
-<script charset="UTF-8" src="./window-observer.js"> </script>
-<script crossorigin src="./swagger-ui-bundle.js"></script>
-<script crossorigin src="./swagger-ui-standalone-preset.js"></script>
+<script charset="UTF-8" src="/doc/swagger-ui/window-observer.js"> </script>
+<script crossorigin src="/doc/swagger-ui/swagger-ui-bundle.js"></script>
+<script crossorigin src="/doc/swagger-ui/swagger-ui-standalone-preset.js"></script>
 <script>
     window.onload = () => {
         window.ui = SwaggerUIBundle({


### PR DESCRIPTION
# Description

Changes API docs to use absolute links instead of relative links, as they break with a proxy

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Start a proxy and visit the node docs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
