### PR TITLE
adopt loop var scope in go 1.22

### DIFF
--- a/cmd/thor/sync_logdb.go
+++ b/cmd/thor/sync_logdb.go
@@ -373,14 +373,12 @@ func pumpBlockAndReceipts(ctx context.Context, repo *chain.Repository, headID th
 			select {
 			case <-co.Parallel(func(queue chan<- func()) {
 				for _, b := range buf {
-					h := b.Header()
 					queue <- func() {
-						h.ID()
+						b.Header().ID()
 					}
 					for _, tx := range b.Transactions() {
-						tmpTx := tx
 						queue <- func() {
-							tmpTx.ID()
+							tx.ID()
 						}
 					}
 				}

--- a/comm/comm_test.go
+++ b/comm/comm_test.go
@@ -4,3 +4,37 @@
 // file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
 
 package comm_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoopVar(t *testing.T) {
+	cases := []uint{1, 2, 3, 4}
+
+	ch := make(chan uint)
+
+	go func() {
+		for _, c := range cases {
+			go func() {
+				ch <- c
+			}()
+		}
+	}()
+
+	ret := make([]uint, 0, len(cases))
+	for i := 0; i < len(cases); i++ {
+		v := <-ch
+		ret = append(ret, v)
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i] < ret[j]
+	})
+	// before go1.22 the result is [4, 4, 4, 4]
+	// after go1.22 the result is [1, 2, 3, 4]
+
+	assert.Equal(t, cases, ret)
+}

--- a/comm/communicator.go
+++ b/comm/communicator.go
@@ -238,21 +238,19 @@ func (c *Communicator) BroadcastBlock(blk *block.Block) {
 	toAnnounce := peers[p:]
 
 	for _, peer := range toPropagate {
-		tmpPeer := peer
-		tmpPeer.MarkBlock(blk.Header().ID())
+		peer.MarkBlock(blk.Header().ID())
 		c.goes.Go(func() {
-			if err := proto.NotifyNewBlock(c.ctx, tmpPeer, blk); err != nil {
-				tmpPeer.logger.Debug("failed to broadcast new block", "err", err)
+			if err := proto.NotifyNewBlock(c.ctx, peer, blk); err != nil {
+				peer.logger.Debug("failed to broadcast new block", "err", err)
 			}
 		})
 	}
 
 	for _, peer := range toAnnounce {
-		tmpPeer := peer
-		tmpPeer.MarkBlock(blk.Header().ID())
+		peer.MarkBlock(blk.Header().ID())
 		c.goes.Go(func() {
-			if err := proto.NotifyNewBlockID(c.ctx, tmpPeer, blk.Header().ID()); err != nil {
-				tmpPeer.logger.Debug("failed to broadcast new block id", "err", err)
+			if err := proto.NotifyNewBlockID(c.ctx, peer, blk.Header().ID()); err != nil {
+				peer.logger.Debug("failed to broadcast new block id", "err", err)
 			}
 		})
 	}

--- a/comm/sync.go
+++ b/comm/sync.go
@@ -81,18 +81,16 @@ func warmupBlocks(ctx context.Context, fetched <-chan []*block.Block, warmedUp c
 	<-co.Parallel(func(queue chan<- func()) {
 		for blocks := range fetched {
 			for _, blk := range blocks {
-				h := blk.Header()
 				queue <- func() {
-					h.ID()
-					h.Beta()
+					blk.Header().ID()
+					blk.Header().Beta()
 				}
 				for _, tx := range blk.Transactions() {
-					tmpTx := tx
 					queue <- func() {
-						tmpTx.ID()
-						tmpTx.UnprovedWork()
-						_, _ = tmpTx.IntrinsicGas()
-						_, _ = tmpTx.Delegator()
+						tx.ID()
+						tx.UnprovedWork()
+						_, _ = tx.IntrinsicGas()
+						_, _ = tx.Delegator()
 					}
 				}
 			}

--- a/comm/txs_loop.go
+++ b/comm/txs_loop.go
@@ -27,11 +27,10 @@ func (c *Communicator) txsLoop() {
 				})
 
 				for _, peer := range peers {
-					tmpPeer := peer
-					tmpPeer.MarkTransaction(tx.Hash())
+					peer.MarkTransaction(tx.Hash())
 					c.goes.Go(func() {
-						if err := proto.NotifyNewTx(c.ctx, tmpPeer, tx); err != nil {
-							tmpPeer.logger.Debug("failed to broadcast tx", "err", err)
+						if err := proto.NotifyNewTx(c.ctx, peer, tx); err != nil {
+							peer.logger.Debug("failed to broadcast tx", "err", err)
 						}
 					})
 				}


### PR DESCRIPTION
# Description

This PR is an improvement on top of PR #837, leveraging https://go.dev/blog/loopvar-preview

# How Has This Been Tested?

- [x] Tests in comm_test.go should pass on go1.22
- [x] Change `go 1.21` in `go.mod`, comm_test.go will fail

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
