### PR TITLE
Add TxLog and TxIndex into `logs/event` response body

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -1009,6 +1009,8 @@ components:
           enum:
             - asc
             - desc
+        optionalData:
+          $ref: '#/components/schemas/EventOptionalData'
 
     EventLogsResponse:
       type: array
@@ -1020,7 +1022,7 @@ components:
           - $ref: '#/components/schemas/Event'
           - properties:
               meta:
-                $ref: '#/components/schemas/LogMeta'
+                $ref: '#/components/schemas/EventLogMeta'
 
     TransferLogFilterRequest:
       type: object
@@ -1324,6 +1326,66 @@ components:
           description: The index of the clause in the transaction, from which the log was generated.
           example: 0
           nullable: false
+          
+    EventLogMeta:
+      title: EventLogMeta
+      type: object
+      description: The event or transfer log metadata such as block number, block timestamp, etc.
+      properties:
+        blockID:
+          type: string
+          format: hex
+          description: The block identifier in which the log was included.
+          example: '0x0004f6cc88bb4626a92907718e82f255b8fa511453a78e8797eb8cea3393b215'
+          nullable: false
+          pattern: '^0x[0-9a-f]{64}$'
+        blockNumber:
+          type: integer
+          format: uint32
+          description: The block number (height) of the block in which the log was included.
+          example: 325324
+          nullable: false
+        blockTimestamp:
+          type: integer
+          format: uint64
+          description: The UNIX timestamp of the block in which the log was included.
+          example: 1533267900
+          nullable: false
+        txID:
+          type: string
+          format: hex
+          description: The transaction identifier, from which the log was generated.
+          example: '0x284bba50ef777889ff1a367ed0b38d5e5626714477c40de38d71cedd6f9fa477'
+          nullable: false
+          pattern: '^0x[0-9a-f]{64}$'
+        txOrigin:
+          type: string
+          description: The account from which the transaction was sent.
+          example: '0xdb4027477b2a8fe4c83c6dafe7f86678bb1b8a8d'
+          nullable: false
+          pattern: '^0x[0-9a-f]{40}$'
+        clauseIndex:
+          type: integer
+          format: uint32
+          description: The index of the clause in the transaction, from which the log was generated.
+          example: 0
+          nullable: false
+        optionalData:
+          $ref: '#/components/schemas/LogOptionalData'
+          
+    LogOptionalData:
+      title: optionalData
+      type: object
+      nullable: true
+      properties:
+        txIndex:
+          type: integer
+          nullable: true
+          example: 1
+        logIndex:
+          type: integer
+          nullable: true
+          example: 1
 
     Block:
       title: Block
