### PR TITLE
Add api-allowed-tracers flag

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -44,8 +44,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: vechain/thor-e2e-tests
-          # https://github.com/vechain/thor-e2e-tests/tree/00bd3f1b949b05da94e82686e0089a11a136c34c
-          ref: 87aeb1747995e8b235a796303b0fc08ab16262c6
+          # https://github.com/vechain/thor-e2e-tests/tree/d86b30b6409b27e841eace0f7c5b6e75c0a4e25e
+          ref: d86b30b6409b27e841eace0f7c5b6e75c0a4e25e
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/api/api.go
+++ b/api/api.go
@@ -50,6 +50,7 @@ func New(
 	enableReqLogger bool,
 	enableMetrics bool,
 	logsLimit uint64,
+	allowedTracers map[string]interface{},
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")
 	for i, o := range origins {
@@ -82,7 +83,7 @@ func New(
 		Mount(router, "/blocks")
 	transactions.New(repo, txPool).
 		Mount(router, "/transactions")
-	debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft).
+	debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft, allowedTracers).
 		Mount(router, "/debug")
 	node.New(nw).
 		Mount(router, "/node")

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -216,10 +216,11 @@ func (d *Debug) createTracer(name string, config json.RawMessage) (tracers.Trace
 	if strings.TrimSpace(name) == "" {
 		return nil, fmt.Errorf("tracer name must be defined")
 	}
+	_, noTracers := d.allowedTracers["none"]
 	_, allTracers := d.allowedTracers["all"]
 
-	// fail if the tracer is not enable OR if the "all" tracers code isn't active
-	if _, ok := d.allowedTracers[name]; !ok && !allTracers {
+	// fail if the requested tracer is not allowed OR if the "all" tracers code isn't active
+	if _, ok := d.allowedTracers[name]; noTracers || (!ok && !allTracers) {
 		return nil, fmt.Errorf("creating tracer is not allowed: %s", name)
 	}
 

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -213,6 +213,9 @@ func (d *Debug) handleTraceCall(w http.ResponseWriter, req *http.Request) error 
 }
 
 func (d *Debug) createTracer(name string, config json.RawMessage) (tracers.Tracer, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, fmt.Errorf("tracer name must be defined")
+	}
 	_, allTracers := d.allowedTracers["all"]
 
 	// fail if the tracer is not enable OR if the "all" tracers code isn't active

--- a/api/debug/debug_test.go
+++ b/api/debug/debug_test.go
@@ -53,6 +53,7 @@ func TestDebug(t *testing.T) {
 	// /tracers endpoint
 	for name, tt := range map[string]func(*testing.T){
 		"testTraceClauseWithEmptyTracerName":       testTraceClauseWithEmptyTracerName,
+		"testTraceClauseWithInvalidTracerName":     testTraceClauseWithInvalidTracerName,
 		"testTraceClauseWithEmptyTracerTarget":     testTraceClauseWithEmptyTracerTarget,
 		"testTraceClauseWithBadBlockId":            testTraceClauseWithBadBlockId,
 		"testTraceClauseWithNonExistingBlockId":    testTraceClauseWithNonExistingBlockId,
@@ -163,6 +164,11 @@ func testTraceClauseWithEmptyTracerName(t *testing.T) {
 
 	res = httpPostAndCheckResponseStatus(t, ts.URL+"/debug/tracers", &TraceClauseOption{Name: " "}, 403)
 	assert.Equal(t, "tracer name must be defined", strings.TrimSpace(res))
+}
+
+func testTraceClauseWithInvalidTracerName(t *testing.T) {
+	res := httpPostAndCheckResponseStatus(t, ts.URL+"/debug/tracers", &TraceClauseOption{Name: "non-existent"}, 403)
+	assert.Contains(t, res, "unable to create custom tracer")
 }
 
 func testTraceClauseWithEmptyTracerTarget(t *testing.T) {

--- a/api/debug/debug_test.go
+++ b/api/debug/debug_test.go
@@ -164,6 +164,7 @@ func testTraceClauseWithEmptyTracerName(t *testing.T) {
 	res = httpPostAndCheckResponseStatus(t, ts.URL+"/debug/tracers", &TraceClauseOption{Name: " "}, 403)
 	assert.Equal(t, "tracer name must be defined", strings.TrimSpace(res))
 }
+
 func testTraceClauseWithEmptyTracerTarget(t *testing.T) {
 	res := httpPostAndCheckResponseStatus(t, ts.URL+"/debug/tracers", &TraceClauseOption{Name: "logger"}, 400)
 	assert.Equal(t, "target: unsupported", strings.TrimSpace(res))

--- a/api/debug/debug_test.go
+++ b/api/debug/debug_test.go
@@ -159,7 +159,10 @@ func TestStorageRangeMaxResult(t *testing.T) {
 
 func testTraceClauseWithEmptyTracerName(t *testing.T) {
 	res := httpPostAndCheckResponseStatus(t, ts.URL+"/debug/tracers", &TraceClauseOption{}, 403)
-	assert.Contains(t, strings.TrimSpace(res), "unable to create custom tracer")
+	assert.Equal(t, "tracer name must be defined", strings.TrimSpace(res))
+
+	res = httpPostAndCheckResponseStatus(t, ts.URL+"/debug/tracers", &TraceClauseOption{Name: " "}, 403)
+	assert.Equal(t, "tracer name must be defined", strings.TrimSpace(res))
 }
 func testTraceClauseWithEmptyTracerTarget(t *testing.T) {
 	res := httpPostAndCheckResponseStatus(t, ts.URL+"/debug/tracers", &TraceClauseOption{Name: "logger"}, 400)

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -2117,7 +2117,7 @@ components:
         name:
           type: string
           enum:
-            - ""
+            - logger
             - 4byte
             - call
             - noop

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -151,6 +151,12 @@ var (
 		Usage: "metrics service listening address",
 	}
 
+	allowedTracersFlag = cli.StringFlag{
+		Name:  "allowed-tracers",
+		Value: "all",
+		Usage: "define allowed API tracers",
+	}
+
 	// solo mode only flags
 	onDemandFlag = cli.BoolFlag{
 		Name:  "on-demand",

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -168,7 +168,7 @@ var (
 
 	allowedTracersFlag = cli.StringFlag{
 		Name:  "api-allowed-tracers",
-		Value: "all",
+		Value: "none",
 		Usage: "define allowed API tracers",
 	}
 

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -152,7 +152,7 @@ var (
 	}
 
 	allowedTracersFlag = cli.StringFlag{
-		Name:  "allowed-tracers",
+		Name:  "api-allowed-tracers",
 		Value: "all",
 		Usage: "define allowed API tracers",
 	}

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -35,6 +36,7 @@ import (
 
 	// Force-load the tracer engines to trigger registration
 	_ "github.com/vechain/thor/v2/tracers/js"
+	_ "github.com/vechain/thor/v2/tracers/logger"
 	_ "github.com/vechain/thor/v2/tracers/native"
 )
 
@@ -93,6 +95,7 @@ func main() {
 			disablePrunerFlag,
 			enableMetricsFlag,
 			metricsAddrFlag,
+			allowedTracersFlag,
 		},
 		Action: defaultAction,
 		Commands: []cli.Command{
@@ -125,6 +128,7 @@ func main() {
 					disablePrunerFlag,
 					enableMetricsFlag,
 					metricsAddrFlag,
+					allowedTracersFlag,
 				},
 				Action: soloAction,
 			},
@@ -242,6 +246,7 @@ func defaultAction(ctx *cli.Context) error {
 		ctx.Bool(enableAPILogsFlag.Name),
 		ctx.Bool(enableMetricsFlag.Name),
 		ctx.Uint64(apiLogsLimitFlag.Name),
+		parseTracerList(strings.TrimSpace(ctx.String(allowedTracersFlag.Name))),
 	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 
@@ -380,6 +385,7 @@ func soloAction(ctx *cli.Context) error {
 		ctx.Bool(enableAPILogsFlag.Name),
 		ctx.Bool(enableMetricsFlag.Name),
 		ctx.Uint64(apiLogsLimitFlag.Name),
+		parseTracerList(strings.TrimSpace(ctx.String(allowedTracersFlag.Name))),
 	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -754,3 +754,16 @@ func readIntFromUInt64Flag(val uint64) (int, error) {
 
 	return i, nil
 }
+
+func parseTracerList(list string) map[string]interface{} {
+	inputs := strings.Split(list, ",")
+	tracerMap := map[string]interface{}{}
+	for _, i := range inputs {
+		if i == "" {
+			continue
+		}
+		tracerMap[i] = new(interface{})
+	}
+
+	return tracerMap
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -168,6 +168,7 @@ bin/thor -h
 | `--api-call-gas-limit`      | Limit contract call gas (default: 50000000)                                                 |
 | `--api-backtrace-limit`     | Limit the distance between 'position' and best block for subscriptions APIs (default: 1000) |
 | `--api-allow-custom-tracer` | Allow custom JS tracer to be used for the tracer API                                        |
+| `--api-allowed-tracers`     | Comma-separated list of allowed tracers (default: "all")                                    |
 | `--enable-api-logs`         | Enables API requests logging                                                                |
 | `--api-logs-limit`          | Limit the number of logs returned by /logs API (default: 1000)                              |
 | `--verbosity`               | Log verbosity (0-9) (default: 3)                                                            |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -168,7 +168,7 @@ bin/thor -h
 | `--api-call-gas-limit`      | Limit contract call gas (default: 50000000)                                                 |
 | `--api-backtrace-limit`     | Limit the distance between 'position' and best block for subscriptions APIs (default: 1000) |
 | `--api-allow-custom-tracer` | Allow custom JS tracer to be used for the tracer API                                        |
-| `--api-allowed-tracers`     | Comma-separated list of allowed tracers (default: "all")                                    |
+| `--api-allowed-tracers`     | Comma-separated list of allowed tracers (default: "none")                                   |
 | `--enable-api-logs`         | Enables API requests logging                                                                |
 | `--api-logs-limit`          | Limit the number of logs returned by /logs API (default: 1000)                              |
 | `--verbosity`               | Log verbosity (0-9) (default: 3)                                                            |

--- a/tracers/logger/logger.go
+++ b/tracers/logger/logger.go
@@ -34,6 +34,10 @@ import (
 	"github.com/vechain/thor/v2/vm"
 )
 
+func init() {
+	tracers.DefaultDirectory.Register("logger", NewStructLogger, false)
+}
+
 // Storage represents a contract's storage.
 type Storage map[common.Hash]common.Hash
 
@@ -119,7 +123,7 @@ type StructLogger struct {
 }
 
 // NewStructLogger returns a new logger
-func NewStructLogger(cfg json.RawMessage) (*StructLogger, error) {
+func NewStructLogger(cfg json.RawMessage) (tracers.Tracer, error) {
 	var config Config
 	if cfg != nil {
 		if err := json.Unmarshal(cfg, &config); err != nil {

--- a/tracers/logger/logger_test.go
+++ b/tracers/logger/logger_test.go
@@ -58,11 +58,12 @@ func (*dummyStatedb) SetState(_ common.Address, _ common.Hash, _ common.Hash) {}
 
 func TestStoreCapture(t *testing.T) {
 	var (
-		logger, _ = NewStructLogger(nil)
-		env       = vm.NewEVM(vm.Context{}, &dummyStatedb{}, &vm.ChainConfig{ChainConfig: *params.TestChainConfig}, vm.Config{Tracer: logger})
+		unCastedLogger, _ = NewStructLogger(nil)
+		env               = vm.NewEVM(vm.Context{}, &dummyStatedb{}, &vm.ChainConfig{ChainConfig: *params.TestChainConfig}, vm.Config{Tracer: unCastedLogger.(*StructLogger)})
 
 		contract = vm.NewContract(&dummyContractRef{}, &dummyContractRef{}, new(big.Int), 100000)
 	)
+	logger := unCastedLogger.(*StructLogger)
 	contract.Code = []byte{byte(vm.PUSH1), 0x1, byte(vm.PUSH1), 0x0, byte(vm.SSTORE)}
 	var index common.Hash
 	logger.CaptureStart(env, common.Address{}, contract.Address(), false, nil, 0, nil)
@@ -123,7 +124,8 @@ func TestFormatLogs(t *testing.T) {
 }
 
 func TestCaptureStart(t *testing.T) {
-	logger, _ := NewStructLogger(nil)
+	unCastedLogger, _ := NewStructLogger(nil)
+	logger := unCastedLogger.(*StructLogger)
 	env := &vm.EVM{}
 
 	logger.CaptureStart(env, common.Address{}, common.Address{}, false, nil, 0, nil)

--- a/tracers/tracers.go
+++ b/tracers/tracers.go
@@ -95,7 +95,7 @@ func (d *directory) New(name string, cfg json.RawMessage, allowCustom bool) (Tra
 		// Assume JS code
 		tracer, err := d.jsEval(name, cfg)
 		if err != nil {
-			return nil, errors.Wrap(err, "create custom tracer")
+			return nil, errors.Wrap(err, "unable to create custom tracer")
 		}
 		return tracer, nil
 	} else {


### PR DESCRIPTION
# Description

This is a tentative PR with regard to https://github.com/vechain/protocol-board-repo/issues/292

- Adds a new `allowed-tracers` flag. Ex: `--allowed-tracers="all"`, `--allowed-tracers="call,4byte"
- The default available tracers are changed - `--allowed-tracers="none"` is the default
- Node operator can now pick-and-choose which tracers are available
- "" is no longer accepted as a valid (defaulted to log) tracer name

Fixes # https://github.com/vechain/protocol-board-repo/issues/292

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
