### PR TITLE
fix: tag returns 2 results when latest RC equals official release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PACKAGE = github.com/vechain/thor
 
 GIT_COMMIT = $(shell git --no-pager log --pretty="%h" -n 1)
-GIT_TAG = $(shell git tag -l --points-at HEAD)
+GIT_TAG = $(shell git tag -l --points-at HEAD | head -n 1)
 COPYRIGHT_YEAR = $(shell git --no-pager log -1 --format=%ad --date=format:%Y)
 THOR_VERSION = $(shell cat cmd/thor/VERSION)
 DISCO_VERSION = $(shell cat cmd/disco/VERSION)


### PR DESCRIPTION
# Description

Fix make thor when 2 tags exist

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
