### PR TITLE
Ability to change log verbosity while the node is running

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -1,0 +1,33 @@
+package admin
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+)
+
+func HTTPHandler(logLevel *slog.LevelVar) http.Handler {
+	router := mux.NewRouter()
+	router.PathPrefix("/admin").Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		verbosity := r.URL.Query().Get("verbosity")
+		switch verbosity {
+		case "debug":
+			logLevel.Set(slog.LevelDebug)
+		case "info":
+			logLevel.Set(slog.LevelInfo)
+		case "warn":
+			logLevel.Set(slog.LevelWarn)
+		case "error":
+			logLevel.Set(slog.LevelError)
+		default:
+			http.Error(w, "Invalid verbosity level", http.StatusBadRequest)
+			return
+		}
+
+		fmt.Fprintln(w, "Verbosity changed to ", verbosity)
+	}))
+	return handlers.CompressHandler(router)
+}

--- a/cmd/disco/utils.go
+++ b/cmd/disco/utils.go
@@ -8,6 +8,7 @@ package main
 import (
 	"crypto/ecdsa"
 	"io"
+	"log/slog"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -19,15 +20,18 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-func initLogger(ctx *cli.Context) {
+func initLogger(ctx *cli.Context) *slog.LevelVar {
 	logLevel := log.FromLegacyLevel(ctx.Int(verbosityFlag.Name))
+	var level slog.LevelVar
+	level.Set(logLevel)
 	output := io.Writer(os.Stdout)
 	useColor := (isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb"
-	handler := log.NewTerminalHandlerWithLevel(output, logLevel, useColor)
+	handler := log.NewTerminalHandlerWithLevel(output, &level, useColor)
 	log.SetDefault(log.NewLogger(handler))
 	ethlog.Root().SetHandler(&ethLogger{
 		logger: log.WithContext("pkg", "geth"),
 	})
+	return &level
 }
 
 type ethLogger struct {

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -150,6 +150,15 @@ var (
 		Value: "localhost:2112",
 		Usage: "metrics service listening address",
 	}
+	enableAdminFlag = cli.BoolFlag{
+		Name:  "enable-admin",
+		Usage: "enables admin service",
+	}
+	adminAddrFlag = cli.StringFlag{
+		Name:  "admin-addr",
+		Value: "localhost:2113",
+		Usage: "admin service listening address",
+	}
 
 	// solo mode only flags
 	onDemandFlag = cli.BoolFlag{

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -39,6 +39,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/mattn/go-tty"
 	"github.com/pkg/errors"
+	"github.com/vechain/thor/v2/admin"
 	"github.com/vechain/thor/v2/api/doc"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/cmd/thor/node"
@@ -585,6 +586,27 @@ func startMetricsServer(addr string) (string, func(), error) {
 	}, nil
 }
 
+func startAdminServer(addr string, logLevel *slog.LevelVar) (string, func(), error) {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return "", nil, errors.Wrapf(err, "listen admin API addr [%v]", addr)
+	}
+
+	router := mux.NewRouter()
+	router.PathPrefix("/admin").Handler(admin.HTTPHandler(logLevel))
+	handler := handlers.CompressHandler(router)
+
+	srv := &http.Server{Handler: handler, ReadHeaderTimeout: time.Second, ReadTimeout: 5 * time.Second}
+	var goes co.Goes
+	goes.Go(func() {
+		srv.Serve(listener)
+	})
+	return "http://" + listener.Addr().String() + "/admin", func() {
+		srv.Close()
+		goes.Wait()
+	}, nil
+}
+
 func printStartupMessage1(
 	gene *genesis.Genesis,
 	repo *chain.Repository,
@@ -636,8 +658,9 @@ func printStartupMessage2(
 	apiURL string,
 	nodeID string,
 	metricsURL string,
+	adminURL string,
 ) {
-	fmt.Printf(`%v    API portal   [ %v ]%v%v`,
+	fmt.Printf(`%v    API portal   [ %v ]%v%v%v`,
 		func() string { // node ID
 			if nodeID == "" {
 				return ""
@@ -655,6 +678,15 @@ func printStartupMessage2(
 				return fmt.Sprintf(`
     Metrics      [ %v ]`,
 					metricsURL)
+			}
+		}(),
+		func() string { // metrics URL
+			if adminURL == "" {
+				return ""
+			} else {
+				return fmt.Sprintf(`
+    Admin        [ %v ]`,
+					adminURL)
 			}
 		}(),
 		func() string {
@@ -679,6 +711,7 @@ func printSoloStartupMessage(
 	apiURL string,
 	forkConfig thor.ForkConfig,
 	metricsURL string,
+	adminURL string,
 ) {
 	bestBlock := repo.BestBlockSummary()
 
@@ -689,6 +722,7 @@ func printSoloStartupMessage(
     Data dir    [ %v ]
     API portal  [ %v ]
     Metrics     [ %v ]
+    Admin       [ %v ]
 `,
 		common.MakeName("Thor solo", fullVersion()),
 		gene.ID(), gene.Name(),
@@ -701,6 +735,12 @@ func printSoloStartupMessage(
 				return "Disabled"
 			}
 			return metricsURL
+		}(),
+		func() string {
+			if adminURL == "" {
+				return "Disabled"
+			}
+			return adminURL
 		}(),
 	)
 

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -60,8 +60,10 @@ import (
 
 var devNetGenesisID = genesis.NewDevnet().ID()
 
-func initLogger(ctx *cli.Context) {
+func initLogger(ctx *cli.Context) *slog.LevelVar {
 	logLevel := log.FromLegacyLevel(ctx.Int(verbosityFlag.Name))
+	var level slog.LevelVar
+	level.Set(logLevel)
 	jsonLogs := ctx.Bool(jsonLogsFlag.Name)
 	output := io.Writer(os.Stdout)
 
@@ -70,12 +72,13 @@ func initLogger(ctx *cli.Context) {
 		handler = log.JSONHandlerWithLevel(output, logLevel)
 	} else {
 		useColor := (isatty.IsTerminal(os.Stderr.Fd()) || isatty.IsCygwinTerminal(os.Stderr.Fd())) && os.Getenv("TERM") != "dumb"
-		handler = log.NewTerminalHandlerWithLevel(output, logLevel, useColor)
+		handler = log.NewTerminalHandlerWithLevel(output, &level, useColor)
 	}
 	log.SetDefault(log.NewLogger(handler))
 	ethlog.Root().SetHandler(&ethLogger{
 		logger: log.WithContext("pkg", "geth"),
 	})
+	return &level
 }
 
 type ethLogger struct {

--- a/log/handler.go
+++ b/log/handler.go
@@ -55,7 +55,7 @@ func (h *discardHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 type TerminalHandler struct {
 	mu       sync.Mutex
 	wr       io.Writer
-	lvl      slog.Level
+	lvl      *slog.LevelVar
 	useColor bool
 	attrs    []slog.Attr
 	// fieldPadding is a map with maximum field value lengths seen until now
@@ -75,12 +75,14 @@ type TerminalHandler struct {
 //
 //	[DBUG] [May 16 20:58:45] remove route ns=haproxy addr=127.0.0.1:50002
 func NewTerminalHandler(wr io.Writer, useColor bool) *TerminalHandler {
-	return NewTerminalHandlerWithLevel(wr, levelMaxVerbosity, useColor)
+	var level slog.LevelVar
+	level.Set(levelMaxVerbosity)
+	return NewTerminalHandlerWithLevel(wr, &level, useColor)
 }
 
 // NewTerminalHandlerWithLevel returns the same handler as NewTerminalHandler but only outputs
 // records which are less than or equal to the specified verbosity level.
-func NewTerminalHandlerWithLevel(wr io.Writer, lvl slog.Level, useColor bool) *TerminalHandler {
+func NewTerminalHandlerWithLevel(wr io.Writer, lvl *slog.LevelVar, useColor bool) *TerminalHandler {
 	return &TerminalHandler{
 		wr:           wr,
 		lvl:          lvl,
@@ -99,7 +101,7 @@ func (h *TerminalHandler) Handle(_ context.Context, r slog.Record) error {
 }
 
 func (h *TerminalHandler) Enabled(_ context.Context, level slog.Level) bool {
-	return level >= h.lvl
+	return level.Level() >= h.lvl.Level()
 }
 
 func (h *TerminalHandler) WithGroup(name string) slog.Handler {

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -33,7 +33,9 @@ import (
 
 func TestTerminalHandlerWithAttrs(t *testing.T) {
 	out := new(bytes.Buffer)
-	handler := NewTerminalHandlerWithLevel(out, LevelTrace, false).WithAttrs([]slog.Attr{slog.String("baz", "bat")})
+	var level slog.LevelVar
+	level.Set(LevelTrace)
+	handler := NewTerminalHandlerWithLevel(out, &level, false).WithAttrs([]slog.Attr{slog.String("baz", "bat")})
 	logger := NewLogger(handler)
 	logger.Trace("a message", "foo", "bar")
 	have := out.String()
@@ -128,7 +130,9 @@ func TestLoggerOutput(t *testing.T) {
 	)
 
 	out := new(bytes.Buffer)
-	handler := NewTerminalHandlerWithLevel(out, LevelInfo, false)
+	var level slog.LevelVar
+	level.Set(LevelInfo)
+	handler := NewTerminalHandlerWithLevel(out, &level, false)
 	NewLogger(handler).Info("This is a message",
 		"foo", int16(123),
 		"bytes", bb,


### PR DESCRIPTION
To implement this a new server was added running on a different port and is only enabled explicitly by the user. It supports a single endpoint that accepts the verbosity to set to the logger.