### PR TITLE
use middleware to capture HTTP server metrics

### DIFF
--- a/api/accounts/accounts.go
+++ b/api/accounts/accounts.go
@@ -354,21 +354,21 @@ func (a *Accounts) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/*").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "accounts_call_batch_code", a.handleCallBatchCode))
+		HandlerFunc(utils.WrapHandlerFunc(a.handleCallBatchCode))
 	sub.Path("/{address}").
 		Methods(http.MethodGet).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "accounts_get_account", a.handleGetAccount))
+		HandlerFunc(utils.WrapHandlerFunc(a.handleGetAccount))
 	sub.Path("/{address}/code").
 		Methods(http.MethodGet).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "accounts_get_code", a.handleGetCode))
+		HandlerFunc(utils.WrapHandlerFunc(a.handleGetCode))
 	sub.Path("/{address}/storage/{key}").
 		Methods("GET").
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "accounts_get_storage", a.handleGetStorage))
+		HandlerFunc(utils.WrapHandlerFunc(a.handleGetStorage))
 	// These two methods are currently deprecated
 	sub.Path("").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "accounts_api_call_contract", a.handleCallContract))
+		HandlerFunc(utils.WrapHandlerFunc(a.handleCallContract))
 	sub.Path("/{address}").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "accounts_call_contract_address", a.handleCallContract))
+		HandlerFunc(utils.WrapHandlerFunc(a.handleCallContract))
 }

--- a/api/accounts/accounts.go
+++ b/api/accounts/accounts.go
@@ -354,21 +354,27 @@ func (a *Accounts) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/*").
 		Methods(http.MethodPost).
+		Name("accounts_call_batch_code").
 		HandlerFunc(utils.WrapHandlerFunc(a.handleCallBatchCode))
 	sub.Path("/{address}").
 		Methods(http.MethodGet).
+		Name("accounts_get_detail").
 		HandlerFunc(utils.WrapHandlerFunc(a.handleGetAccount))
 	sub.Path("/{address}/code").
 		Methods(http.MethodGet).
+		Name("accounts_get_code").
 		HandlerFunc(utils.WrapHandlerFunc(a.handleGetCode))
 	sub.Path("/{address}/storage/{key}").
 		Methods("GET").
+		Name("accounts_get_storage").
 		HandlerFunc(utils.WrapHandlerFunc(a.handleGetStorage))
 	// These two methods are currently deprecated
 	sub.Path("").
 		Methods(http.MethodPost).
+		Name("accounts_call_contract").
 		HandlerFunc(utils.WrapHandlerFunc(a.handleCallContract))
 	sub.Path("/{address}").
 		Methods(http.MethodPost).
+		Name("accounts_call_contract_address").
 		HandlerFunc(utils.WrapHandlerFunc(a.handleCallContract))
 }

--- a/api/accounts/accounts.go
+++ b/api/accounts/accounts.go
@@ -358,7 +358,7 @@ func (a *Accounts) Mount(root *mux.Router, pathPrefix string) {
 		HandlerFunc(utils.WrapHandlerFunc(a.handleCallBatchCode))
 	sub.Path("/{address}").
 		Methods(http.MethodGet).
-		Name("accounts_get_detail").
+		Name("accounts_get_account").
 		HandlerFunc(utils.WrapHandlerFunc(a.handleGetAccount))
 	sub.Path("/{address}/code").
 		Methods(http.MethodGet).

--- a/api/api.go
+++ b/api/api.go
@@ -96,6 +96,10 @@ func New(
 		router.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 	}
 
+	if enableMetrics {
+		router.Use(metricMiddleware)
+	}
+
 	handler := handlers.CompressHandler(router)
 	handler = handlers.CORS(
 		handlers.AllowedOrigins(origins),
@@ -105,9 +109,6 @@ func New(
 
 	if enableReqLogger {
 		handler = RequestLoggerHandler(handler, log)
-	}
-	if enableMetrics {
-		handler = metricsHandler(handler)
 	}
 
 	return handler.ServeHTTP, subs.Close // subscriptions handles hijacked conns, which need to be closed

--- a/api/api.go
+++ b/api/api.go
@@ -40,15 +40,15 @@ func New(
 	logDB *logdb.LogDB,
 	bft bft.Finalizer,
 	nw node.Network,
+	forkConfig thor.ForkConfig,
 	allowedOrigins string,
 	backtraceLimit uint32,
 	callGasLimit uint64,
 	pprofOn bool,
 	skipLogs bool,
 	allowCustomTracer bool,
-	isReqLoggerEnabled bool,
+	enableReqLogger bool,
 	enableMetrics bool,
-	forkConfig thor.ForkConfig,
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")
 	for i, o := range origins {
@@ -97,16 +97,15 @@ func New(
 	}
 
 	handler := handlers.CompressHandler(router)
-	if isReqLoggerEnabled {
-		handler = RequestLoggerHandler(handler, log)
-	}
-
 	handler = handlers.CORS(
 		handlers.AllowedOrigins(origins),
 		handlers.AllowedHeaders([]string{"content-type", "x-genesis-id"}),
 		handlers.ExposedHeaders([]string{"x-genesis-id", "x-thorest-ver"}),
 	)(handler)
 
+	if enableReqLogger {
+		handler = RequestLoggerHandler(handler, log)
+	}
 	if enableMetrics {
 		handler = metricsHandler(handler)
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -47,6 +47,7 @@ func New(
 	skipLogs bool,
 	allowCustomTracer bool,
 	isReqLoggerEnabled bool,
+	enableMetrics bool,
 	forkConfig thor.ForkConfig,
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")
@@ -105,6 +106,10 @@ func New(
 		handlers.AllowedHeaders([]string{"content-type", "x-genesis-id"}),
 		handlers.ExposedHeaders([]string{"x-genesis-id", "x-thorest-ver"}),
 	)(handler)
+
+	if enableMetrics {
+		handler = metricsHandler(handler)
+	}
 
 	return handler.ServeHTTP, subs.Close // subscriptions handles hijacked conns, which need to be closed
 }

--- a/api/api.go
+++ b/api/api.go
@@ -97,7 +97,7 @@ func New(
 	}
 
 	if enableMetrics {
-		router.Use(metricMiddleware)
+		router.Use(metricsMiddleware)
 	}
 
 	handler := handlers.CompressHandler(router)

--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -95,6 +95,6 @@ func (b *Blocks) Mount(root *mux.Router, pathPrefix string) {
 	sub := root.PathPrefix(pathPrefix).Subrouter()
 	sub.Path("/{revision}").
 		Methods(http.MethodGet).
-		Name("blocks_get_detail").
+		Name("blocks_get_block").
 		HandlerFunc(utils.WrapHandlerFunc(b.handleGetBlock))
 }

--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -95,5 +95,6 @@ func (b *Blocks) Mount(root *mux.Router, pathPrefix string) {
 	sub := root.PathPrefix(pathPrefix).Subrouter()
 	sub.Path("/{revision}").
 		Methods(http.MethodGet).
+		Name("blocks_get_detail").
 		HandlerFunc(utils.WrapHandlerFunc(b.handleGetBlock))
 }

--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -95,5 +95,5 @@ func (b *Blocks) Mount(root *mux.Router, pathPrefix string) {
 	sub := root.PathPrefix(pathPrefix).Subrouter()
 	sub.Path("/{revision}").
 		Methods(http.MethodGet).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "blocks_get_block", b.handleGetBlock))
+		HandlerFunc(utils.WrapHandlerFunc(b.handleGetBlock))
 }

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -424,11 +424,14 @@ func (d *Debug) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/tracers").
 		Methods(http.MethodPost).
+		Name("debug_trace_clause").
 		HandlerFunc(utils.WrapHandlerFunc(d.handleTraceClause))
 	sub.Path("/tracers/call").
 		Methods(http.MethodPost).
+		Name("debug_trace_call").
 		HandlerFunc(utils.WrapHandlerFunc(d.handleTraceCall))
 	sub.Path("/storage-range").
 		Methods(http.MethodPost).
+		Name("debug_trace_storage").
 		HandlerFunc(utils.WrapHandlerFunc(d.handleDebugStorage))
 }

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -424,11 +424,11 @@ func (d *Debug) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/tracers").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "debug_trace_clause", d.handleTraceClause))
+		HandlerFunc(utils.WrapHandlerFunc(d.handleTraceClause))
 	sub.Path("/tracers/call").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "debug_trace_call", d.handleTraceCall))
+		HandlerFunc(utils.WrapHandlerFunc(d.handleTraceCall))
 	sub.Path("/storage-range").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "debug_debug_storage", d.handleDebugStorage))
+		HandlerFunc(utils.WrapHandlerFunc(d.handleDebugStorage))
 }

--- a/api/events/events.go
+++ b/api/events/events.go
@@ -63,6 +63,6 @@ func (e *Events) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
-		Name("events_filter").
+		Name("logs_filter_event").
 		HandlerFunc(utils.WrapHandlerFunc(e.handleFilter))
 }

--- a/api/events/events.go
+++ b/api/events/events.go
@@ -63,5 +63,5 @@ func (e *Events) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "events_filter", e.handleFilter))
+		HandlerFunc(utils.WrapHandlerFunc(e.handleFilter))
 }

--- a/api/events/events.go
+++ b/api/events/events.go
@@ -63,5 +63,6 @@ func (e *Events) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
+		Name("events_filter").
 		HandlerFunc(utils.WrapHandlerFunc(e.handleFilter))
 }

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -34,8 +34,8 @@ func (m *metricsResponseWriter) WriteHeader(code int) {
 	m.ResponseWriter.WriteHeader(code)
 }
 
-// metricMiddleware is a middleware that records metrics for each request.
-func metricMiddleware(next http.Handler) http.Handler {
+// metricsMiddleware is a middleware that records metrics for each request.
+func metricsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rt := mux.CurrentRoute(r)
 

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/vechain/thor/v2/metrics"
+)
+
+var (
+	metricHttpReqCounter  = metrics.CounterVec("api_request_count", []string{"path", "code", "method"})
+	metricHttpReqDuration = metrics.HistogramVec("api_duration_ms", []string{"path", "code", "method"}, metrics.BucketHTTPReqs)
+)
+
+// metricsResponseWriter is a wrapper around http.ResponseWriter that captures the status code.
+type metricsResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func newMetricsResponseWriter(w http.ResponseWriter) *metricsResponseWriter {
+	return &metricsResponseWriter{w, http.StatusOK}
+}
+
+func (m *metricsResponseWriter) WriteHeader(code int) {
+	m.statusCode = code
+	m.ResponseWriter.WriteHeader(code)
+}
+
+// metricsHandler is a middleware that records metrics for each request.
+func metricsHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		now := time.Now()
+
+		mrw := newMetricsResponseWriter(w)
+		h.ServeHTTP(mrw, r)
+
+		url := strings.ReplaceAll(strings.TrimLeft(r.URL.Path, "/"), "/", "_") // ensure no unexpected slashes
+		metricHttpReqCounter.AddWithLabel(1, map[string]string{"path": url, "code": strconv.Itoa(mrw.statusCode), "method": r.Method})
+		metricHttpReqDuration.ObserveWithLabels(time.Since(now).Milliseconds(), map[string]string{"path": url, "code": strconv.Itoa(mrw.statusCode), "method": r.Method})
+	})
+}

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2024 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package api
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/vechain/thor/v2/api/accounts"
+	"github.com/vechain/thor/v2/chain"
+	"github.com/vechain/thor/v2/cmd/thor/solo"
+	"github.com/vechain/thor/v2/genesis"
+	"github.com/vechain/thor/v2/metrics"
+	"github.com/vechain/thor/v2/muxdb"
+	"github.com/vechain/thor/v2/state"
+	"github.com/vechain/thor/v2/thor"
+)
+
+func TestMetricsMiddleware(t *testing.T) {
+	metrics.InitializePrometheusMetrics()
+
+	db := muxdb.NewMem()
+	stater := state.NewStater(db)
+	gene := genesis.NewDevnet()
+
+	b, _, _, err := gene.Build(stater)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo, _ := chain.NewRepository(db, b)
+
+	router := mux.NewRouter()
+	acc := accounts.New(repo, stater, math.MaxUint64, thor.NoFork, solo.NewBFTEngine(repo))
+	acc.Mount(router, "/accounts")
+	router.PathPrefix("/metrics").Handler(metrics.HTTPHandler())
+	router.Use(metricsMiddleware)
+	ts := httptest.NewServer(router)
+
+	httpGet(t, ts.URL+"/accounts/0x")
+	httpGet(t, ts.URL+"/accounts/"+thor.Address{}.String())
+
+	body, _ := httpGet(t, ts.URL+"/metrics")
+	parser := expfmt.TextParser{}
+	metrics, err := parser.TextToMetricFamilies(bytes.NewReader(body))
+	assert.Nil(t, err)
+
+	m := metrics["thor_metrics_api_request_count"].GetMetric()
+	assert.Equal(t, 2, len(m), "should be 2 metric entries")
+	assert.Equal(t, float64(1), m[0].GetCounter().GetValue())
+	assert.Equal(t, float64(1), m[1].GetCounter().GetValue())
+
+	labels := m[0].GetLabel()
+	assert.Equal(t, 3, len(labels))
+	assert.Equal(t, "code", labels[0].GetName())
+	assert.Equal(t, "200", labels[0].GetValue())
+	assert.Equal(t, "method", labels[1].GetName())
+	assert.Equal(t, "GET", labels[1].GetValue())
+	assert.Equal(t, "name", labels[2].GetName())
+	assert.Equal(t, "accounts_get_account", labels[2].GetValue())
+
+	labels = m[1].GetLabel()
+	assert.Equal(t, 3, len(labels))
+	assert.Equal(t, "code", labels[0].GetName())
+	assert.Equal(t, "400", labels[0].GetValue())
+	assert.Equal(t, "method", labels[1].GetName())
+	assert.Equal(t, "GET", labels[1].GetValue())
+	assert.Equal(t, "name", labels[2].GetName())
+	assert.Equal(t, "accounts_get_account", labels[2].GetValue())
+}
+
+func httpGet(t *testing.T, url string) ([]byte, int) {
+	res, err := http.Get(url) // nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := io.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r, res.StatusCode
+}

--- a/api/node/node.go
+++ b/api/node/node.go
@@ -35,5 +35,5 @@ func (n *Node) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/network/peers").
 		Methods(http.MethodGet).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "node_network", n.handleNetwork))
+		HandlerFunc(utils.WrapHandlerFunc(n.handleNetwork))
 }

--- a/api/node/node.go
+++ b/api/node/node.go
@@ -35,6 +35,6 @@ func (n *Node) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/network/peers").
 		Methods(http.MethodGet).
-		Name("node_network_peers").
+		Name("node_get_peers").
 		HandlerFunc(utils.WrapHandlerFunc(n.handleNetwork))
 }

--- a/api/node/node.go
+++ b/api/node/node.go
@@ -35,5 +35,6 @@ func (n *Node) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/network/peers").
 		Methods(http.MethodGet).
+		Name("node_network_peers").
 		HandlerFunc(utils.WrapHandlerFunc(n.handleNetwork))
 }

--- a/api/subscriptions/subscriptions.go
+++ b/api/subscriptions/subscriptions.go
@@ -383,8 +383,10 @@ func (s *Subscriptions) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/txpool").
 		Methods(http.MethodGet).
+		Name("subscriptions_pending_tx").
 		HandlerFunc(utils.WrapHandlerFunc(s.handlePendingTransactions))
 	sub.Path("/{subject}").
 		Methods(http.MethodGet).
+		Name("subscriptions_subject").
 		HandlerFunc(utils.WrapHandlerFunc(s.handleSubject))
 }

--- a/api/subscriptions/subscriptions.go
+++ b/api/subscriptions/subscriptions.go
@@ -383,8 +383,8 @@ func (s *Subscriptions) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("/txpool").
 		Methods(http.MethodGet).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "subscriptions_pending_transactions", s.handlePendingTransactions))
+		HandlerFunc(utils.WrapHandlerFunc(s.handlePendingTransactions))
 	sub.Path("/{subject}").
 		Methods(http.MethodGet).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "subscriptions_subject", s.handleSubject))
+		HandlerFunc(utils.WrapHandlerFunc(s.handleSubject))
 }

--- a/api/transactions/transactions.go
+++ b/api/transactions/transactions.go
@@ -219,11 +219,14 @@ func (t *Transactions) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
+		Name("transactions_send").
 		HandlerFunc(utils.WrapHandlerFunc(t.handleSendTransaction))
 	sub.Path("/{id}").
 		Methods(http.MethodGet).
+		Name("transactions_get_detail").
 		HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionByID))
 	sub.Path("/{id}/receipt").
 		Methods(http.MethodGet).
+		Name("transactions_get_receipt").
 		HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionReceiptByID))
 }

--- a/api/transactions/transactions.go
+++ b/api/transactions/transactions.go
@@ -219,11 +219,11 @@ func (t *Transactions) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "transactions_send_transaction", t.handleSendTransaction))
+		HandlerFunc(utils.WrapHandlerFunc(t.handleSendTransaction))
 	sub.Path("/{id}").
 		Methods(http.MethodGet).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "transactions_get_transaction_by_id", t.handleGetTransactionByID))
+		HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionByID))
 	sub.Path("/{id}/receipt").
 		Methods(http.MethodGet).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "transactions_get_transaction_by_receipt", t.handleGetTransactionReceiptByID))
+		HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionReceiptByID))
 }

--- a/api/transactions/transactions.go
+++ b/api/transactions/transactions.go
@@ -219,11 +219,11 @@ func (t *Transactions) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
-		Name("transactions_send").
+		Name("transactions_send_tx").
 		HandlerFunc(utils.WrapHandlerFunc(t.handleSendTransaction))
 	sub.Path("/{id}").
 		Methods(http.MethodGet).
-		Name("transactions_get_detail").
+		Name("transactions_get_tx").
 		HandlerFunc(utils.WrapHandlerFunc(t.handleGetTransactionByID))
 	sub.Path("/{id}/receipt").
 		Methods(http.MethodGet).

--- a/api/transfers/transfers.go
+++ b/api/transfers/transfers.go
@@ -69,6 +69,6 @@ func (t *Transfers) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
-		Name("transfers_filter").
+		Name("logs_filter_transfer").
 		HandlerFunc(utils.WrapHandlerFunc(t.handleFilterTransferLogs))
 }

--- a/api/transfers/transfers.go
+++ b/api/transfers/transfers.go
@@ -69,5 +69,5 @@ func (t *Transfers) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
-		HandlerFunc(utils.MetricsWrapHandlerFunc(pathPrefix, "transfers_transfer_logs", t.handleFilterTransferLogs))
+		HandlerFunc(utils.WrapHandlerFunc(t.handleFilterTransferLogs))
 }

--- a/api/transfers/transfers.go
+++ b/api/transfers/transfers.go
@@ -69,5 +69,6 @@ func (t *Transfers) Mount(root *mux.Router, pathPrefix string) {
 
 	sub.Path("").
 		Methods(http.MethodPost).
+		Name("transfers_filter").
 		HandlerFunc(utils.WrapHandlerFunc(t.handleFilterTransferLogs))
 }

--- a/api/utils/http.go
+++ b/api/utils/http.go
@@ -9,11 +9,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/vechain/thor/v2/metrics"
 )
 
 type httpError struct {
@@ -69,38 +64,6 @@ func WrapHandlerFunc(f HandlerFunc) http.HandlerFunc {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 			}
 		}
-	}
-}
-
-// MetricsWrapHandlerFunc wraps a given handler and adds metrics to it
-func MetricsWrapHandlerFunc(pathPrefix, endpoint string, f HandlerFunc) http.HandlerFunc {
-	fixedPath := strings.ReplaceAll(pathPrefix, "/", "_") // ensure no unexpected slashes
-	httpReqCounter := metrics.CounterVec(fixedPath+"_request_count", []string{"path", "code", "method"})
-	httpReqDuration := metrics.HistogramVec(
-		fixedPath+"_duration_ms", []string{"path", "code", "method"}, metrics.BucketHTTPReqs,
-	)
-
-	return func(w http.ResponseWriter, r *http.Request) {
-		now := time.Now()
-		err := f(w, r)
-
-		method := r.Method
-		status := http.StatusOK
-		if err != nil {
-			if he, ok := err.(*httpError); ok {
-				if he.cause != nil {
-					http.Error(w, he.cause.Error(), he.status)
-				} else {
-					w.WriteHeader(he.status)
-				}
-				status = he.status
-			} else {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				status = http.StatusInternalServerError
-			}
-		}
-		httpReqCounter.AddWithLabel(1, map[string]string{"path": endpoint, "code": strconv.Itoa(status), "method": method})
-		httpReqDuration.ObserveWithLabels(time.Since(now).Milliseconds(), map[string]string{"path": endpoint, "code": strconv.Itoa(status), "method": method})
 	}
 }
 

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -59,7 +59,7 @@ var (
 		Name:  "api-allow-custom-tracer",
 		Usage: "allow custom JS tracer to be used tracer API",
 	}
-	apiLogsEnabledFlag = cli.BoolFlag{
+	enableAPILogsFlag = cli.BoolFlag{
 		Name:  "enable-api-logs",
 		Usage: "enables API requests logging",
 	}

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -127,7 +127,7 @@ var (
 		Name:  "disable-pruner",
 		Usage: "disable state pruner to keep all history",
 	}
-	metricsEnabledFlag = cli.BoolFlag{
+	enableMetricsFlag = cli.BoolFlag{
 		Name:  "enable-metrics",
 		Usage: "enables metrics collection",
 	}

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -79,7 +79,7 @@ func main() {
 			apiCallGasLimitFlag,
 			apiBacktraceLimitFlag,
 			apiAllowCustomTracerFlag,
-			apiLogsEnabledFlag,
+			enableAPILogsFlag,
 			verbosityFlag,
 			maxPeersFlag,
 			p2pPortFlag,
@@ -108,7 +108,7 @@ func main() {
 					apiCallGasLimitFlag,
 					apiBacktraceLimitFlag,
 					apiAllowCustomTracerFlag,
-					apiLogsEnabledFlag,
+					enableAPILogsFlag,
 					onDemandFlag,
 					blockInterval,
 					persistFlag,
@@ -225,15 +225,15 @@ func defaultAction(ctx *cli.Context) error {
 		logDB,
 		bftEngine,
 		p2pCommunicator.Communicator(),
+		forkConfig,
 		ctx.String(apiCorsFlag.Name),
 		uint32(ctx.Int(apiBacktraceLimitFlag.Name)),
 		uint64(ctx.Int(apiCallGasLimitFlag.Name)),
 		ctx.Bool(pprofFlag.Name),
 		skipLogs,
 		ctx.Bool(apiAllowCustomTracerFlag.Name),
-		ctx.Bool(apiLogsEnabledFlag.Name),
+		ctx.Bool(enableAPILogsFlag.Name),
 		ctx.Bool(enableMetricsFlag.Name),
-		forkConfig,
 	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 
@@ -354,14 +354,16 @@ func soloAction(ctx *cli.Context) error {
 		logDB,
 		bftEngine,
 		&solo.Communicator{},
+		forkConfig,
 		ctx.String(apiCorsFlag.Name),
 		uint32(ctx.Int(apiBacktraceLimitFlag.Name)),
 		uint64(ctx.Int(apiCallGasLimitFlag.Name)),
 		ctx.Bool(pprofFlag.Name),
 		skipLogs,
 		ctx.Bool(apiAllowCustomTracerFlag.Name),
+		ctx.Bool(enableAPILogsFlag.Name),
 		ctx.Bool(enableMetricsFlag.Name),
-		forkConfig)
+	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 
 	apiURL, srvCloser, err := startAPIServer(ctx, apiHandler, repo.GenesisBlock().Header().ID())

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -90,7 +90,7 @@ func main() {
 			pprofFlag,
 			verifyLogsFlag,
 			disablePrunerFlag,
-			metricsEnabledFlag,
+			enableMetricsFlag,
 			metricsAddrFlag,
 		},
 		Action: defaultAction,
@@ -120,7 +120,7 @@ func main() {
 					txPoolLimitFlag,
 					txPoolLimitPerAccountFlag,
 					disablePrunerFlag,
-					metricsEnabledFlag,
+					enableMetricsFlag,
 					metricsAddrFlag,
 				},
 				Action: soloAction,
@@ -153,7 +153,7 @@ func defaultAction(ctx *cli.Context) error {
 
 	// enable metrics as soon as possible
 	metricsURL := ""
-	if ctx.Bool(metricsEnabledFlag.Name) {
+	if ctx.Bool(enableMetricsFlag.Name) {
 		metrics.InitializePrometheusMetrics()
 		url, close, err := startMetricsServer(ctx.String(metricsAddrFlag.Name))
 		if err != nil {
@@ -232,7 +232,9 @@ func defaultAction(ctx *cli.Context) error {
 		skipLogs,
 		ctx.Bool(apiAllowCustomTracerFlag.Name),
 		ctx.Bool(apiLogsEnabledFlag.Name),
-		forkConfig)
+		ctx.Bool(enableMetricsFlag.Name),
+		forkConfig,
+	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 
 	apiURL, srvCloser, err := startAPIServer(ctx, apiHandler, repo.GenesisBlock().Header().ID())
@@ -273,7 +275,7 @@ func soloAction(ctx *cli.Context) error {
 
 	// enable metrics as soon as possible
 	metricsURL := ""
-	if ctx.Bool(metricsEnabledFlag.Name) {
+	if ctx.Bool(enableMetricsFlag.Name) {
 		metrics.InitializePrometheusMetrics()
 		url, close, err := startMetricsServer(ctx.String(metricsAddrFlag.Name))
 		if err != nil {
@@ -358,7 +360,7 @@ func soloAction(ctx *cli.Context) error {
 		ctx.Bool(pprofFlag.Name),
 		skipLogs,
 		ctx.Bool(apiAllowCustomTracerFlag.Name),
-		ctx.Bool(apiLogsEnabledFlag.Name),
+		ctx.Bool(enableMetricsFlag.Name),
 		forkConfig)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/elastic/gosigar v0.10.5
 	github.com/ethereum/go-ethereum v1.8.14
 	github.com/gorilla/handlers v1.5.1
-	github.com/gorilla/mux v1.6.0
+	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.4.1
 	github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad
 	github.com/holiman/uint256 v1.2.0
@@ -48,7 +48,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/pprof v0.0.0-20230207041349-798e818bf904 // indirect
-	github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f // indirect
 	github.com/huin/goupnp v0.0.0-20171109214107-dceda08e705b // indirect
 	github.com/jackpal/go-nat-pmp v1.0.1 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,12 +69,10 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=
 github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
-github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f h1:9oNbS1z4rVpbnkHBdPZU4jo9bSmrLpII768arSyMFgk=
-github.com/gorilla/context v0.0.0-20160226214623-1ea25387ff6f/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
-github.com/gorilla/mux v1.6.0 h1:UykbtMB/w5No2LmE16gINgLj+r/vbziTgaoERQv6U+0=
-github.com/gorilla/mux v1.6.0/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/golang-lru v0.0.0-20160813221303-0a025b7e63ad h1:eMxs9EL0PvIGS9TTtxg4R+JxuPGav82J8rA+GFnY7po=


### PR DESCRIPTION
# Description

Using middleware to capture HTTP server metrics, added names for all paths, added feature that only records named path's metrics to avoid random API access potentially blowing up metrics db.

In this PR, **dependency upgraded** `github.com/gorilla/mux` v1.6.0 -> v1.8.1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
