### PR TITLE
Selectable block interval on solo

### DIFF
--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -128,6 +128,11 @@ var (
 		Name:  "on-demand",
 		Usage: "create new block when there is pending transaction",
 	}
+	blockInterval = cli.IntFlag{
+		Name:  "block-interval",
+		Value: 10,
+		Usage: "choose a custom block interval for solo mode (seconds)",
+	}
 	persistFlag = cli.BoolFlag{
 		Name:  "persist",
 		Usage: "blockchain data storage option, if set data will be saved to disk",

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -335,8 +335,7 @@ func soloAction(ctx *cli.Context) error {
 
 	blockInterval := ctx.Int(blockInterval.Name)
 	if blockInterval == 0 {
-		blockInterval = 10
-		return fmt.Errorf("block-interval cannot be zero")
+		return errors.New("block-interval cannot be zero")
 	}
 
 	printSoloStartupMessage(gene, repo, instanceDir, apiURL, forkConfig)

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -105,6 +105,7 @@ func main() {
 					apiBacktraceLimitFlag,
 					apiAllowCustomTracerFlag,
 					onDemandFlag,
+					blockInterval,
 					persistFlag,
 					gasLimitFlag,
 					verbosityFlag,
@@ -332,6 +333,12 @@ func soloAction(ctx *cli.Context) error {
 	}
 	defer func() { log.Info("stopping API server..."); srvCloser() }()
 
+	blockInterval := ctx.Int(blockInterval.Name)
+	if blockInterval == 0 {
+		blockInterval = 10
+		return fmt.Errorf("block-interval cannot be zero")
+	}
+
 	printSoloStartupMessage(gene, repo, instanceDir, apiURL, forkConfig)
 
 	optimizer := optimizer.New(mainDB, repo, !ctx.Bool(disablePrunerFlag.Name))
@@ -344,6 +351,7 @@ func soloAction(ctx *cli.Context) error {
 		uint64(ctx.Int(gasLimitFlag.Name)),
 		ctx.Bool(onDemandFlag.Name),
 		skipLogs,
+		uint64(blockInterval),
 		forkConfig).Run(exitSignal)
 }
 

--- a/cmd/thor/solo/solo_test.go
+++ b/cmd/thor/solo/solo_test.go
@@ -29,7 +29,7 @@ func newSolo() *Solo {
 	repo, _ := chain.NewRepository(db, b)
 	mempool := txpool.New(repo, stater, txpool.Options{Limit: 10000, LimitPerAccount: 16, MaxLifetime: 10 * time.Minute})
 
-	return New(repo, stater, logDb, mempool, 0, true, false, thor.ForkConfig{})
+	return New(repo, stater, logDb, mempool, 0, true, false, 10, thor.ForkConfig{})
 }
 
 func TestInitSolo(t *testing.T) {

--- a/cmd/thor/solo/solo_test.go
+++ b/cmd/thor/solo/solo_test.go
@@ -29,7 +29,7 @@ func newSolo() *Solo {
 	repo, _ := chain.NewRepository(db, b)
 	mempool := txpool.New(repo, stater, txpool.Options{Limit: 10000, LimitPerAccount: 16, MaxLifetime: 10 * time.Minute})
 
-	return New(repo, stater, logDb, mempool, 0, true, false, 10, thor.ForkConfig{})
+	return New(repo, stater, logDb, mempool, 0, true, false, thor.BlockInterval, thor.ForkConfig{})
 }
 
 func TestInitSolo(t *testing.T) {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -187,6 +187,7 @@ bin/thor -h
 |------------------------------|----------------------------------------------------|
 | `--genesis`                  | Path to genesis file(default: builtin devnet)            |
 | `--on-demand`                | Create new block when there is pending transaction |
+| `--block-interval`           | Choose a block interval in seconds (default 10s) |
 | `--persist`                  | Save blockchain data to disk(default to memory)    |
 | `--gas-limit`                | Gas limit for each block                           |
 | `--txpool-limit`             | Transaction pool size limit                        |


### PR DESCRIPTION
Tackles the following [issue](https://github.com/orgs/vechain/projects/22/views/1?filterQuery=label%3A%22App%3A+Thor%22%2C%22App%3A+VIP%22%2C%22App%3A+Thorest%22++solo&pane=issue&itemId=53228366). In this PR I basically added the option to use a command-line argument specifically for solo to allow the developer to choose a custom block interval with a minimum value of 1. I tested it and it looks like its working fine for 1 second block intervals as well as larger intervals like 100 seconds.