### PR TITLE
Add cli option for limit-per-account in the mempool

### DIFF
--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -150,11 +150,6 @@ var (
 		Value: "localhost:2112",
 		Usage: "metrics service listening address",
 	}
-	txPoolLimitFlag = cli.Uint64Flag{
-		Name:  "txpool-limit",
-		Value: 10000,
-		Usage: "set tx limit in pool",
-	}
 	txPoolLimitPerAccountFlag = cli.Uint64Flag{
 		Name:  "txpool-limit-per-account",
 		Value: 16,
@@ -179,6 +174,11 @@ var (
 		Name:  "gas-limit",
 		Value: 40_000_000,
 		Usage: "block gas limit(adaptive if set to 0)",
+	}
+	txPoolLimitFlag = cli.Uint64Flag{
+		Name:  "txpool-limit",
+		Value: 10000,
+		Usage: "set tx limit in pool",
 	}
 	genesisFlag = cli.StringFlag{
 		Name:  "genesis",

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -150,6 +150,16 @@ var (
 		Value: "localhost:2112",
 		Usage: "metrics service listening address",
 	}
+	txPoolLimitFlag = cli.Uint64Flag{
+		Name:  "txpool-limit",
+		Value: 10000,
+		Usage: "set tx limit in pool",
+	}
+	txPoolLimitPerAccountFlag = cli.Uint64Flag{
+		Name:  "txpool-limit-per-account",
+		Value: 16,
+		Usage: "set tx limit per account in pool",
+	}
 
 	// solo mode only flags
 	onDemandFlag = cli.BoolFlag{
@@ -169,16 +179,6 @@ var (
 		Name:  "gas-limit",
 		Value: 40_000_000,
 		Usage: "block gas limit(adaptive if set to 0)",
-	}
-	txPoolLimitFlag = cli.Uint64Flag{
-		Name:  "txpool-limit",
-		Value: 10000,
-		Usage: "set tx limit in pool",
-	}
-	txPoolLimitPerAccountFlag = cli.Uint64Flag{
-		Name:  "txpool-limit-per-account",
-		Value: 16,
-		Usage: "set tx limit per account in pool",
 	}
 	genesisFlag = cli.StringFlag{
 		Name:  "genesis",

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -93,7 +93,6 @@ func main() {
 			disablePrunerFlag,
 			enableMetricsFlag,
 			metricsAddrFlag,
-			txPoolLimitFlag,
 			txPoolLimitPerAccountFlag,
 		},
 		Action: defaultAction,
@@ -214,10 +213,6 @@ func defaultAction(ctx *cli.Context) error {
 	}
 
 	txpoolOpt := defaultTxPoolOptions
-	txpoolOpt.Limit, err = readIntFromUInt64Flag(ctx.Uint64(txPoolLimitFlag.Name))
-	if err != nil {
-		return errors.Wrap(err, "parse txpool-limit flag")
-	}
 	txpoolOpt.LimitPerAccount, err = readIntFromUInt64Flag(ctx.Uint64(txPoolLimitPerAccountFlag.Name))
 	if err != nil {
 		return errors.Wrap(err, "parse txpool-limit-per-account flag")

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -93,6 +93,8 @@ func main() {
 			disablePrunerFlag,
 			enableMetricsFlag,
 			metricsAddrFlag,
+			txPoolLimitFlag,
+			txPoolLimitPerAccountFlag,
 		},
 		Action: defaultAction,
 		Commands: []cli.Command{
@@ -212,6 +214,14 @@ func defaultAction(ctx *cli.Context) error {
 	}
 
 	txpoolOpt := defaultTxPoolOptions
+	txpoolOpt.Limit, err = readIntFromUInt64Flag(ctx.Uint64(txPoolLimitFlag.Name))
+	if err != nil {
+		return errors.Wrap(err, "parse txpool-limit flag")
+	}
+	txpoolOpt.LimitPerAccount, err = readIntFromUInt64Flag(ctx.Uint64(txPoolLimitPerAccountFlag.Name))
+	if err != nil {
+		return errors.Wrap(err, "parse txpool-limit-per-account flag")
+	}
 	txPool := txpool.New(repo, state.NewStater(mainDB), txpoolOpt)
 	defer func() { log.Info("closing tx pool..."); txPool.Close() }()
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -182,6 +182,7 @@ bin/thor -h
 | `--disable-pruner`          | Disable state pruner to keep all history                                                    |
 | `--enable-metrics`          | Enables the metrics server                                                                  |
 | `--metrics-addr`            | Metrics service listening address                                                           |
+| `--txpool-limit-per-account`| Transaction pool size limit per account                                                     |
 | `--help, -h`                | Show help                                                                                   |
 | `--version, -v`             | Print the version                                                                           |
 
@@ -195,7 +196,7 @@ bin/thor -h
 | `--persist`                  | Save blockchain data to disk(default to memory)    |
 | `--gas-limit`                | Gas limit for each block                           |
 | `--txpool-limit`             | Transaction pool size limit                        |
-| `--txpool-limit-per-account` | Transaction pool size limit per account            |
+
 
 #### Discovery Node Flags
 


### PR DESCRIPTION
This PR makes the already existing flags 

- `txpool-limit-per-account` (default 16)
- `txpool-limit` (default 10k)

which were previously solo only flags available in testnet and mainnet modes. No unbounded option was added but we can discuss if that is necessary. 