### PR TITLE
Add LogIndex into logs/event response body

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -1009,6 +1009,8 @@ components:
           enum:
             - asc
             - desc
+        optionalData:
+          $ref: '#/components/schemas/EventOptionalData'
 
     EventLogsResponse:
       type: array
@@ -1020,7 +1022,7 @@ components:
           - $ref: '#/components/schemas/Event'
           - properties:
               meta:
-                $ref: '#/components/schemas/LogMeta'
+                $ref: '#/components/schemas/EventLogMeta'
 
     TransferLogFilterRequest:
       type: object
@@ -1186,7 +1188,7 @@ components:
         - $ref: '#/components/schemas/ClauseTracerOption'
       example:
         target: '0x010709463c1f0c9aa66a31182fb36d1977d99bfb6526bae0564a0eac4006c31a/0/0'
-        name: "call"
+        name: "prestate"
         config: { }
 
     PostDebugTracerCallRequest:
@@ -1207,7 +1209,6 @@ components:
         gasPayer: "0xd3ae78222beadb038203be21ed5ce7c9b1bff602"
         expiration: 1000
         blockRef: "0x00000000851caf3c"
-        name: "call"
 
     TxMeta:
       title: TxMeta
@@ -1325,6 +1326,62 @@ components:
           description: The index of the clause in the transaction, from which the log was generated.
           example: 0
           nullable: false
+          
+    EventLogMeta:
+      title: EventLogMeta
+      type: object
+      description: The event or transfer log metadata such as block number, block timestamp, etc.
+      properties:
+        blockID:
+          type: string
+          format: hex
+          description: The block identifier in which the log was included.
+          example: '0x0004f6cc88bb4626a92907718e82f255b8fa511453a78e8797eb8cea3393b215'
+          nullable: false
+          pattern: '^0x[0-9a-f]{64}$'
+        blockNumber:
+          type: integer
+          format: uint32
+          description: The block number (height) of the block in which the log was included.
+          example: 325324
+          nullable: false
+        blockTimestamp:
+          type: integer
+          format: uint64
+          description: The UNIX timestamp of the block in which the log was included.
+          example: 1533267900
+          nullable: false
+        txID:
+          type: string
+          format: hex
+          description: The transaction identifier, from which the log was generated.
+          example: '0x284bba50ef777889ff1a367ed0b38d5e5626714477c40de38d71cedd6f9fa477'
+          nullable: false
+          pattern: '^0x[0-9a-f]{64}$'
+        txOrigin:
+          type: string
+          description: The account from which the transaction was sent.
+          example: '0xdb4027477b2a8fe4c83c6dafe7f86678bb1b8a8d'
+          nullable: false
+          pattern: '^0x[0-9a-f]{40}$'
+        clauseIndex:
+          type: integer
+          format: uint32
+          description: The index of the clause in the transaction, from which the log was generated.
+          example: 0
+          nullable: false
+        extendedLogMeta:
+          $ref: '#/components/schemas/ExtendedLogMeta'
+          
+    ExtendedLogMeta:
+      title: extendedLogMeta
+      type: object
+      nullable: true
+      properties:
+        logIndex:
+          type: integer
+          nullable: true
+          example: 1
 
     Block:
       title: Block
