### PR TITLE
enhancement: logdb - include optional tx and log indexes in responses

### DIFF
--- a/api/events/events.go
+++ b/api/events/events.go
@@ -44,7 +44,7 @@ func (e *Events) filter(ctx context.Context, ef *EventFilter) ([]*FilteredEvent,
 	}
 	fes := make([]*FilteredEvent, len(events))
 	for i, e := range events {
-		fes[i] = convertEvent(e)
+		fes[i] = convertEvent(e, ef.Indexes)
 	}
 	return fes, nil
 }

--- a/api/transfers/transfers.go
+++ b/api/transfers/transfers.go
@@ -50,7 +50,7 @@ func (t *Transfers) filter(ctx context.Context, filter *TransferFilter) ([]*Filt
 	}
 	tLogs := make([]*FilteredTransfer, len(transfers))
 	for i, trans := range transfers {
-		tLogs[i] = convertTransfer(trans)
+		tLogs[i] = convertTransfer(trans, filter.Indexes)
 	}
 	return tLogs, nil
 }

--- a/api/transfers/types.go
+++ b/api/transfers/types.go
@@ -19,6 +19,8 @@ type LogMeta struct {
 	TxID           thor.Bytes32 `json:"txID"`
 	TxOrigin       thor.Address `json:"txOrigin"`
 	ClauseIndex    uint32       `json:"clauseIndex"`
+	LogIndex       *uint32      `json:"logIndex,omitempty"` // pointer for backwards compatibility
+	TxIndex        *uint32      `json:"txIndex,omitempty"`  // pointer for backwards compatibility
 }
 
 type FilteredTransfer struct {
@@ -28,9 +30,9 @@ type FilteredTransfer struct {
 	Meta      LogMeta               `json:"meta"`
 }
 
-func convertTransfer(transfer *logdb.Transfer) *FilteredTransfer {
+func convertTransfer(transfer *logdb.Transfer, indexes bool) *FilteredTransfer {
 	v := math.HexOrDecimal256(*transfer.Amount)
-	return &FilteredTransfer{
+	t := &FilteredTransfer{
 		Sender:    transfer.Sender,
 		Recipient: transfer.Recipient,
 		Amount:    &v,
@@ -43,6 +45,13 @@ func convertTransfer(transfer *logdb.Transfer) *FilteredTransfer {
 			ClauseIndex:    transfer.ClauseIndex,
 		},
 	}
+
+	if indexes {
+		t.Meta.TxIndex = &transfer.TxIndex
+		t.Meta.LogIndex = &transfer.LogIndex
+	}
+
+	return t
 }
 
 type TransferFilter struct {
@@ -50,4 +59,5 @@ type TransferFilter struct {
 	Range       *events.Range
 	Options     *logdb.Options
 	Order       logdb.Order //default asc
+	Indexes     bool
 }

--- a/cmd/thor/sync_logdb.go
+++ b/cmd/thor/sync_logdb.go
@@ -301,7 +301,8 @@ func verifyLogDBPerBlock(
 				}
 				expectedEvLogs = append(expectedEvLogs, &logdb.Event{
 					BlockNumber: n,
-					Index:       uint32(len(expectedEvLogs)),
+					TxIndex:     uint32(txIndex),
+					LogIndex:    uint32(len(expectedEvLogs)),
 					BlockID:     id,
 					BlockTime:   ts,
 					TxID:        tx.ID(),
@@ -315,7 +316,8 @@ func verifyLogDBPerBlock(
 			for _, tr := range output.Transfers {
 				expectedTrLogs = append(expectedTrLogs, &logdb.Transfer{
 					BlockNumber: n,
-					Index:       uint32(len(expectedTrLogs)),
+					TxIndex:     uint32(txIndex),
+					LogIndex:    uint32(len(expectedTrLogs)),
 					BlockID:     id,
 					BlockTime:   ts,
 					TxID:        tx.ID(),

--- a/logdb/logdb_test.go
+++ b/logdb/logdb_test.go
@@ -146,7 +146,8 @@ func TestEvents(t *testing.T) {
 			origin, _ := tx.Origin()
 			allEvents = append(allEvents, &logdb.Event{
 				BlockNumber: b.Header().Number(),
-				Index:       uint32(j),
+				TxIndex:     uint32(j),
+				LogIndex:    uint32(j),
 				BlockID:     b.Header().ID(),
 				BlockTime:   b.Header().Timestamp(),
 				TxID:        tx.ID(),
@@ -159,7 +160,8 @@ func TestEvents(t *testing.T) {
 
 			allTransfers = append(allTransfers, &logdb.Transfer{
 				BlockNumber: b.Header().Number(),
-				Index:       uint32(j),
+				TxIndex:     uint32(j),
+				LogIndex:    uint32(j),
 				BlockID:     b.Header().ID(),
 				BlockTime:   b.Header().Timestamp(),
 				TxID:        tx.ID(),

--- a/logdb/sequence.go
+++ b/logdb/sequence.go
@@ -5,21 +5,44 @@
 
 package logdb
 
-import "math"
-
 type sequence int64
 
-func newSequence(blockNum uint32, index uint32) sequence {
-	if (index & math.MaxInt32) != index {
-		panic("index too large")
+// Adjust these constants based on your bit allocation requirements
+const (
+	blockNumBits = 31
+	txIndexBits  = 12
+	logIndexBits = 21
+	// Max = 2^31 - 1 = 2,147,483,647
+	blockNumMask = (1 << blockNumBits) - 1
+	// Max = 2^12 - 1 = 4,095
+	txIndexMask = (1 << txIndexBits) - 1
+	// Max = 2^21 - 1 = 2,097,151
+	logIndexMask = (1 << logIndexBits) - 1
+)
+
+func newSequence(blockNum uint32, txIndex uint32, logIndex uint32) sequence {
+	if blockNum > blockNumMask {
+		panic("block number too large")
 	}
-	return (sequence(blockNum) << 31) | sequence(index)
+	if txIndex > txIndexMask {
+		panic("transaction index too large")
+	}
+	if logIndex > logIndexMask {
+		panic("log index too large")
+	}
+	return (sequence(blockNum) << (txIndexBits + logIndexBits)) |
+		(sequence(txIndex) << logIndexBits) |
+		sequence(logIndex)
 }
 
 func (s sequence) BlockNumber() uint32 {
-	return uint32(s >> 31)
+	return uint32(s>>(txIndexBits+logIndexBits)) & blockNumMask
 }
 
-func (s sequence) Index() uint32 {
-	return uint32(s & math.MaxInt32)
+func (s sequence) TxIndex() uint32 {
+	return uint32((s >> logIndexBits) & txIndexMask)
+}
+
+func (s sequence) LogIndex() uint32 {
+	return uint32(s & logIndexMask)
 }

--- a/logdb/types.go
+++ b/logdb/types.go
@@ -15,7 +15,8 @@ import (
 // Event represents tx.Event that can be stored in db.
 type Event struct {
 	BlockNumber uint32
-	Index       uint32
+	LogIndex    uint32
+	TxIndex     uint32
 	BlockID     thor.Bytes32
 	BlockTime   uint64
 	TxID        thor.Bytes32
@@ -29,7 +30,8 @@ type Event struct {
 // Transfer represents tx.Transfer that can be stored in db.
 type Transfer struct {
 	BlockNumber uint32
-	Index       uint32
+	TxIndex     uint32
+	LogIndex    uint32
 	BlockID     thor.Bytes32
 	BlockTime   uint64
 	TxID        thor.Bytes32


### PR DESCRIPTION
# Description

Includes log and TX indexes in the logDB sequence entries and optionally return them in response bodies.

This will break existing nodes, as a fully sync would be required. (On top of maindb v4 if we want to include it)

**NOTE**: IMO it would be better to revert the sequence changes and store the tx index the same way as we do for clause index

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [ ] Unit tests
- [ ] E2E tests
- [x] Manually:

1) Test case: `indexes` omitted from request body

Request:
```bash
curl --request POST \
  --url http://127.0.0.1:8669/logs/transfer \
  --header 'Accept: application/json, text/plain' \
  --header 'Content-Type: application/json' \
  --data '{
  "range": {
    "from": 100,
    "to": 17289864
  },
  "options": {
    "offset": 0,
    "limit": 1
  },
  "criteriaSet": []
}' | jq
```

Response:
```json
[
  {
    "sender": "0x137053dfbe6c0a43f915ad2efefefdcc2708e975",
    "recipient": "0x1e3a0ef75b142c1fcd54609ce6352a8b5d3b898d",
    "amount": "0xad78ebc5ac6200000",
    "meta": {
      "blockID": "0x000093d16b04addea4e2051edc427607dc25c7241c9c0bbcc5cf4098e204aa4c",
      "blockNumber": 37841,
      "blockTimestamp": 1530695350,
      "txID": "0xfc996d321a96702d0468a60e17b032fe5fa9e3f6edb6a55858eb2e2d5580af8d",
      "txOrigin": "0x137053dfbe6c0a43f915ad2efefefdcc2708e975",
      "clauseIndex": 0
    }
  }
]
```

2) Test case: `"indexes": true`

Request:
```bash
curl --request POST \
  --url http://127.0.0.1:8669/logs/transfer \
  --header 'Accept: application/json, text/plain' \
  --header 'Content-Type: application/json' \
  --data '{
  "range": {
    "from": 100,
    "to": 17289864
  },
  "options": {
    "offset": 0,
    "limit": 1
  },
  "criteriaSet": [],
  "indexes": true
}' | jq
```

Respons:
```json
[
  {
    "sender": "0x137053dfbe6c0a43f915ad2efefefdcc2708e975",
    "recipient": "0x1e3a0ef75b142c1fcd54609ce6352a8b5d3b898d",
    "amount": "0xad78ebc5ac6200000",
    "meta": {
      "blockID": "0x000093d16b04addea4e2051edc427607dc25c7241c9c0bbcc5cf4098e204aa4c",
      "blockNumber": 37841,
      "blockTimestamp": 1530695350,
      "txID": "0xfc996d321a96702d0468a60e17b032fe5fa9e3f6edb6a55858eb2e2d5580af8d",
      "txOrigin": "0x137053dfbe6c0a43f915ad2efefefdcc2708e975",
      "clauseIndex": 0,
      "logIndex": 0,
      "txIndex": 0
    }
  }
]
```

3) Test case: `"indexes": false`

Request:
```bash
curl --request POST \
  --url http://127.0.0.1:8669/logs/transfer \
  --header 'Accept: application/json, text/plain' \
  --header 'Content-Type: application/json' \
  --data '{
  "range": {
    "from": 100,
    "to": 17289864
  },
  "options": {
    "offset": 0,
    "limit": 1
  },
  "criteriaSet": [],
  "indexes": false
}' | jq
```

Respons:
```json
[
  {
    "sender": "0x137053dfbe6c0a43f915ad2efefefdcc2708e975",
    "recipient": "0x1e3a0ef75b142c1fcd54609ce6352a8b5d3b898d",
    "amount": "0xad78ebc5ac6200000",
    "meta": {
      "blockID": "0x000093d16b04addea4e2051edc427607dc25c7241c9c0bbcc5cf4098e204aa4c",
      "blockNumber": 37841,
      "blockTimestamp": 1530695350,
      "txID": "0xfc996d321a96702d0468a60e17b032fe5fa9e3f6edb6a55858eb2e2d5580af8d",
      "txOrigin": "0x137053dfbe6c0a43f915ad2efefefdcc2708e975",
      "clauseIndex": 0
    }
  }
]
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
