### PR TITLE
api: fix max result in debug trace storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build thor in a stock Go builder container
-FROM golang:1.22-alpine3.20 as builder
+FROM golang:1.22-alpine3.20 AS builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 WORKDIR  /go/thor

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -36,6 +36,8 @@ import (
 	"github.com/vechain/thor/v2/xenv"
 )
 
+const defaultMaxStorageResult = 1000
+
 var devNetGenesisID = genesis.NewDevnet().ID()
 
 type Debug struct {
@@ -296,6 +298,15 @@ func (d *Debug) handleDebugStorage(w http.ResponseWriter, req *http.Request) err
 	if err := utils.ParseJSON(req.Body, &opt); err != nil {
 		return utils.BadRequest(errors.WithMessage(err, "body"))
 	}
+
+	if opt.MaxResult > defaultMaxStorageResult {
+		return utils.BadRequest(errors.Errorf("maxResult: exceeds limit of %d", defaultMaxStorageResult))
+	}
+
+	if opt.MaxResult == 0 {
+		opt.MaxResult = defaultMaxStorageResult
+	}
+
 	blockID, txIndex, clauseIndex, err := d.parseTarget(opt.Target)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Description

In the API doc, it is describing `The maximum number of results to be returned. Default is 1000.` for the option `maxResult`, but the feature wasn't implemented in the code. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
