### PR TITLE
use uint64 for number flags

### DIFF
--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -45,17 +45,17 @@ var (
 		Value: "",
 		Usage: "comma separated list of domains from which to accept cross origin requests to API",
 	}
-	apiTimeoutFlag = cli.IntFlag{
+	apiTimeoutFlag = cli.Uint64Flag{
 		Name:  "api-timeout",
 		Value: 10000,
 		Usage: "API request timeout value in milliseconds",
 	}
-	apiCallGasLimitFlag = cli.IntFlag{
+	apiCallGasLimitFlag = cli.Uint64Flag{
 		Name:  "api-call-gas-limit",
 		Value: 50000000,
 		Usage: "limit contract call gas",
 	}
-	apiBacktraceLimitFlag = cli.IntFlag{
+	apiBacktraceLimitFlag = cli.Uint64Flag{
 		Name:  "api-backtrace-limit",
 		Value: 1000,
 		Usage: "limit the distance between 'position' and best block for subscriptions APIs",
@@ -64,7 +64,7 @@ var (
 		Name:  "api-allow-custom-tracer",
 		Usage: "allow custom JS tracer to be used tracer API",
 	}
-	apiLogsLimitFlag = cli.IntFlag{
+	apiLogsLimitFlag = cli.Uint64Flag{
 		Name:  "api-logs-limit",
 		Value: 1000,
 		Usage: "limit the number of logs returned by /logs API",
@@ -73,17 +73,17 @@ var (
 		Name:  "enable-api-logs",
 		Usage: "enables API requests logging",
 	}
-	verbosityFlag = cli.IntFlag{
+	verbosityFlag = cli.Uint64Flag{
 		Name:  "verbosity",
-		Value: int(log15.LvlInfo),
+		Value: uint64(log15.LvlInfo),
 		Usage: "log verbosity (0-9)",
 	}
-	maxPeersFlag = cli.IntFlag{
+	maxPeersFlag = cli.Uint64Flag{
 		Name:  "max-peers",
 		Usage: "maximum number of P2P network peers (P2P network disabled if set to 0)",
 		Value: 25,
 	}
-	p2pPortFlag = cli.IntFlag{
+	p2pPortFlag = cli.Uint64Flag{
 		Name:  "p2p-port",
 		Value: 11235,
 		Usage: "P2P network listening port",
@@ -110,7 +110,7 @@ var (
 		Name:  "export",
 		Usage: "export master key to keystore",
 	}
-	targetGasLimitFlag = cli.IntFlag{
+	targetGasLimitFlag = cli.Uint64Flag{
 		Name:  "target-gas-limit",
 		Value: 0,
 		Usage: "target block gas limit (adaptive if set to 0)",
@@ -128,7 +128,7 @@ var (
 		Usage:  "verify log db at startup",
 		Hidden: true,
 	}
-	cacheFlag = cli.IntFlag{
+	cacheFlag = cli.Uint64Flag{
 		Name:  "cache",
 		Usage: "megabytes of ram allocated to trie nodes cache",
 		Value: 4096,
@@ -152,7 +152,7 @@ var (
 		Name:  "on-demand",
 		Usage: "create new block when there is pending transaction",
 	}
-	blockInterval = cli.IntFlag{
+	blockInterval = cli.Uint64Flag{
 		Name:  "block-interval",
 		Value: 10,
 		Usage: "choose a custom block interval for solo mode (seconds)",
@@ -161,17 +161,17 @@ var (
 		Name:  "persist",
 		Usage: "blockchain data storage option, if set data will be saved to disk",
 	}
-	gasLimitFlag = cli.IntFlag{
+	gasLimitFlag = cli.Uint64Flag{
 		Name:  "gas-limit",
 		Value: 40_000_000,
 		Usage: "block gas limit(adaptive if set to 0)",
 	}
-	txPoolLimitFlag = cli.IntFlag{
+	txPoolLimitFlag = cli.Uint64Flag{
 		Name:  "txpool-limit",
 		Value: 10000,
 		Usage: "set tx limit in pool",
 	}
-	txPoolLimitPerAccountFlag = cli.IntFlag{
+	txPoolLimitPerAccountFlag = cli.Uint64Flag{
 		Name:  "txpool-limit-per-account",
 		Value: 16,
 		Usage: "set tx limit per account in pool",

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -152,9 +152,9 @@ func defaultAction(ctx *cli.Context) error {
 
 	defer func() { log.Info("exited") }()
 
-	lvl, err := readIntFromFlag(ctx, verbosityFlag.Name)
+	lvl, err := readIntFromUInt64Flag(ctx.Uint64(verbosityFlag.Name))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "parse verbosity flag")
 	}
 	initLogger(log15.Lvl(lvl))
 
@@ -279,9 +279,9 @@ func soloAction(ctx *cli.Context) error {
 	exitSignal := handleExitSignal()
 	defer func() { log.Info("exited") }()
 
-	lvl, err := readIntFromFlag(ctx, verbosityFlag.Name)
+	lvl, err := readIntFromUInt64Flag(ctx.Uint64(verbosityFlag.Name))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "parse verbosity flag")
 	}
 	initLogger(log15.Lvl(lvl))
 
@@ -351,13 +351,13 @@ func soloAction(ctx *cli.Context) error {
 	}
 
 	txPoolOption := defaultTxPoolOptions
-	txPoolOption.Limit, err = readIntFromFlag(ctx, txPoolLimitFlag.Name)
+	txPoolOption.Limit, err = readIntFromUInt64Flag(ctx.Uint64(txPoolLimitFlag.Name))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "parse txpool-limit flag")
 	}
-	txPoolOption.LimitPerAccount, err = readIntFromFlag(ctx, txPoolLimitPerAccountFlag.Name)
+	txPoolOption.LimitPerAccount, err = readIntFromUInt64Flag(ctx.Uint64(txPoolLimitPerAccountFlag.Name))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "parse txpool-limit-per-account flag")
 	}
 
 	txPool := txpool.New(repo, state.NewStater(mainDB), txPoolOption)

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -60,9 +60,8 @@ import (
 
 var devNetGenesisID = genesis.NewDevnet().ID()
 
-func initLogger(ctx *cli.Context) {
-	logLevel := ctx.Int(verbosityFlag.Name)
-	log15.Root().SetHandler(log15.LvlFilterHandler(log15.Lvl(logLevel), log15.StderrHandler))
+func initLogger(lvl log15.Lvl) {
+	log15.Root().SetHandler(log15.LvlFilterHandler(lvl, log15.StderrHandler))
 	// set go-ethereum log lvl to Warn
 	ethLogHandler := ethlog.NewGlogHandler(ethlog.StreamHandler(os.Stderr, ethlog.TerminalFormat(true)))
 	ethLogHandler.Verbosity(ethlog.LvlWarn)
@@ -711,4 +710,15 @@ func parseNodeList(list string) ([]*discover.Node, error) {
 	}
 
 	return nodes, nil
+}
+
+func readIntFromFlag(ctx *cli.Context, name string) (int, error) {
+	val := ctx.Uint64(name)
+	i := int(val)
+
+	if i < 0 {
+		return 0, fmt.Errorf("invalid value for flag -%s: %d", name, val)
+	}
+
+	return i, nil
 }

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -712,12 +712,11 @@ func parseNodeList(list string) ([]*discover.Node, error) {
 	return nodes, nil
 }
 
-func readIntFromFlag(ctx *cli.Context, name string) (int, error) {
-	val := ctx.Uint64(name)
+func readIntFromUInt64Flag(val uint64) (int, error) {
 	i := int(val)
 
 	if i < 0 {
-		return 0, fmt.Errorf("invalid value for flag -%s: %d", name, val)
+		return 0, fmt.Errorf("invalid value %d ", val)
 	}
 
 	return i, nil


### PR DESCRIPTION
# Description

This is a minor improvement of the flags parsing component.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
