### PR TITLE
Debug thor solo with different genesis

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -51,7 +51,7 @@ func New(
 	enableMetrics bool,
 	logsLimit uint64,
 	allowedTracers map[string]interface{},
-	skipPoA bool,
+	soloMode bool,
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")
 	for i, o := range origins {
@@ -84,7 +84,7 @@ func New(
 		Mount(router, "/blocks")
 	transactions.New(repo, txPool).
 		Mount(router, "/transactions")
-	debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft, allowedTracers, skipPoA).
+	debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft, allowedTracers, soloMode).
 		Mount(router, "/debug")
 	node.New(nw).
 		Mount(router, "/node")

--- a/api/api.go
+++ b/api/api.go
@@ -51,6 +51,7 @@ func New(
 	enableMetrics bool,
 	logsLimit uint64,
 	allowedTracers map[string]interface{},
+	skipPoA bool,
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")
 	for i, o := range origins {
@@ -83,7 +84,7 @@ func New(
 		Mount(router, "/blocks")
 	transactions.New(repo, txPool).
 		Mount(router, "/transactions")
-	debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft, allowedTracers).
+	debug.New(repo, stater, forkConfig, callGasLimit, allowCustomTracer, bft, allowedTracers, skipPoA).
 		Mount(router, "/debug")
 	node.New(nw).
 		Mount(router, "/node")

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -24,7 +24,6 @@ import (
 	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/consensus"
-	"github.com/vechain/thor/v2/genesis"
 	"github.com/vechain/thor/v2/muxdb"
 	"github.com/vechain/thor/v2/runtime"
 	"github.com/vechain/thor/v2/state"
@@ -38,8 +37,6 @@ import (
 
 const defaultMaxStorageResult = 1000
 
-var devNetGenesisID = genesis.NewDevnet().ID()
-
 type Debug struct {
 	repo              *chain.Repository
 	stater            *state.Stater
@@ -48,9 +45,18 @@ type Debug struct {
 	allowCustomTracer bool
 	bft               bft.Finalizer
 	allowedTracers    map[string]interface{}
+	skipPoA           bool
 }
 
-func New(repo *chain.Repository, stater *state.Stater, forkConfig thor.ForkConfig, callGaslimit uint64, allowCustomTracer bool, bft bft.Finalizer, allowedTracers map[string]interface{}) *Debug {
+func New(
+	repo *chain.Repository,
+	stater *state.Stater,
+	forkConfig thor.ForkConfig,
+	callGaslimit uint64,
+	allowCustomTracer bool,
+	bft bft.Finalizer,
+	allowedTracers map[string]interface{},
+	skipPoA bool) *Debug {
 	return &Debug{
 		repo,
 		stater,
@@ -59,6 +65,7 @@ func New(repo *chain.Repository, stater *state.Stater, forkConfig thor.ForkConfi
 		allowCustomTracer,
 		bft,
 		allowedTracers,
+		skipPoA,
 	}
 }
 
@@ -78,12 +85,11 @@ func (d *Debug) prepareClauseEnv(ctx context.Context, blockID thor.Bytes32, txIn
 	if clauseIndex >= uint32(len(txs[txIndex].Clauses())) {
 		return nil, nil, thor.Bytes32{}, utils.Forbidden(errors.New("clause index out of range"))
 	}
-	skipPoA := d.repo.GenesisBlock().Header().ID() == devNetGenesisID
 	rt, err := consensus.New(
 		d.repo,
 		d.stater,
 		d.forkConfig,
-	).NewRuntimeForReplay(block.Header(), skipPoA)
+	).NewRuntimeForReplay(block.Header(), d.skipPoA)
 	if err != nil {
 		return nil, nil, thor.Bytes32{}, err
 	}

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -56,7 +56,7 @@ func New(
 	allowCustomTracer bool,
 	bft bft.Finalizer,
 	allowedTracers map[string]interface{},
-	skipPoA bool) *Debug {
+	soloMode bool) *Debug {
 	return &Debug{
 		repo,
 		stater,
@@ -65,7 +65,7 @@ func New(
 		allowCustomTracer,
 		bft,
 		allowedTracers,
-		skipPoA,
+		soloMode,
 	}
 }
 

--- a/api/debug/debug_test.go
+++ b/api/debug/debug_test.go
@@ -597,7 +597,7 @@ func initDebugServer(t *testing.T) {
 	forkConfig := thor.GetForkConfig(b.Header().ID())
 	router := mux.NewRouter()
 	allTracersEnabled := map[string]interface{}{"all": new(interface{})}
-	debug = New(repo, stater, forkConfig, 21000, true, solo.NewBFTEngine(repo), allTracersEnabled)
+	debug = New(repo, stater, forkConfig, 21000, true, solo.NewBFTEngine(repo), allTracersEnabled, false)
 	debug.Mount(router, "/debug")
 	ts = httptest.NewServer(router)
 }

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -689,9 +689,9 @@ paths:
     post:
       tags:
         - Debug
-      summary: Trace a contract call
+      summary: Trace a call
       description: |
-        This endpoint enables clients to create a tracer for a specific vechain function call. 
+        This endpoint enables clients to create a tracer for a specific vechain clause. 
         
         You can customize the tracer using various options to suit your debugging requirements.
 

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -266,6 +266,7 @@ func defaultAction(ctx *cli.Context) error {
 		ctx.Bool(enableMetricsFlag.Name),
 		ctx.Uint64(apiLogsLimitFlag.Name),
 		parseTracerList(strings.TrimSpace(ctx.String(allowedTracersFlag.Name))),
+		false,
 	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 
@@ -416,6 +417,7 @@ func soloAction(ctx *cli.Context) error {
 		ctx.Bool(enableMetricsFlag.Name),
 		ctx.Uint64(apiLogsLimitFlag.Name),
 		parseTracerList(strings.TrimSpace(ctx.String(allowedTracersFlag.Name))),
+		true,
 	)
 	defer func() { log.Info("closing API..."); apiCloser() }()
 


### PR DESCRIPTION
# Description

There's a small bug when starting thor solo with a different genesis. PoA is still in use when the genesis is different from devnet genesis.

This fixes it by changing the PoA use check.

To replicate issue: 
```
curl -X GET http://localhost:8669/blocks/1

{"number":1,"id":"0x00000001a054ddd4f2297c4476670a4cb7f877658dcde2f96977bf9c28faf5cf","size":548,"parentID":"0x0000000008602e7a995c747a3215b426c0c65709480b9e9ac57ad37c3f7d73de","timestamp":1724420473,"gasLimit":40000000,"beneficiary":"0xf077b491b355e64048ce21e3a6fc4751eeea77fa","gasUsed":23405,"totalScore":1,"txsRoot":"0x956359ee97d46c0f7dfed2b2a9972778329b613d98fb57c6e98d293b8571b516","txsFeatures":1,"stateRoot":"0xd56b8cb8e15a668db8c971caeb96924f283e1c3c532823d74e85617bdaaa3255","receiptsRoot":"0x9007c0410c0b67afb8455b10853f7c85c829b38e211fa91c732a93116037ccd8","com":false,"signer":"0xf077b491b355e64048ce21e3a6fc4751eeea77fa","isTrunk":true,"isFinalized":false,"transactions":["0x26b930ea64375f4326092dd5e846d277c435a018efb38780be30e3c4921e6315"]}
```

```
curl -X POST 'http://localhost:8669/debug/tracers' \
-H 'Content-Type: application/json' \
-d '{
  "target": "0x00000001a054ddd4f2297c4476670a4cb7f877658dcde2f96977bf9c28faf5cf/0/0",
  "name": "prestate"
}'
block signer invalid: 0xf077b491b355e64048ce21e3a6fc4751eeea77fa unauthorized block proposer
```

Fixes # Discovered when doing [this](https://github.com/vechain/otherviews-workboard/issues/91)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
