### PR TITLE
Adding Test for Subscription Blocks Backtrace

### DIFF
--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -57,7 +57,6 @@ func New(
 	bft bft.Committer,
 	allowedTracers []string,
 	soloMode bool) *Debug {
-
 	allowedMap := make(map[string]struct{})
 	for _, t := range allowedTracers {
 		allowedMap[t] = struct{}{}

--- a/api/subscriptions/subscriptions_test.go
+++ b/api/subscriptions/subscriptions_test.go
@@ -227,7 +227,7 @@ func initSubscriptionsServer(t *testing.T) {
 	ts = httptest.NewServer(router)
 }
 
-func TestSubscriptionsBacklog(t *testing.T) {
+func TestSubscriptionsBacktrace(t *testing.T) {
 	r, generatedBlocks, pool := initChainMultipleBlocks(t, 10)
 	repo = r
 	txPool = pool
@@ -238,9 +238,9 @@ func TestSubscriptionsBacklog(t *testing.T) {
 	ts = httptest.NewServer(router)
 	defer ts.Close()
 
-	t.Run("testHandleSubjectWithTransferBacklog", testHandleSubjectWithTransferBacklog)
+	t.Run("testHandleSubjectWithTransferBacktrace", testHandleSubjectWithTransferBacktrace)
 }
-func testHandleSubjectWithTransferBacklog(t *testing.T) {
+func testHandleSubjectWithTransferBacktrace(t *testing.T) {
 	genesisBlock := blocks[0]
 	queryArg := fmt.Sprintf("pos=%s", genesisBlock.Header().ID().String())
 	u := url.URL{Scheme: "ws", Host: strings.TrimPrefix(ts.URL, "http://"), Path: "/subscriptions/transfer", RawQuery: queryArg}

--- a/api/subscriptions/subscriptions_test.go
+++ b/api/subscriptions/subscriptions_test.go
@@ -238,9 +238,9 @@ func TestSubscriptionsBacktrace(t *testing.T) {
 	ts = httptest.NewServer(router)
 	defer ts.Close()
 
-	t.Run("testHandleSubjectWithTransferBacktrace", testHandleSubjectWithTransferBacktrace)
+	t.Run("testHandleSubjectWithTransferBacktraceLimit", testHandleSubjectWithTransferBacktraceLimit)
 }
-func testHandleSubjectWithTransferBacktrace(t *testing.T) {
+func testHandleSubjectWithTransferBacktraceLimit(t *testing.T) {
 	genesisBlock := blocks[0]
 	queryArg := fmt.Sprintf("pos=%s", genesisBlock.Header().ID().String())
 	u := url.URL{Scheme: "ws", Host: strings.TrimPrefix(ts.URL, "http://"), Path: "/subscriptions/transfer", RawQuery: queryArg}


### PR DESCRIPTION
# Description

This adds a test for the Subscriptions blocks Backtrace.
It allows moving the test from e2e into integrations.

Fixes # (issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
