### PR TITLE
make custom tracer to work with allowed tracers flag

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -44,8 +44,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: vechain/thor-e2e-tests
-          # https://github.com/vechain/thor-e2e-tests/tree/d86b30b6409b27e841eace0f7c5b6e75c0a4e25e
-          ref: d86b30b6409b27e841eace0f7c5b6e75c0a4e25e
+          # https://github.com/vechain/thor-e2e-tests/tree/209f6ea9a81a98dc2d5e42bf036d2878c5837036
+          ref: 209f6ea9a81a98dc2d5e42bf036d2878c5837036
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/api/api.go
+++ b/api/api.go
@@ -50,7 +50,7 @@ func New(
 	enableReqLogger bool,
 	enableMetrics bool,
 	logsLimit uint64,
-	allowedTracers map[string]interface{},
+	allowedTracers []string,
 	soloMode bool,
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(allowedOrigins), ",")

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -241,7 +241,11 @@ func (d *Debug) createTracer(name string, config json.RawMessage) (tracers.Trace
 		return tracers.DefaultDirectory.New(tracerName, config, false)
 	}
 
-	return tracers.DefaultDirectory.New(tracerName, config, d.allowCustomTracer)
+	if d.allowCustomTracer {
+		return tracers.DefaultDirectory.New(tracerName, config, true)
+	}
+
+	return nil, errors.New("tracer is not defined")
 }
 
 func (d *Debug) traceCall(ctx context.Context, tracer tracers.Tracer, header *block.Header, st *state.State, txCtx *xenv.TransactionContext, gas uint64, clause *tx.Clause) (interface{}, error) {

--- a/api/debug/debug_test.go
+++ b/api/debug/debug_test.go
@@ -619,7 +619,7 @@ func TestCreateTracer(t *testing.T) {
 	assert.Nil(t, err)
 	assert.IsType(t, &logger.StructLogger{}, tr)
 	_, err = debug.createTracer("{result:()=>{}, fault:()=>{}}", nil)
-	assert.EqualError(t, err, "unsupported tracer")
+	assert.EqualError(t, err, "tracer is not defined")
 
 	tr, err = debug.createTracer("structLogger", nil)
 	assert.Nil(t, err)

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -2117,7 +2117,7 @@ components:
         name:
           type: string
           enum:
-            - logger
+            - structLogger
             - 4byte
             - call
             - noop

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -169,7 +169,7 @@ var (
 	allowedTracersFlag = cli.StringFlag{
 		Name:  "api-allowed-tracers",
 		Value: "none",
-		Usage: "define allowed API tracers",
+		Usage: "comma separated list of allowed API tracers(none,all,call,prestate etc.)",
 	}
 
 	// solo mode only flags

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -753,15 +753,24 @@ func readIntFromUInt64Flag(val uint64) (int, error) {
 	return i, nil
 }
 
-func parseTracerList(list string) map[string]interface{} {
+func parseTracerList(list string) []string {
 	inputs := strings.Split(list, ",")
-	tracerMap := map[string]interface{}{}
+	tracers := make([]string, 0, len(inputs))
+
 	for _, i := range inputs {
-		if i == "" {
+		name := strings.TrimSpace(i)
+		if name == "" {
 			continue
 		}
-		tracerMap[i] = new(interface{})
+		if name == "none" {
+			return []string{}
+		}
+		if name == "all" {
+			return []string{"all"}
+		}
+
+		tracers = append(tracers, i)
 	}
 
-	return tracerMap
+	return tracers
 }

--- a/tracers/logger/logger.go
+++ b/tracers/logger/logger.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	tracers.DefaultDirectory.Register("logger", NewStructLogger, false)
+	tracers.DefaultDirectory.Register("structLoggerTracer", NewStructLogger, false)
 }
 
 // Storage represents a contract's storage.

--- a/tracers/tracers.go
+++ b/tracers/tracers.go
@@ -79,6 +79,17 @@ func (d *directory) RegisterJSEval(f jsCtorFn) {
 	d.jsEval = f
 }
 
+// Lookup returns true if the given tracer is registered.
+func (d *directory) Lookup(name string) bool {
+	if _, ok := d.elems[name]; ok {
+		return ok
+	}
+
+	// backward compatible, allow users emit "Tracer" suffix
+	_, ok := d.elems[name+"Tracer"]
+	return ok
+}
+
 // New returns a new instance of a tracer, by iterating through the
 // registered lookups. Name is either name of an existing tracer
 // or an arbitrary JS code.


### PR DESCRIPTION
# Description

- Make custom tracer work with allowed tracers
- Rename `logger` tracer to `structLoggerTracer` and remain backward compatiability

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
