### PR TITLE
feat: add enable-debug flag

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -50,7 +50,7 @@ func New(
 	enableReqLogger bool,
 	enableMetrics bool,
 	logsLimit uint64,
-	enableDebug bool,
+	enableAPIDebug bool,
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")
 	for i, o := range origins {
@@ -83,7 +83,7 @@ func New(
 		Mount(router, "/blocks")
 	transactions.New(repo, txPool).
 		Mount(router, "/transactions")
-	if enableDebug {
+	if enableAPIDebug {
 		debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft).
 			Mount(router, "/debug")
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -50,6 +50,7 @@ func New(
 	enableReqLogger bool,
 	enableMetrics bool,
 	logsLimit uint64,
+	enableDebug bool,
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")
 	for i, o := range origins {
@@ -82,8 +83,10 @@ func New(
 		Mount(router, "/blocks")
 	transactions.New(repo, txPool).
 		Mount(router, "/transactions")
-	debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft).
-		Mount(router, "/debug")
+	if enableDebug {
+		debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft).
+			Mount(router, "/debug")
+	}
 	node.New(nw).
 		Mount(router, "/node")
 	subs := subscriptions.New(repo, origins, backtraceLimit, txPool)

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -150,6 +150,10 @@ var (
 		Value: "localhost:2112",
 		Usage: "metrics service listening address",
 	}
+	enableDebug = cli.BoolFlag{
+		Name:  "enable-debug",
+		Usage: "enable `/debug` endpoint on the node",
+	}
 
 	// solo mode only flags
 	onDemandFlag = cli.BoolFlag{

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -150,8 +150,8 @@ var (
 		Value: "localhost:2112",
 		Usage: "metrics service listening address",
 	}
-	enableDebug = cli.BoolFlag{
-		Name:  "enable-debug",
+	enableAPIDebug = cli.BoolFlag{
+		Name:  "enable-api-debug",
 		Usage: "enable `/debug` endpoint on the node",
 	}
 

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -95,6 +95,7 @@ func main() {
 			disablePrunerFlag,
 			enableMetricsFlag,
 			metricsAddrFlag,
+			enableDebug,
 		},
 		Action: defaultAction,
 		Commands: []cli.Command{
@@ -127,6 +128,7 @@ func main() {
 					disablePrunerFlag,
 					enableMetricsFlag,
 					metricsAddrFlag,
+					enableDebug,
 				},
 				Action: soloAction,
 			},
@@ -240,6 +242,7 @@ func defaultAction(ctx *cli.Context) error {
 		ctx.Bool(enableAPILogsFlag.Name),
 		ctx.Bool(enableMetricsFlag.Name),
 		ctx.Uint64(apiLogsLimitFlag.Name),
+		ctx.Bool(enableDebug.Name),
 	)
 	defer func() { logger.Info("closing API..."); apiCloser() }()
 
@@ -376,6 +379,7 @@ func soloAction(ctx *cli.Context) error {
 		ctx.Bool(enableAPILogsFlag.Name),
 		ctx.Bool(enableMetricsFlag.Name),
 		ctx.Uint64(apiLogsLimitFlag.Name),
+		ctx.Bool(enableDebug.Name),
 	)
 	defer func() { logger.Info("closing API..."); apiCloser() }()
 

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -93,7 +93,7 @@ func main() {
 			disablePrunerFlag,
 			enableMetricsFlag,
 			metricsAddrFlag,
-			enableDebug,
+			enableAPIDebug,
 		},
 		Action: defaultAction,
 		Commands: []cli.Command{
@@ -126,7 +126,7 @@ func main() {
 					disablePrunerFlag,
 					enableMetricsFlag,
 					metricsAddrFlag,
-					enableDebug,
+					enableAPIDebug,
 				},
 				Action: soloAction,
 			},
@@ -244,7 +244,7 @@ func defaultAction(ctx *cli.Context) error {
 		ctx.Bool(enableAPILogsFlag.Name),
 		ctx.Bool(enableMetricsFlag.Name),
 		ctx.Uint64(apiLogsLimitFlag.Name),
-		ctx.Bool(enableDebug.Name),
+		ctx.Bool(enableAPIDebug.Name),
 	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 
@@ -383,7 +383,7 @@ func soloAction(ctx *cli.Context) error {
 		ctx.Bool(enableAPILogsFlag.Name),
 		ctx.Bool(enableMetricsFlag.Name),
 		ctx.Uint64(apiLogsLimitFlag.Name),
-		ctx.Bool(enableDebug.Name),
+		ctx.Bool(enableAPIDebug.Name),
 	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -181,6 +181,7 @@ bin/thor -h
 | `--cache`                   | Megabytes of RAM allocated to trie nodes cache (default: 4096)                              |
 | `--disable-pruner`          | Disable state pruner to keep all history                                                    |
 | `--enable-metrics`          | Enables the metrics server                                                                  |
+| `--enable-debug`            | Enables the /debug endpoint                                                                 |
 | `--metrics-addr`            | Metrics service listening address                                                           |
 | `--help, -h`                | Show help                                                                                   |
 | `--version, -v`             | Print the version                                                                           |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -181,7 +181,7 @@ bin/thor -h
 | `--cache`                   | Megabytes of RAM allocated to trie nodes cache (default: 4096)                              |
 | `--disable-pruner`          | Disable state pruner to keep all history                                                    |
 | `--enable-metrics`          | Enables the metrics server                                                                  |
-| `--enable-debug`            | Enables the /debug endpoint                                                                 |
+| `--enable-api-debug`        | Enables the /debug endpoint                                                                 |
 | `--metrics-addr`            | Metrics service listening address                                                           |
 | `--help, -h`                | Show help                                                                                   |
 | `--version, -v`             | Print the version                                                                           |


### PR DESCRIPTION
# Description

As default `/debug` endpoint is disabled on the node, and can be turned on with a supplied flag `--enable-debug`

[issue](https://github.com/vechain/protocol-board-repo/issues/266)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Ran node in solo mode with debug enabled and disabled and called debug endpoints

**Test Configuration**:

* Go Version: go1.22.1 linux/amd64
* Hardware: 
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