@@ -1916,6 +1973,20 @@ components:
         }
         ```
         This refers to the range from block 10 to block 1000.
+        
+    EventOptionalData:
+      nullable: true
+      type: object
+      title: EventOptionalData
+      properties:
+        loglIndex:
+          type: boolean
+          example: true
+          nullable: true
+          description: |
+            Specifies whether to include in the response the event log index.
+      description: |
+        Specifies all the optional data that can be included in the response.
 
     EventCriteria:
       type: object

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -1188,7 +1188,7 @@ components:
         - $ref: '#/components/schemas/ClauseTracerOption'
       example:
         target: '0x010709463c1f0c9aa66a31182fb36d1977d99bfb6526bae0564a0eac4006c31a/0/0'
-        name: "prestate"
+        name: "call"
         config: { }
 
     PostDebugTracerCallRequest:
@@ -1209,6 +1209,7 @@ components:
         gasPayer: "0xd3ae78222beadb038203be21ed5ce7c9b1bff602"
         expiration: 1000
         blockRef: "0x00000000851caf3c"
+        name: "call"
 
     TxMeta:
       title: TxMeta

--- a/api/events/events.go
+++ b/api/events/events.go
@@ -44,7 +44,7 @@ func (e *Events) filter(ctx context.Context, ef *EventFilter) ([]*FilteredEvent,
 	}
 	fes := make([]*FilteredEvent, len(events))
 	for i, e := range events {
-		fes[i] = convertEvent(e)
+		fes[i] = convertEvent(e, ef.OptionalData)
 	}
 	return fes, nil
 }

--- a/api/events/events_test.go
+++ b/api/events/events_test.go
@@ -76,6 +76,13 @@ func TestOptionalData(t *testing.T) {
 			expected: nil,
 		},
 		{
+			name: "optional data with logIndex as false",
+			optData: &events.EventOptionalData{
+				LogIndex: false,
+			},
+			expected: nil,
+		},
+		{
 			name: "optional data with logIndex",
 			optData: &events.EventOptionalData{
 				LogIndex: true,

--- a/api/events/types_test.go
+++ b/api/events/types_test.go
@@ -187,5 +187,4 @@ func TestIsEmpty(t *testing.T) {
 		LogIndex: &val,
 	}
 	assert.False(t, notEmptyCase.Empty())
-
 }

--- a/api/events/types_test.go
+++ b/api/events/types_test.go
@@ -3,19 +3,20 @@
 // Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
 // file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
 
-package events_test
+package events
 
 import (
 	"math"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/vechain/thor/v2/api/events"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/genesis"
 	"github.com/vechain/thor/v2/logdb"
 	"github.com/vechain/thor/v2/muxdb"
 	"github.com/vechain/thor/v2/state"
+	"github.com/vechain/thor/v2/thor"
 )
 
 func TestEventsTypes(t *testing.T) {
@@ -33,13 +34,13 @@ func TestEventsTypes(t *testing.T) {
 }
 
 func testConvertRangeWithBlockRangeType(t *testing.T, chain *chain.Chain) {
-	rng := &events.Range{
-		Unit: events.BlockRangeType,
+	rng := &Range{
+		Unit: BlockRangeType,
 		From: 1,
 		To:   2,
 	}
 
-	convertedRng, err := events.ConvertRange(chain, rng)
+	convertedRng, err := ConvertRange(chain, rng)
 
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(rng.From), convertedRng.From)
@@ -47,8 +48,8 @@ func testConvertRangeWithBlockRangeType(t *testing.T, chain *chain.Chain) {
 }
 
 func testConvertRangeWithTimeRangeTypeLessThenGenesis(t *testing.T, chain *chain.Chain) {
-	rng := &events.Range{
-		Unit: events.TimeRangeType,
+	rng := &Range{
+		Unit: TimeRangeType,
 		From: 1,
 		To:   2,
 	}
@@ -57,7 +58,7 @@ func testConvertRangeWithTimeRangeTypeLessThenGenesis(t *testing.T, chain *chain
 		To:   math.MaxUint32,
 	}
 
-	convRng, err := events.ConvertRange(chain, rng)
+	convRng, err := ConvertRange(chain, rng)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEmptyRange, convRng)
@@ -68,8 +69,8 @@ func testConvertRangeWithTimeRangeType(t *testing.T, chain *chain.Chain) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rng := &events.Range{
-		Unit: events.TimeRangeType,
+	rng := &Range{
+		Unit: TimeRangeType,
 		From: 1,
 		To:   genesis.Timestamp(),
 	}
@@ -78,7 +79,7 @@ func testConvertRangeWithTimeRangeType(t *testing.T, chain *chain.Chain) {
 		To:   0,
 	}
 
-	convRng, err := events.ConvertRange(chain, rng)
+	convRng, err := ConvertRange(chain, rng)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedZeroRange, convRng)
@@ -89,8 +90,8 @@ func testConvertRangeWithFromGreaterThanGenesis(t *testing.T, chain *chain.Chain
 	if err != nil {
 		t.Fatal(err)
 	}
-	rng := &events.Range{
-		Unit: events.TimeRangeType,
+	rng := &Range{
+		Unit: TimeRangeType,
 		From: genesis.Timestamp() + 1_000,
 		To:   genesis.Timestamp() + 10_000,
 	}
@@ -99,7 +100,7 @@ func testConvertRangeWithFromGreaterThanGenesis(t *testing.T, chain *chain.Chain
 		To:   math.MaxUint32,
 	}
 
-	convRng, err := events.ConvertRange(chain, rng)
+	convRng, err := ConvertRange(chain, rng)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEmptyRange, convRng)
@@ -122,4 +123,69 @@ func initChain(t *testing.T) *chain.Chain {
 	}
 
 	return repo.NewBestChain()
+}
+
+func TestConvertEvent(t *testing.T) {
+	event := &logdb.Event{
+		Address:     thor.Address{0x01},
+		Data:        []byte{0x02, 0x03},
+		BlockID:     thor.Bytes32{0x04},
+		BlockNumber: 5,
+		BlockTime:   6,
+		TxID:        thor.Bytes32{0x07},
+		Index:       9,
+		TxOrigin:    thor.Address{0x0A},
+		ClauseIndex: 10,
+		Topics: [5]*thor.Bytes32{
+			{0x0B},
+			{0x0C},
+			nil,
+			nil,
+			nil,
+		},
+	}
+	eventOptData := &EventOptionalData{
+		LogIndex: true,
+	}
+
+	expectedTopics := []*thor.Bytes32{
+		{0x0B},
+		{0x0C},
+	}
+	expectedData := hexutil.Encode(event.Data)
+
+	result := convertEvent(event, eventOptData)
+
+	assert.Equal(t, event.Address, result.Address)
+	assert.Equal(t, expectedData, result.Data)
+	assert.Equal(t, event.BlockID, result.Meta.BlockID)
+	assert.Equal(t, event.BlockNumber, result.Meta.BlockNumber)
+	assert.Equal(t, event.BlockTime, result.Meta.BlockTimestamp)
+	assert.Equal(t, event.TxID, result.Meta.TxID)
+	assert.Equal(t, event.Index, *result.Meta.ExtendedLogMeta.LogIndex)
+	assert.Equal(t, event.TxOrigin, result.Meta.TxOrigin)
+	assert.Equal(t, event.ClauseIndex, result.Meta.ClauseIndex)
+	assert.Equal(t, expectedTopics, result.Topics)
+}
+
+func TestIsEmpty(t *testing.T) {
+	// Empty cases
+	var nilCase *ExtendedLogMeta
+	assert.True(t, nilCase.Empty())
+
+	emptyCase := &ExtendedLogMeta{}
+	assert.True(t, emptyCase.Empty())
+
+	emptyCase = &ExtendedLogMeta{
+		LogIndex: nil,
+	}
+	assert.True(t, emptyCase.Empty())
+
+	// Not empty cases
+	val := uint32(1)
+	notEmptyCase := &ExtendedLogMeta{
+		LogIndex: &val,
+	}
+	assert.False(t, notEmptyCase.Empty())
+
 }


### PR DESCRIPTION
# Description

This PR adds `logIndex` fields into `logs/event` response body.

[GH Issue](https://github.com/vechain/protocol-board-repo/issues/326)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

- [x] Manual test
- [x] Unit test
- [x] E2E test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
