### PR TITLE
Update linter to 1.55

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -15,12 +15,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.55.2
           # use the default if on main branch, otherwise use the pull request config
           args: --timeout=30m --config=.golangci.yml
           only-new-issues: true


### PR DESCRIPTION
# Description

This is weird one.
1. Linter should be failing for both [PR](https://github.com/vechain/thor/actions/runs/9227306033/job/25388962083) and [Master](https://github.com/vechain/thor/actions/runs/9227356106/job/25389300810). But it only fails in [Master](https://github.com/vechain/thor/actions/runs/9227356106/job/25389300810).

2. When one emulates what github does: `docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.54.2 golangci-lint run -v` it fails with:
```
state/state.go:515:40: G601: Implicit memory aliasing in for loop. (gosec)
		if err := saveAccount(trieCpy, addr, &c.data, &c.meta); err != nil {
		                                     ^
vm/instructions_test.go:223:2: G101: Potential hardcoded credentials (gosec)
	y := "a1f5aac137876480252e5dcac62c354ec0d42b76b0642b6181ed099849ea1d57"
	^
vm/instructions_test.go:243:2: G101: Potential hardcoded credentials (gosec)
	x := "4bfcd8bb2ac462735b48a17580690283980aa2d679f091c64364594df113ea37"
	^
vm/instructions_test.go:244:2: G101: Potential hardcoded credentials (gosec)
	y := "97f9b1765588c4e6b69142eb00d20507301545acf3e1238c86c8b29be227d46e"
```

3. Unsure why this does not happen in the [PR run](https://github.com/vechain/thor/actions/runs/9227306033/job/25388962083) 

4. Locally I typically run version 1.55.2 where the linter does not fail.
5. @leszek-vechain is running version 1.57.2 where the linter does not fail.

My assessment is that something is off in the 1.54.2 version because it technically is not repeating the expected result.

This PR bumps the Linter to 1.55.2 and go to 1.22 (for the linter).

I think as part of the update golang task we should do a bump the linter to latest and upgrade all dev versions to the same version. ie. I'm running go1.22 golangci-lint but running go1.19 for thor.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
