### PR TITLE
Rename telemetry flags to metrics

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/vechain/thor/v2/metric"
+	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/tx"
 )
 
@@ -90,16 +90,16 @@ func (b *Block) DecodeRLP(s *rlp.Stream) error {
 		header: &payload.Header,
 		txs:    payload.Txs,
 	}
-	b.cache.size.Store(metric.StorageSize(rlp.ListSize(size)))
+	b.cache.size.Store(thor.StorageSize(rlp.ListSize(size)))
 	return nil
 }
 
 // Size returns block size in bytes.
-func (b *Block) Size() metric.StorageSize {
+func (b *Block) Size() thor.StorageSize {
 	if cached := b.cache.size.Load(); cached != nil {
-		return cached.(metric.StorageSize)
+		return cached.(thor.StorageSize)
 	}
-	var size metric.StorageSize
+	var size thor.StorageSize
 	rlp.Encode(&size, b)
 	b.cache.size.Store(size)
 	return size

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -123,15 +123,14 @@ var (
 		Name:  "disable-pruner",
 		Usage: "disable state pruner to keep all history",
 	}
-
-	telemetryEnabledFlag = cli.BoolTFlag{
-		Name:  "telemetry-enabled",
-		Usage: "enables telemetry server",
+	metricsFlag = cli.BoolFlag{
+		Name:  "metrics",
+		Usage: "enables metrics collection and",
 	}
-	telemetryAddrFlag = cli.StringFlag{
-		Name:  "telemetry-addr",
+	metricsAddrFlag = cli.StringFlag{
+		Name:  "metrics-addr",
 		Value: "localhost:2112",
-		Usage: "Telemetry service listening address",
+		Usage: "metrics service listening address",
 	}
 
 	// solo mode only flags

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -559,15 +559,10 @@ func startAPIServer(ctx *cli.Context, handler http.Handler, genesisID thor.Bytes
 	}, nil
 }
 
-func startTelemetryServer(addr, allowedOrigins string) (string, func(), error) {
-	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")
-	for i, o := range origins {
-		origins[i] = strings.ToLower(strings.TrimSpace(o))
-	}
-
+func startMetricsServer(addr string) (string, func(), error) {
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "listen Telemetry API addr [%v]", addr)
+		return "", nil, errors.Wrapf(err, "listen metrics API addr [%v]", addr)
 	}
 
 	router := mux.NewRouter()
@@ -594,47 +589,82 @@ func printStartupMessage1(
 ) {
 	bestBlock := repo.BestBlockSummary()
 
+	name := common.MakeName("Thor", fullVersion())
+	if master == nil { // solo has no master
+		name = common.MakeName("Thor solo", fullVersion())
+	}
+
 	fmt.Printf(`Starting %v
     Network      [ %v %v ]
     Best block   [ %v #%v @%v ]
-    Forks        [ %v ]
-    Master       [ %v ]
-    Beneficiary  [ %v ]
+    Forks        [ %v ]%v
     Instance dir [ %v ]
 `,
-		common.MakeName("Thor", fullVersion()),
+		name,
 		gene.ID(), gene.Name(),
 		bestBlock.Header.ID(), bestBlock.Header.Number(), time.Unix(int64(bestBlock.Header.Timestamp()), 0),
 		forkConfig,
-		master.Address(),
 		func() string {
-			if master.Beneficiary == nil {
-				return "not set, defaults to endorsor"
+			// solo mode does not have master, so skip this part
+			if master == nil {
+				return ""
+			} else {
+				return fmt.Sprintf(`
+    Master       [ %v ]
+    Beneficiary  [ %v ]`,
+					master.Address(),
+					func() string {
+						if master.Beneficiary == nil {
+							return "not set, defaults to endorsor"
+						}
+						return master.Beneficiary.String()
+					}(),
+				)
 			}
-			return master.Beneficiary.String()
 		}(),
-		dataDir)
+		dataDir,
+	)
 }
 
 func printStartupMessage2(
+	gene *genesis.Genesis,
 	apiURL string,
 	nodeID string,
-	telemetryServerURL string,
+	metricsURL string,
 ) {
-	telemetryAnnouncement := ""
-
-	if telemetryServerURL != "Disabled" {
-		telemetryAnnouncement = fmt.Sprintf("Telemetry    [ %s ]", telemetryServerURL)
-	}
-
-	fmt.Printf(`    
-	API portal   [ %v ]
-    Node ID      [ %v ]
-    %s
+	fmt.Printf(`%v    API portal   [ %v ]%v%v`,
+		func() string { // node ID
+			if nodeID == "" {
+				return ""
+			} else {
+				return fmt.Sprintf(`    Node ID      [ %v ]
 `,
+					nodeID)
+			}
+		}(),
 		apiURL,
-		nodeID,
-		telemetryAnnouncement)
+		func() string { // metrics URL
+			if metricsURL == "" {
+				return ""
+			} else {
+				return fmt.Sprintf(`
+    Metrics      [ %v ]`,
+					metricsURL)
+			}
+		}(),
+		func() string {
+			// print default dev net's dev accounts info
+			if gene.ID() == devNetGenesisID {
+				return `
+┌──────────────────┬───────────────────────────────────────────────────────────────────────────────┐
+│  Mnemonic Words  │  denial kitchen pet squirrel other broom bar gas better priority spoil cross  │
+└──────────────────┴───────────────────────────────────────────────────────────────────────────────┘
+`
+			} else {
+				return "\n"
+			}
+		}(),
+	)
 }
 
 func openMemMainDB() *muxdb.MuxDB {
@@ -647,48 +677,6 @@ func openMemLogDB() *logdb.LogDB {
 		panic(errors.Wrap(err, "open log database"))
 	}
 	return db
-}
-
-func printSoloStartupMessage(
-	gene *genesis.Genesis,
-	repo *chain.Repository,
-	dataDir string,
-	apiURL string,
-	telemetryServerURL string,
-	forkConfig thor.ForkConfig,
-) {
-	bestBlock := repo.BestBlockSummary()
-
-	telemetryAnnouncement := ""
-
-	if telemetryServerURL != "Disabled" {
-		telemetryAnnouncement = fmt.Sprintf("Telemetry   [ %s ]", telemetryServerURL)
-	}
-
-	info := fmt.Sprintf(`Starting %v
-    Network     [ %v %v ]    
-    Best block  [ %v #%v @%v ]
-    Forks       [ %v ]
-    Data dir    [ %v ]
-    API portal  [ %v ]
-    %s
-`,
-		common.MakeName("Thor solo", fullVersion()),
-		gene.ID(), gene.Name(),
-		bestBlock.Header.ID(), bestBlock.Header.Number(), time.Unix(int64(bestBlock.Header.Timestamp()), 0),
-		forkConfig,
-		dataDir,
-		apiURL,
-		telemetryAnnouncement)
-
-	if gene.ID() == devNetGenesisID {
-		info += `┌──────────────────┬───────────────────────────────────────────────────────────────────────────────┐
-│  Mnemonic Words  │  denial kitchen pet squirrel other broom bar gas better priority spoil cross  │
-└──────────────────┴───────────────────────────────────────────────────────────────────────────────┘
-`
-	}
-
-	fmt.Print(info)
 }
 
 func parseNodeList(list string) ([]*discover.Node, error) {

--- a/comm/handle_rpc.go
+++ b/comm/handle_rpc.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/comm/proto"
-	"github.com/vechain/thor/v2/metric"
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/tx"
 )
@@ -111,7 +110,7 @@ func (c *Communicator) handleRPC(peer *Peer, msg *p2p.Msg, write func(interface{
 		const maxBlocks = 1024
 		const maxSize = 512 * 1024
 		result := make([]rlp.RawValue, 0, maxBlocks)
-		var size metric.StorageSize
+		var size thor.StorageSize
 		chain := c.repo.NewBestChain()
 		for size < maxSize && len(result) < maxBlocks {
 			b, err := chain.GetBlock(num)
@@ -124,7 +123,7 @@ func (c *Communicator) handleRPC(peer *Peer, msg *p2p.Msg, write func(interface{
 			raw, _ := rlp.EncodeToBytes(b)
 			result = append(result, rlp.RawValue(raw))
 			num++
-			size += metric.StorageSize(len(raw))
+			size += thor.StorageSize(len(raw))
 		}
 		write(result)
 	case proto.MsgGetTxs:
@@ -142,7 +141,7 @@ func (c *Communicator) handleRPC(peer *Peer, msg *p2p.Msg, write func(interface{
 
 			var (
 				toSend tx.Transactions
-				size   metric.StorageSize
+				size   thor.StorageSize
 				n      int
 			)
 

--- a/thor/size.go
+++ b/thor/size.go
@@ -3,7 +3,7 @@
 // Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
 // file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
 
-package metric
+package thor
 
 import (
 	"fmt"

--- a/tx/transaction.go
+++ b/tx/transaction.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/vechain/thor/v2/metric"
 	"github.com/vechain/thor/v2/thor"
 )
 
@@ -307,16 +306,16 @@ func (t *Transaction) DecodeRLP(s *rlp.Stream) error {
 	}
 	*t = Transaction{body: body}
 
-	t.cache.size.Store(metric.StorageSize(rlp.ListSize(size)))
+	t.cache.size.Store(thor.StorageSize(rlp.ListSize(size)))
 	return nil
 }
 
 // Size returns size in bytes when RLP encoded.
-func (t *Transaction) Size() metric.StorageSize {
+func (t *Transaction) Size() thor.StorageSize {
 	if cached := t.cache.size.Load(); cached != nil {
-		return cached.(metric.StorageSize)
+		return cached.(thor.StorageSize)
 	}
-	var size metric.StorageSize
+	var size thor.StorageSize
 	rlp.Encode(&size, t)
 	t.cache.size.Store(size)
 	return size

--- a/tx/transaction_test.go
+++ b/tx/transaction_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
-	"github.com/vechain/thor/v2/metric"
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/tx"
 )
@@ -77,7 +76,7 @@ func TestTxSize(t *testing.T) {
 	tx := GetMockTx()
 
 	size := tx.Size()
-	assert.Equal(t, size, metric.StorageSize(87))
+	assert.Equal(t, size, thor.StorageSize(87))
 }
 
 func TestProvedWork(t *testing.T) {


### PR DESCRIPTION
# Description

This PR renames telemetry related flags to metrics and makes the metrics feature disabled by default. Along with a refactor 
to the start-up message function.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
