### PR TITLE
feat: create a node info endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -57,6 +57,16 @@ func New(
 	}
 
 	router := mux.NewRouter()
+	info := node.Info{
+		Version:           doc.Version(),
+		LogsEnabled:       !skipLogs,
+		LogsLimit:         logsLimit,
+		DebugEnabled:      true,
+		DebugCustomTracer: allowCustomTracer,
+		DebugPprofEnabled: pprofOn,
+		CallGasLimit:      callGasLimit,
+		WSBackTraceLimit:  backtraceLimit,
+	}
 
 	// to serve stoplight, swagger and api docs
 	router.PathPrefix("/doc").Handler(
@@ -84,7 +94,7 @@ func New(
 		Mount(router, "/transactions")
 	debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft).
 		Mount(router, "/debug")
-	node.New(nw).
+	node.New(nw, info).
 		Mount(router, "/node")
 	subs := subscriptions.New(repo, origins, backtraceLimit, txPool)
 	subs.Mount(router, "/subscriptions")

--- a/api/api.go
+++ b/api/api.go
@@ -63,7 +63,6 @@ func New(
 		LogsLimit:         logsLimit,
 		DebugEnabled:      true,
 		DebugCustomTracer: allowCustomTracer,
-		DebugPprofEnabled: pprofOn,
 		CallGasLimit:      callGasLimit,
 		WSBackTraceLimit:  backtraceLimit,
 	}

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -378,6 +378,21 @@ paths:
                 type: string
                 example: 'Invalid request body'
 
+  /node/info:
+    get:
+      tags:
+        - Node
+      summary: Retrieve node information
+      description: |
+        Retrieve information about the node, such as enabled endpoints and limits.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NodeInfo'
+
   /node/network/peers:
     get:
       tags:
@@ -1064,6 +1079,51 @@ components:
       nullable: false
       items:
         $ref: '#/components/schemas/PeerStats'
+
+    NodeInfo:
+      type: object
+      title: NodeInfo
+      nullable: false
+      properties:
+        version:
+          type: string
+          description: The version of the node
+          example: '2.0.0'
+          nullable: false
+        logsEnabled:
+          type: boolean
+          description: Indicates whether the `/logs` API is enabled
+          example: true
+          nullable: false
+        logsLimit:
+          type: integer
+          description: The maximum number of logs that can be retrieved in a single request.
+          example: 1000
+          nullable: false
+        debugEnabled:
+          type: boolean
+          description: Indicates whether the `/debug` API is enabled.
+          example: true
+          nullable: false
+        debugCustomTracer:
+          type: boolean
+          description: Indicates whether the custom tracers are allowed in the `/debug` API.
+          example: true
+        debugPprofEnabled:
+          type: boolean
+          description: Indicates whether the `/debug/pprof` endpoints are enabled.
+          example: true
+          nullable: false
+        callGasLimit:
+          type: integer
+          description: The maximum gas limit for a contract call.
+          example: 10000000
+          nullable: false
+        wsBackTraceLimit:
+          type: integer
+          description: The maximum amount of blocks that a websocket subscription can go back to.
+          example: 10
+          nullable: false
 
     SubscriptionBlockResponse:
       type: object

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -1109,11 +1109,6 @@ components:
           type: boolean
           description: Indicates whether the custom tracers are allowed in the `/debug` API.
           example: true
-        debugPprofEnabled:
-          type: boolean
-          description: Indicates whether the `/debug/pprof` endpoints are enabled.
-          example: true
-          nullable: false
         callGasLimit:
           type: integer
           description: The maximum gas limit for a contract call.

--- a/api/node/node.go
+++ b/api/node/node.go
@@ -13,12 +13,14 @@ import (
 )
 
 type Node struct {
-	nw Network
+	nw   Network
+	info Info
 }
 
-func New(nw Network) *Node {
+func New(nw Network, info Info) *Node {
 	return &Node{
 		nw,
+		info,
 	}
 }
 
@@ -30,6 +32,10 @@ func (n *Node) handleNetwork(w http.ResponseWriter, req *http.Request) error {
 	return utils.WriteJSON(w, n.PeersStats())
 }
 
+func (n *Node) handleNodeInfo(w http.ResponseWriter, req *http.Request) error {
+	return utils.WriteJSON(w, n.info)
+}
+
 func (n *Node) Mount(root *mux.Router, pathPrefix string) {
 	sub := root.PathPrefix(pathPrefix).Subrouter()
 
@@ -37,4 +43,8 @@ func (n *Node) Mount(root *mux.Router, pathPrefix string) {
 		Methods(http.MethodGet).
 		Name("node_get_peers").
 		HandlerFunc(utils.WrapHandlerFunc(n.handleNetwork))
+	sub.Path("/info").
+		Methods(http.MethodGet).
+		Name("node_get_info").
+		HandlerFunc(utils.WrapHandlerFunc(n.handleNodeInfo))
 }

--- a/api/node/types.go
+++ b/api/node/types.go
@@ -14,6 +14,17 @@ type Network interface {
 	PeersStats() []*comm.PeerStats
 }
 
+type Info struct {
+	Version           string `json:"version"`
+	LogsEnabled       bool   `json:"logsEnabled"`
+	LogsLimit         uint64 `json:"logsLimit"`
+	DebugEnabled      bool   `json:"debugEnabled"`
+	DebugCustomTracer bool   `json:"debugCustomTracer"`
+	DebugPprofEnabled bool   `json:"debugPprofEnabled"`
+	CallGasLimit      uint64 `json:"callGasLimit"`
+	WSBackTraceLimit  uint32 `json:"wsBackTraceLimit"`
+}
+
 type PeerStats struct {
 	Name        string       `json:"name"`
 	BestBlockID thor.Bytes32 `json:"bestBlockID"`

--- a/api/node/types.go
+++ b/api/node/types.go
@@ -20,7 +20,6 @@ type Info struct {
 	LogsLimit         uint64 `json:"logsLimit"`
 	DebugEnabled      bool   `json:"debugEnabled"`
 	DebugCustomTracer bool   `json:"debugCustomTracer"`
-	DebugPprofEnabled bool   `json:"debugPprofEnabled"`
 	CallGasLimit      uint64 `json:"callGasLimit"`
 	WSBackTraceLimit  uint32 `json:"wsBackTraceLimit"`
 }


### PR DESCRIPTION
# Description

Create a `/node/info` endpoint to retrieve details about the node

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [ ] E2E Test
- [ ] Unit Test
- [x] Manual Test
```bash
curl http://localhost:8669/node/info | jq
```

Output:
```json
{
  "version": "2.1.3",
  "logsEnabled": true,
  "logsLimit": 1000,
  "debugEnabled": true,
  "debugCustomTracer": false,
  "debugPprofEnabled": false,
  "callGasLimit": 50000000,
  "wsBackTraceLimit": 1000
}
```

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
