### PR TITLE
Fix WS connection hijack

### DIFF
--- a/api/metrics.go
+++ b/api/metrics.go
@@ -6,6 +6,9 @@
 package api
 
 import (
+	"bufio"
+	"errors"
+	"net"
 	"net/http"
 	"strconv"
 	"time"
@@ -32,6 +35,21 @@ func newMetricsResponseWriter(w http.ResponseWriter) *metricsResponseWriter {
 func (m *metricsResponseWriter) WriteHeader(code int) {
 	m.statusCode = code
 	m.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack complies the writer with WS subscriptions interface
+// Hijack lets the caller take over the connection.
+// After a call to Hijack the HTTP server library
+// will not do anything else with the connection.
+//
+// It becomes the caller's responsibility to manage
+// and close the connection.
+func (m *metricsResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := m.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, errors.New("hijack not supported")
+	}
+	return h.Hijack()
 }
 
 // metricsMiddleware is a middleware that records metrics for each request.


### PR DESCRIPTION
# Description

Hijack lets the caller take over the connection.
This is needed in WS connections and was not implemented in the metrics new response writer.

This PR adds the Hijack method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