@@ -1915,6 +1977,26 @@ components:
         }
         ```
         This refers to the range from block 10 to block 1000.
+        
+    EventOptionalData:
+      nullable: true
+      type: object
+      title: EventOptionalData
+      properties:
+        txIndex:
+          type: boolean
+          example: true
+          nullable: true
+          description: |
+            Specifies whether to include in the response the event transaction index.
+        loglIndex:
+          type: boolean
+          example: true
+          nullable: true
+          description: |
+            Specifies whether to include in the response the event log index.
+      description: |
+        Specifies all the optional data that can be included in the response.
 
     EventCriteria:
       type: object

--- a/api/events/events.go
+++ b/api/events/events.go
@@ -44,7 +44,7 @@ func (e *Events) filter(ctx context.Context, ef *EventFilter) ([]*FilteredEvent,
 	}
 	fes := make([]*FilteredEvent, len(events))
 	for i, e := range events {
-		fes[i] = convertEvent(e)
+		fes[i] = convertEvent(e, ef.OptionalData)
 	}
 	return fes, nil
 }

--- a/api/events/events_test.go
+++ b/api/events/events_test.go
@@ -59,6 +59,79 @@ func TestEvents(t *testing.T) {
 	testEventWithBlocks(t, blocksToInsert)
 }
 
+func TestOptionalData(t *testing.T) {
+	db := createDb(t)
+	initEventServer(t, db, defaultLogLimit)
+	defer ts.Close()
+	insertBlocks(t, db, 5)
+
+	testCases := []struct {
+		name     string
+		optData  *events.EventOptionalData
+		expected *events.LogOptionalData
+	}{
+		{
+			name:     "empty optional data",
+			optData:  &events.EventOptionalData{},
+			expected: nil,
+		},
+		{
+			name: "optional data with txIndex",
+			optData: &events.EventOptionalData{
+				TxIndex: true,
+			},
+			expected: &events.LogOptionalData{
+				TxIndex: new(uint32),
+			},
+		},
+		{
+			name: "optional data with logIndex",
+			optData: &events.EventOptionalData{
+				LogIndex: true,
+			},
+			expected: &events.LogOptionalData{
+				LogIndex: new(uint32),
+			},
+		},
+		{
+			name: "optional data with txIndex and logIndex",
+			optData: &events.EventOptionalData{
+				TxIndex:  true,
+				LogIndex: true,
+			},
+			expected: &events.LogOptionalData{
+				TxIndex:  new(uint32),
+				LogIndex: new(uint32),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter := events.EventFilter{
+				CriteriaSet:  make([]*events.EventCriteria, 0),
+				Range:        nil,
+				Options:      &logdb.Options{Limit: 6},
+				Order:        logdb.DESC,
+				OptionalData: tc.optData,
+			}
+
+			res, statusCode := httpPost(t, ts.URL+"/events", filter)
+			assert.Equal(t, http.StatusOK, statusCode)
+			var tLogs []*events.FilteredEvent
+			if err := json.Unmarshal(res, &tLogs); err != nil {
+				t.Fatal(err)
+			}
+			assert.Equal(t, http.StatusOK, statusCode)
+			assert.Equal(t, 5, len(tLogs))
+
+			for _, tLog := range tLogs {
+				assert.Equal(t, tc.expected, tLog.Meta.OptionalData)
+			}
+		})
+	}
+}
+
 func TestOption(t *testing.T) {
 	db := createDb(t)
 	initEventServer(t, db, 5)

--- a/api/events/types.go
+++ b/api/events/types.go
@@ -21,6 +21,7 @@ type LogMeta struct {
 	BlockNumber    uint32       `json:"blockNumber"`
 	BlockTimestamp uint64       `json:"blockTimestamp"`
 	TxID           thor.Bytes32 `json:"txID"`
+	TxIndex        uint32       `json:"txIndex"`
 	TxOrigin       thor.Address `json:"txOrigin"`
 	ClauseIndex    uint32       `json:"clauseIndex"`
 }
@@ -51,6 +52,7 @@ func convertEvent(event *logdb.Event) *FilteredEvent {
 			BlockNumber:    event.BlockNumber,
 			BlockTimestamp: event.BlockTime,
 			TxID:           event.TxID,
+			TxIndex:        event.TxIndex,
 			TxOrigin:       event.TxOrigin,
 			ClauseIndex:    event.ClauseIndex,
 		},
@@ -74,6 +76,7 @@ func (e *FilteredEvent) String() string {
 				blockNumber    %v,
 				blockTimestamp %v),
 				txID     %v,
+				txIndex  %v,
 				txOrigin %v,
 				clauseIndex %v)
 			)`,
@@ -84,6 +87,7 @@ func (e *FilteredEvent) String() string {
 		e.Meta.BlockNumber,
 		e.Meta.BlockTimestamp,
 		e.Meta.TxID,
+		e.Meta.TxIndex,
 		e.Meta.TxOrigin,
 		e.Meta.ClauseIndex,
 	)

--- a/api/events/types.go
+++ b/api/events/types.go
@@ -22,6 +22,7 @@ type LogMeta struct {
 	BlockTimestamp uint64       `json:"blockTimestamp"`
 	TxID           thor.Bytes32 `json:"txID"`
 	TxIndex        uint32       `json:"txIndex"`
+	LogIndex       uint32       `json:"logIndex"`
 	TxOrigin       thor.Address `json:"txOrigin"`
 	ClauseIndex    uint32       `json:"clauseIndex"`
 }
@@ -53,6 +54,7 @@ func convertEvent(event *logdb.Event) *FilteredEvent {
 			BlockTimestamp: event.BlockTime,
 			TxID:           event.TxID,
 			TxIndex:        event.TxIndex,
+			LogIndex:       event.Index,
 			TxOrigin:       event.TxOrigin,
 			ClauseIndex:    event.ClauseIndex,
 		},
@@ -77,6 +79,7 @@ func (e *FilteredEvent) String() string {
 				blockTimestamp %v),
 				txID     %v,
 				txIndex  %v,
