### PR TITLE
Fix and re-add subscription test

### DIFF
--- a/api/subscriptions/subscriptions_test.go
+++ b/api/subscriptions/subscriptions_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -34,12 +35,50 @@ func TestMain(t *testing.T) {
 	initSubscriptionsServer(t)
 	defer ts.Close()
 
+	testHandlePendingTransactions(t)
 	testHandleSubjectWithBlock(t)
 	testHandleSubjectWithEvent(t)
 	testHandleSubjectWithTransfer(t)
 	testHandleSubjectWithBeat(t)
 	testHandleSubjectWithBeat2(t)
 	testHandleSubjectWithNonValidArgument(t)
+}
+
+func testHandlePendingTransactions(t *testing.T) {
+	// This channel makes sure the new tx is notified to mempool subscribers
+	// and then to pendingTx as well so that websocket has the tx to read
+	txChan := make(chan *txpool.TxEvent)
+	sub := txPool.SubscribeTxEvent(txChan)
+	defer sub.Unsubscribe()
+
+	u := url.URL{Scheme: "ws", Host: strings.TrimPrefix(ts.URL, "http://"), Path: "/subscriptions/txpool"}
+
+	conn, resp, err := websocket.DefaultDialer.Dial(u.String(), nil)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	// Check the protocol upgrade to websocket
+	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	assert.Equal(t, "Upgrade", resp.Header.Get("Connection"))
+	assert.Equal(t, "websocket", resp.Header.Get("Upgrade"))
+
+	// Add a new tx to the mempool
+	transaction := createTx(t, repo, 1)
+	txPool.AddLocal(transaction)
+
+	<-txChan
+	time.Sleep(100 * time.Millisecond)
+
+	_, msg, err := conn.ReadMessage()
+
+	assert.NoError(t, err)
+
+	var pendingTx *PendingTxIDMessage
+	if err := json.Unmarshal(msg, &pendingTx); err != nil {
+		t.Fatal(err)
+	} else {
+		assert.Equal(t, transaction.ID(), pendingTx.ID)
+	}
 }
 
 func testHandleSubjectWithBlock(t *testing.T) {

--- a/api/subscriptions/subscriptions_test.go
+++ b/api/subscriptions/subscriptions_test.go
@@ -66,6 +66,7 @@ func testHandlePendingTransactions(t *testing.T) {
 	transaction := createTx(t, repo, 1)
 	txPool.AddLocal(transaction)
 
+	// Wait for the tx to be notified from mempool
 	<-txChan
 	time.Sleep(100 * time.Millisecond)
 

--- a/api/subscriptions/subscriptions_test.go
+++ b/api/subscriptions/subscriptions_test.go
@@ -13,7 +13,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -68,7 +67,6 @@ func testHandlePendingTransactions(t *testing.T) {
 
 	// Wait for the tx to be notified from mempool
 	<-txChan
-	time.Sleep(100 * time.Millisecond)
 
 	_, msg, err := conn.ReadMessage()
 


### PR DESCRIPTION
# Description

This PR reintroduce the pending subscription test previously deleted because flaky.

Fixes # [issue-214](https://github.com/vechain/protocol-board-repo/issues/214)

## Type of change

- [x] Add new test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
