### PR TITLE
pool:check executable against next block number

### DIFF
--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -55,7 +55,7 @@ func (o *txObject) Executable(chain *chain.Chain, state *state.State, headBlock 
 	switch {
 	case o.Gas() > headBlock.GasLimit():
 		return false, errors.New("gas too large")
-	case o.IsExpired(headBlock.Number()):
+	case o.IsExpired(headBlock.Number() + 1):
 		return false, errors.New("expired")
 	case o.BlockRef().Number() > headBlock.Number()+uint32(5*60/thor.BlockInterval):
 		// reject deferred tx which will be applied after 5mins
@@ -81,12 +81,10 @@ func (o *txObject) Executable(chain *chain.Chain, state *state.State, headBlock 
 		}
 	}
 
-	if o.BlockRef().Number() > headBlock.Number() {
+	// tx valid in the future
+	if o.BlockRef().Number() > headBlock.Number()+1 {
 		return false, nil
 	}
-
-	// checkpoint := state.NewCheckpoint()
-	// defer state.RevertTo(checkpoint)
 
 	if _, _, _, _, err := o.resolved.BuyGas(state, headBlock.Timestamp()+thor.BlockInterval); err != nil {
 		return false, err

--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -55,7 +55,7 @@ func (o *txObject) Executable(chain *chain.Chain, state *state.State, headBlock 
 	switch {
 	case o.Gas() > headBlock.GasLimit():
 		return false, errors.New("gas too large")
-	case o.IsExpired(headBlock.Number() + 1):
+	case o.IsExpired(headBlock.Number() + 1): // Check tx expiration on top of next block
 		return false, errors.New("expired")
 	case o.BlockRef().Number() > headBlock.Number()+uint32(5*60/thor.BlockInterval):
 		// reject deferred tx which will be applied after 5mins
@@ -81,7 +81,7 @@ func (o *txObject) Executable(chain *chain.Chain, state *state.State, headBlock 
 		}
 	}
 
-	// tx valid in the future
+	// Tx is considered executable when the BlockRef has passed in reference to the next block.
 	if o.BlockRef().Number() > headBlock.Number()+1 {
 		return false, nil
 	}


### PR DESCRIPTION
# Description

+ Allow TX valid on next block to propagate.(eg. head at 19, TX with ref 20)
+ Stops propagate TX that is expired on next block.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
