### PR TITLE
chore: remove aws codebuild

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -32,8 +32,7 @@ jobs:
           retention-days: 7
 
   run-tests:
-    # https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html#sample-github-action-runners-create-project
-    runs-on: codebuild-ThorGHA-${{ github.run_id }}-${{ github.run_attempt }}-ubuntu-7.0-large
+    runs-on: ubuntu-latest
     needs: build-docker-image
     env:
       THOR_IMAGE: vechain/thor:${{ github.sha }}


### PR DESCRIPTION
# Description

Remove AWS Codebuild for the e2e as it's not needed anymore and costs money

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