+				logIndex %v,
 				txOrigin %v,
 				clauseIndex %v)
 			)`,
@@ -88,6 +91,7 @@ func (e *FilteredEvent) String() string {
 		e.Meta.BlockTimestamp,
 		e.Meta.TxID,
 		e.Meta.TxIndex,
+		e.Meta.LogIndex,
 		e.Meta.TxOrigin,
 		e.Meta.ClauseIndex,
 	)

--- a/api/events/types_test.go
+++ b/api/events/types_test.go
@@ -3,19 +3,20 @@
 // Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
 // file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
 
-package events_test
+package events
 
 import (
 	"math"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/vechain/thor/v2/api/events"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/genesis"
 	"github.com/vechain/thor/v2/logdb"
 	"github.com/vechain/thor/v2/muxdb"
 	"github.com/vechain/thor/v2/state"
+	"github.com/vechain/thor/v2/thor"
 )
 
 func TestEventsTypes(t *testing.T) {
@@ -33,13 +34,13 @@ func TestEventsTypes(t *testing.T) {
 }
 
 func testConvertRangeWithBlockRangeType(t *testing.T, chain *chain.Chain) {
-	rng := &events.Range{
-		Unit: events.BlockRangeType,
+	rng := &Range{
+		Unit: BlockRangeType,
 		From: 1,
 		To:   2,
 	}
 
-	convertedRng, err := events.ConvertRange(chain, rng)
+	convertedRng, err := ConvertRange(chain, rng)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(rng.From), convertedRng.From)
@@ -47,8 +48,8 @@ func testConvertRangeWithBlockRangeType(t *testing.T, chain *chain.Chain) {
 }
 
 func testConvertRangeWithTimeRangeTypeLessThenGenesis(t *testing.T, chain *chain.Chain) {
-	rng := &events.Range{
-		Unit: events.TimeRangeType,
+	rng := &Range{
+		Unit: TimeRangeType,
 		From: 1,
 		To:   2,
 	}
@@ -57,7 +58,7 @@ func testConvertRangeWithTimeRangeTypeLessThenGenesis(t *testing.T, chain *chain
 		To:   math.MaxUint32,
 	}
 
-	convRng, err := events.ConvertRange(chain, rng)
+	convRng, err := ConvertRange(chain, rng)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEmptyRange, convRng)
@@ -68,8 +69,8 @@ func testConvertRangeWithTimeRangeType(t *testing.T, chain *chain.Chain) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rng := &events.Range{
-		Unit: events.TimeRangeType,
+	rng := &Range{
+		Unit: TimeRangeType,
 		From: 1,
 		To:   genesis.Timestamp(),
 	}
@@ -78,7 +79,7 @@ func testConvertRangeWithTimeRangeType(t *testing.T, chain *chain.Chain) {
 		To:   0,
 	}
 
-	convRng, err := events.ConvertRange(chain, rng)
+	convRng, err := ConvertRange(chain, rng)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedZeroRange, convRng)
@@ -89,8 +90,8 @@ func testConvertRangeWithFromGreaterThanGenesis(t *testing.T, chain *chain.Chain
 	if err != nil {
 		t.Fatal(err)
 	}
-	rng := &events.Range{
-		Unit: events.TimeRangeType,
+	rng := &Range{
+		Unit: TimeRangeType,
 		From: genesis.Timestamp() + 1_000,
 		To:   genesis.Timestamp() + 10_000,
 	}
@@ -99,7 +100,7 @@ func testConvertRangeWithFromGreaterThanGenesis(t *testing.T, chain *chain.Chain
 		To:   math.MaxUint32,
 	}
 
-	convRng, err := events.ConvertRange(chain, rng)
+	convRng, err := ConvertRange(chain, rng)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEmptyRange, convRng)
@@ -122,4 +123,46 @@ func initChain(t *testing.T) *chain.Chain {
 	}
 
 	return repo.NewBestChain()
+}
+
+func TestConvertEvent(t *testing.T) {
+	event := &logdb.Event{
+		Address:     thor.Address{0x01},
+		Data:        []byte{0x02, 0x03},
+		BlockID:     thor.Bytes32{0x04},
+		BlockNumber: 5,
+		BlockTime:   6,
+		TxID:        thor.Bytes32{0x07},
+		TxIndex:     8,
+		Index:       9,
+		TxOrigin:    thor.Address{0x0A},
+		ClauseIndex: 10,
+		Topics: [5]*thor.Bytes32{
+			{0x0B},
+			{0x0C},
+			nil,
+			nil,
+			nil,
+		},
+	}
+
+	expectedTopics := []*thor.Bytes32{
+		{0x0B},
+		{0x0C},
+	}
+	expectedData := hexutil.Encode(event.Data)
+
+	result := convertEvent(event)
+
+	assert.Equal(t, event.Address, result.Address)
+	assert.Equal(t, expectedData, result.Data)
+	assert.Equal(t, event.BlockID, result.Meta.BlockID)
+	assert.Equal(t, event.BlockNumber, result.Meta.BlockNumber)
+	assert.Equal(t, event.BlockTime, result.Meta.BlockTimestamp)
+	assert.Equal(t, event.TxID, result.Meta.TxID)
+	assert.Equal(t, event.TxIndex, result.Meta.TxIndex)
+	assert.Equal(t, event.Index, result.Meta.LogIndex)
+	assert.Equal(t, event.TxOrigin, result.Meta.TxOrigin)
+	assert.Equal(t, event.ClauseIndex, result.Meta.ClauseIndex)
+	assert.Equal(t, expectedTopics, result.Topics)
 }

--- a/api/events/types_test.go
+++ b/api/events/types_test.go
@@ -145,6 +145,10 @@ func TestConvertEvent(t *testing.T) {
 			nil,
 		},
 	}
+	eventOptData := &EventOptionalData{
+		LogIndex: true,
+		TxIndex:  true,
+	}
 
 	expectedTopics := []*thor.Bytes32{
 		{0x0B},
@@ -152,7 +156,7 @@ func TestConvertEvent(t *testing.T) {
 	}
 	expectedData := hexutil.Encode(event.Data)
 
-	result := convertEvent(event)
+	result := convertEvent(event, eventOptData)
 
 	assert.Equal(t, event.Address, result.Address)
 	assert.Equal(t, expectedData, result.Data)
@@ -160,9 +164,40 @@ func TestConvertEvent(t *testing.T) {
 	assert.Equal(t, event.BlockNumber, result.Meta.BlockNumber)
 	assert.Equal(t, event.BlockTime, result.Meta.BlockTimestamp)
 	assert.Equal(t, event.TxID, result.Meta.TxID)
-	assert.Equal(t, event.TxIndex, result.Meta.TxIndex)
-	assert.Equal(t, event.Index, result.Meta.LogIndex)
+	assert.Equal(t, event.TxIndex, *result.Meta.OptionalData.TxIndex)
+	assert.Equal(t, event.Index, *result.Meta.OptionalData.LogIndex)
 	assert.Equal(t, event.TxOrigin, result.Meta.TxOrigin)
 	assert.Equal(t, event.ClauseIndex, result.Meta.ClauseIndex)
 	assert.Equal(t, expectedTopics, result.Topics)
+}
+
+func TestIsEmpty(t *testing.T) {
+	// Empty cases
+	var nilCase *LogOptionalData
+	assert.True(t, nilCase.Empty())
+
+	emptyCase := &LogOptionalData{}
+	assert.True(t, emptyCase.Empty())
+
+	emptyCase = &LogOptionalData{
+		LogIndex: nil,
+	}
+	assert.True(t, emptyCase.Empty())
+
+	emptyCase = &LogOptionalData{
+		TxIndex: nil,
+	}
+	assert.True(t, emptyCase.Empty())
+
+	// Not empty cases
+	val := uint32(1)
+	notEmptyCase := &LogOptionalData{
+		LogIndex: &val,
+	}
+	assert.False(t, notEmptyCase.Empty())
+
+	notEmptyCase = &LogOptionalData{
+		TxIndex: &val,
+	}
+	assert.False(t, notEmptyCase.Empty())
 }

--- a/logdb/logdb_test.go
+++ b/logdb/logdb_test.go
@@ -147,6 +147,7 @@ func TestEvents(t *testing.T) {
 			allEvents = append(allEvents, &logdb.Event{
 				BlockNumber: b.Header().Number(),
 				Index:       uint32(j),
+				TxIndex:     uint32(j),
 				BlockID:     b.Header().ID(),
 				BlockTime:   b.Header().Timestamp(),
 				TxID:        tx.ID(),

--- a/logdb/schema.go
+++ b/logdb/schema.go
@@ -14,6 +14,7 @@ const (
 	// creates events table
 	eventTableSchema = `CREATE TABLE IF NOT EXISTS event (
 	seq INTEGER PRIMARY KEY NOT NULL,
+	txIndex INTEGER NOT NULL,
 	blockID	INTEGER NOT NULL,
 	blockTime INTEGER NOT NULL,
 	txID INTEGER NOT NULL,

--- a/logdb/types.go
+++ b/logdb/types.go
@@ -19,6 +19,7 @@ type Event struct {
 	BlockID     thor.Bytes32
 	BlockTime   uint64
 	TxID        thor.Bytes32
+	TxIndex     uint32
 	TxOrigin    thor.Address //contract caller
 	ClauseIndex uint32
 	Address     thor.Address // always a contract address


### PR DESCRIPTION
# Description

This PR adds `txLog` and `txIndex` fields into `logs/event` response body.

[GH Issue](https://github.com/vechain/protocol-board-repo/issues/288)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Manual test
- [x] Unit test
- [x] E2E test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
