### PR TITLE
Darren/feat/add subscription cache

### DIFF
--- a/api/subscriptions/beat2_reader.go
+++ b/api/subscriptions/beat2_reader.go
@@ -7,6 +7,7 @@ package subscriptions
 
 import (
 	"bytes"
+	"encoding/json"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/vechain/thor/v2/chain"
@@ -17,22 +18,35 @@ import (
 type beat2Reader struct {
 	repo        *chain.Repository
 	blockReader chain.BlockReader
+	cache       *messageCache
 }
 
-func newBeat2Reader(repo *chain.Repository, position thor.Bytes32) *beat2Reader {
+func newBeat2Reader(repo *chain.Repository, position thor.Bytes32, cache *messageCache) *beat2Reader {
 	return &beat2Reader{
 		repo:        repo,
 		blockReader: repo.NewBlockReader(position),
+		cache:       cache,
 	}
 }
 
-func (br *beat2Reader) Read() ([]interface{}, bool, error) {
+func (br *beat2Reader) Read() ([][]byte, bool, error) {
 	blocks, err := br.blockReader.Read()
 	if err != nil {
 		return nil, false, err
 	}
-	var msgs []interface{}
+	var msgs [][]byte
 
+	for _, block := range blocks {
+		msg, err := br.cache.GetOrAdd(block, br.repo)
+		if err != nil {
+			return nil, false, err
+		}
+		msgs = append(msgs, msg)
+	}
+	return msgs, len(blocks) > 0, nil
+}
+
+func generateBeat2Bytes(block *chain.ExtendedBlock, repo *chain.Repository) ([]byte, error) {
 	bloomGenerator := &bloom.Generator{}
 
 	bloomAdd := func(key []byte) {
@@ -43,48 +57,47 @@ func (br *beat2Reader) Read() ([]interface{}, bool, error) {
 		}
 	}
 
-	for _, block := range blocks {
-		header := block.Header()
-		receipts, err := br.repo.GetBlockReceipts(header.ID())
-		if err != nil {
-			return nil, false, err
-		}
-		txs := block.Transactions()
-		for i, receipt := range receipts {
-			bloomAdd(receipt.GasPayer.Bytes())
-			for _, output := range receipt.Outputs {
-				for _, event := range output.Events {
-					bloomAdd(event.Address.Bytes())
-					for _, topic := range event.Topics {
-						bloomAdd(topic.Bytes())
-					}
-				}
-				for _, transfer := range output.Transfers {
-					bloomAdd(transfer.Sender.Bytes())
-					bloomAdd(transfer.Recipient.Bytes())
+	header := block.Header()
+	receipts, err := repo.GetBlockReceipts(header.ID())
+	if err != nil {
+		return nil, err
+	}
+	txs := block.Transactions()
+	for i, receipt := range receipts {
+		bloomAdd(receipt.GasPayer.Bytes())
+		for _, output := range receipt.Outputs {
+			for _, event := range output.Events {
+				bloomAdd(event.Address.Bytes())
+				for _, topic := range event.Topics {
+					bloomAdd(topic.Bytes())
 				}
 			}
-			origin, _ := txs[i].Origin()
-			bloomAdd(origin.Bytes())
+			for _, transfer := range output.Transfers {
+				bloomAdd(transfer.Sender.Bytes())
+				bloomAdd(transfer.Recipient.Bytes())
+			}
 		}
-		signer, _ := header.Signer()
-		bloomAdd(signer.Bytes())
-		bloomAdd(header.Beneficiary().Bytes())
-
-		const bitsPerKey = 20
-		filter := bloomGenerator.Generate(bitsPerKey, bloom.K(bitsPerKey))
-
-		msgs = append(msgs, &Beat2Message{
-			Number:      header.Number(),
-			ID:          header.ID(),
-			ParentID:    header.ParentID(),
-			Timestamp:   header.Timestamp(),
-			TxsFeatures: uint32(header.TxsFeatures()),
-			GasLimit:    header.GasLimit(),
-			Bloom:       hexutil.Encode(filter.Bits),
-			K:           filter.K,
-			Obsolete:    block.Obsolete,
-		})
+		origin, _ := txs[i].Origin()
+		bloomAdd(origin.Bytes())
 	}
-	return msgs, len(blocks) > 0, nil
+	signer, _ := header.Signer()
+	bloomAdd(signer.Bytes())
+	bloomAdd(header.Beneficiary().Bytes())
+
+	const bitsPerKey = 20
+	filter := bloomGenerator.Generate(bitsPerKey, bloom.K(bitsPerKey))
+
+	beat2 := &Beat2Message{
+		Number:      header.Number(),
+		ID:          header.ID(),
+		ParentID:    header.ParentID(),
+		Timestamp:   header.Timestamp(),
+		TxsFeatures: uint32(header.TxsFeatures()),
+		GasLimit:    header.GasLimit(),
+		Bloom:       hexutil.Encode(filter.Bits),
+		K:           filter.K,
+		Obsolete:    block.Obsolete,
+	}
+
+	return json.Marshal(beat2)
 }

--- a/api/subscriptions/beat2_reader.go
+++ b/api/subscriptions/beat2_reader.go
@@ -46,7 +46,7 @@ func (br *beat2Reader) Read() ([][]byte, bool, error) {
 	return msgs, len(blocks) > 0, nil
 }
 
-func generateBeat2Bytes(block *chain.ExtendedBlock, repo *chain.Repository) ([]byte, error) {
+func generateBeat2Message(block *chain.ExtendedBlock, repo *chain.Repository) ([]byte, error) {
 	bloomGenerator := &bloom.Generator{}
 
 	bloomAdd := func(key []byte) {

--- a/api/subscriptions/beat2_reader.go
+++ b/api/subscriptions/beat2_reader.go
@@ -37,7 +37,7 @@ func (br *beat2Reader) Read() ([][]byte, bool, error) {
 	var msgs [][]byte
 
 	for _, block := range blocks {
-		msg, err := br.cache.GetOrAdd(block, br.repo)
+		msg, _, err := br.cache.GetOrAdd(block, br.repo)
 		if err != nil {
 			return nil, false, err
 		}

--- a/api/subscriptions/beat2_reader_test.go
+++ b/api/subscriptions/beat2_reader_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func beat2Cache() *messageCache {
-	cache, _ := newMessageCache(generateBeat2Bytes, 10)
+	cache, _ := newMessageCache(generateBeat2Message, 10)
 	return cache
 }
 

--- a/api/subscriptions/beat2_reader_test.go
+++ b/api/subscriptions/beat2_reader_test.go
@@ -6,11 +6,17 @@
 package subscriptions
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vechain/thor/v2/thor"
 )
+
+func beat2Cache() *messageCache {
+	cache, _ := newMessageCache(generateBeat2Bytes, 10)
+	return cache
+}
 
 func TestBeat2Reader_Read(t *testing.T) {
 	// Arrange
@@ -19,21 +25,23 @@ func TestBeat2Reader_Read(t *testing.T) {
 	newBlock := generatedBlocks[1]
 
 	// Act
-	beatReader := newBeat2Reader(repo, genesisBlk.Header().ID())
+	beatReader := newBeat2Reader(repo, genesisBlk.Header().ID(), beat2Cache())
 	res, ok, err := beatReader.Read()
 
 	// Assert
 	assert.NoError(t, err)
 	assert.True(t, ok)
-	if beatMsg, ok := res[0].(*Beat2Message); !ok {
-		t.Fatal("unexpected type")
-	} else {
-		assert.Equal(t, newBlock.Header().Number(), beatMsg.Number)
-		assert.Equal(t, newBlock.Header().ID(), beatMsg.ID)
-		assert.Equal(t, newBlock.Header().ParentID(), beatMsg.ParentID)
-		assert.Equal(t, newBlock.Header().Timestamp(), beatMsg.Timestamp)
-		assert.Equal(t, uint32(newBlock.Header().TxsFeatures()), beatMsg.TxsFeatures)
-	}
+	beat := &Beat2Message{}
+	err = json.Unmarshal(res[0], beat)
+	assert.NoError(t, err)
+
+	assert.Equal(t, newBlock.Header().Number(), beat.Number)
+	assert.Equal(t, newBlock.Header().ID(), beat.ID)
+	assert.Equal(t, newBlock.Header().ParentID(), beat.ParentID)
+	assert.Equal(t, newBlock.Header().Timestamp(), beat.Timestamp)
+	assert.Equal(t, uint32(newBlock.Header().TxsFeatures()), beat.TxsFeatures)
+	// GasLimit is not part of the deprecated BeatMessage
+	assert.Equal(t, newBlock.Header().GasLimit(), beat.GasLimit)
 }
 
 func TestBeat2Reader_Read_NoNewBlocksToRead(t *testing.T) {
@@ -42,7 +50,7 @@ func TestBeat2Reader_Read_NoNewBlocksToRead(t *testing.T) {
 	newBlock := generatedBlocks[1]
 
 	// Act
-	beatReader := newBeat2Reader(repo, newBlock.Header().ID())
+	beatReader := newBeat2Reader(repo, newBlock.Header().ID(), beat2Cache())
 	res, ok, err := beatReader.Read()
 
 	// Assert
@@ -56,7 +64,7 @@ func TestBeat2Reader_Read_ErrorWhenReadingBlocks(t *testing.T) {
 	repo, _, _ := initChain(t)
 
 	// Act
-	beatReader := newBeat2Reader(repo, thor.MustParseBytes32("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))
+	beatReader := newBeat2Reader(repo, thor.MustParseBytes32("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), beat2Cache())
 	res, ok, err := beatReader.Read()
 
 	// Assert

--- a/api/subscriptions/beat_reader.go
+++ b/api/subscriptions/beat_reader.go
@@ -36,7 +36,7 @@ func (br *beatReader) Read() ([][]byte, bool, error) {
 	}
 	var msgs [][]byte
 	for _, block := range blocks {
-		msg, err := br.cache.GetOrAdd(block, br.repo)
+		msg, _, err := br.cache.GetOrAdd(block, br.repo)
 		if err != nil {
 			return nil, false, err
 		}

--- a/api/subscriptions/beat_reader.go
+++ b/api/subscriptions/beat_reader.go
@@ -57,7 +57,7 @@ func (bc *bloomContent) len() int {
 	return len(bc.items)
 }
 
-func generateBeatBytes(block *chain.ExtendedBlock, repo *chain.Repository) ([]byte, error) {
+func generateBeatMessage(block *chain.ExtendedBlock, repo *chain.Repository) ([]byte, error) {
 	header := block.Header()
 	receipts, err := repo.GetBlockReceipts(header.ID())
 	if err != nil {

--- a/api/subscriptions/beat_reader_test.go
+++ b/api/subscriptions/beat_reader_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func beatCache() *messageCache {
-	cache, _ := newMessageCache(generateBeatBytes, 10)
+	cache, _ := newMessageCache(generateBeatMessage, 10)
 	return cache
 }
 

--- a/api/subscriptions/block_reader.go
+++ b/api/subscriptions/block_reader.go
@@ -33,7 +33,7 @@ func (br *blockReader) Read() ([][]byte, bool, error) {
 	}
 	var msgs [][]byte
 	for _, block := range blocks {
-		msg, err := br.cache.GetOrAdd(block, br.repo)
+		msg, _, err := br.cache.GetOrAdd(block, br.repo)
 		if err != nil {
 			return nil, false, err
 		}

--- a/api/subscriptions/block_reader.go
+++ b/api/subscriptions/block_reader.go
@@ -42,7 +42,7 @@ func (br *blockReader) Read() ([][]byte, bool, error) {
 	return msgs, len(blocks) > 0, nil
 }
 
-func generateBlockBytes(block *chain.ExtendedBlock, _ *chain.Repository) ([]byte, error) {
+func generateBlockMessage(block *chain.ExtendedBlock, _ *chain.Repository) ([]byte, error) {
 	blk, err := convertBlock(block)
 	if err != nil {
 		return nil, err

--- a/api/subscriptions/block_reader.go
+++ b/api/subscriptions/block_reader.go
@@ -6,6 +6,8 @@
 package subscriptions
 
 import (
+	"encoding/json"
+
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/thor"
 )
@@ -13,27 +15,37 @@ import (
 type blockReader struct {
 	repo        *chain.Repository
 	blockReader chain.BlockReader
+	cache       *messageCache
 }
 
-func newBlockReader(repo *chain.Repository, position thor.Bytes32) *blockReader {
+func newBlockReader(repo *chain.Repository, position thor.Bytes32, cache *messageCache) *blockReader {
 	return &blockReader{
 		repo:        repo,
 		blockReader: repo.NewBlockReader(position),
+		cache:       cache,
 	}
 }
 
-func (br *blockReader) Read() ([]interface{}, bool, error) {
+func (br *blockReader) Read() ([][]byte, bool, error) {
 	blocks, err := br.blockReader.Read()
 	if err != nil {
 		return nil, false, err
 	}
-	var msgs []interface{}
+	var msgs [][]byte
 	for _, block := range blocks {
-		msg, err := convertBlock(block)
+		msg, err := br.cache.GetOrAdd(block, br.repo)
 		if err != nil {
 			return nil, false, err
 		}
 		msgs = append(msgs, msg)
 	}
 	return msgs, len(blocks) > 0, nil
+}
+
+func generateBlockBytes(block *chain.ExtendedBlock, _ *chain.Repository) ([]byte, error) {
+	blk, err := convertBlock(block)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(blk)
 }

--- a/api/subscriptions/block_reader_test.go
+++ b/api/subscriptions/block_reader_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func blockCache() *messageCache {
-	cache, _ := newMessageCache(generateBlockBytes, 10)
+	cache, _ := newMessageCache(generateBlockMessage, 10)
 	return cache
 }
 

--- a/api/subscriptions/event_reader.go
+++ b/api/subscriptions/event_reader.go
@@ -6,6 +6,8 @@
 package subscriptions
 
 import (
+	"encoding/json"
+
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/thor"
 )
@@ -24,12 +26,12 @@ func newEventReader(repo *chain.Repository, position thor.Bytes32, filter *Event
 	}
 }
 
-func (er *eventReader) Read() ([]interface{}, bool, error) {
+func (er *eventReader) Read() ([][]byte, bool, error) {
 	blocks, err := er.blockReader.Read()
 	if err != nil {
 		return nil, false, err
 	}
-	var msgs []interface{}
+	var msgs [][]byte
 	for _, block := range blocks {
 		receipts, err := er.repo.GetBlockReceipts(block.Header().ID())
 		if err != nil {
@@ -44,7 +46,11 @@ func (er *eventReader) Read() ([]interface{}, bool, error) {
 						if err != nil {
 							return nil, false, err
 						}
-						msgs = append(msgs, msg)
+						bytes, err := json.Marshal(msg)
+						if err != nil {
+							return nil, false, err
+						}
+						msgs = append(msgs, bytes)
 					}
 				}
 			}

--- a/api/subscriptions/event_reader_test.go
+++ b/api/subscriptions/event_reader_test.go
@@ -6,6 +6,7 @@
 package subscriptions
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,11 +39,9 @@ func TestEventReader_Read(t *testing.T) {
 	assert.True(t, ok)
 	var eventMessages []*EventMessage
 	for _, event := range events {
-		if msg, ok := event.(*EventMessage); ok {
-			eventMessages = append(eventMessages, msg)
-		} else {
-			t.Fatal("unexpected type")
-		}
+		eventMsg := &EventMessage{}
+		assert.NoError(t, json.Unmarshal(event, eventMsg))
+		eventMessages = append(eventMessages, eventMsg)
 	}
 	assert.Equal(t, 1, len(eventMessages))
 	eventMsg := eventMessages[0]

--- a/api/subscriptions/message_cache.go
+++ b/api/subscriptions/message_cache.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
 package subscriptions
 
 import (

--- a/api/subscriptions/message_cache.go
+++ b/api/subscriptions/message_cache.go
@@ -1,0 +1,50 @@
+package subscriptions
+
+import (
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/vechain/thor/v2/chain"
+)
+
+type messageHandler = func(*chain.ExtendedBlock, *chain.Repository) ([]byte, error)
+
+type messageCache struct {
+	cache     *lru.Cache
+	generator messageHandler
+	mu        sync.RWMutex
+}
+
+func newMessageCache(handler messageHandler, cacheSize int) (*messageCache, error) {
+	cache, err := lru.New(cacheSize)
+	return &messageCache{
+		cache:     cache,
+		generator: handler,
+	}, err
+}
+
+// GetOrAdd can be called by thousands of goroutines concurrently. The first goroutine that invokes it for a specific
+// block will generate the message and store it in the cache. Subsequent goroutines will read the message from the cache.
+func (mc *messageCache) GetOrAdd(block *chain.ExtendedBlock, repo *chain.Repository) ([]byte, error) {
+	blockID := block.Header().ID().String()
+	mc.mu.RLock()
+	msg, ok := mc.cache.Get(blockID)
+	mc.mu.RUnlock()
+	if ok {
+		return msg.([]byte), nil
+	}
+
+	mc.mu.Lock()
+	defer mc.mu.Unlock()
+	msg, ok = mc.cache.Get(blockID)
+	if ok {
+		return msg.([]byte), nil
+	}
+
+	msg, err := mc.generator(block, repo)
+	if err != nil {
+		return nil, err
+	}
+	mc.cache.Add(blockID, msg)
+	return msg.([]byte), nil
+}

--- a/api/subscriptions/message_cache_test.go
+++ b/api/subscriptions/message_cache_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
 package subscriptions
 
 import (

--- a/api/subscriptions/message_cache_test.go
+++ b/api/subscriptions/message_cache_test.go
@@ -1,0 +1,51 @@
+package subscriptions
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vechain/thor/v2/chain"
+)
+
+func handler(blk *chain.ExtendedBlock, _ *chain.Repository) ([]byte, error) {
+	data := make(map[string]interface{})
+	data["id"] = blk.Header().ID().String()
+	return json.Marshal(blk)
+}
+
+func TestMessageCache_GetOrAdd(t *testing.T) {
+	repo, generatedBlocks, _ := initChain(t)
+
+	blk0 := generatedBlocks[0]
+	blk1 := generatedBlocks[1]
+
+	cache, err := newMessageCache(handler, 10)
+	assert.NoError(t, err)
+
+	counter := atomic.Int32{}
+	wg := sync.WaitGroup{}
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		start := time.Now().Add(20 * time.Millisecond)
+		go func() {
+			defer wg.Done()
+			time.Sleep(time.Until(start))
+			_, added, err := cache.GetOrAdd(&chain.ExtendedBlock{Block: blk0}, repo)
+			assert.NoError(t, err)
+			if added {
+				counter.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, counter.Load(), int32(1))
+
+	_, added, err := cache.GetOrAdd(&chain.ExtendedBlock{Block: blk1}, repo)
+	assert.NoError(t, err)
+	assert.True(t, added)
+	assert.Equal(t, cache.cache.Len(), 2)
+}

--- a/api/subscriptions/subscriptions.go
+++ b/api/subscriptions/subscriptions.go
@@ -53,9 +53,9 @@ const (
 
 func New(repo *chain.Repository, allowedOrigins []string, backtraceLimit uint32, txpool *txpool.TxPool) *Subscriptions {
 	cacheSize := backtraceLimit * 120 / 100
-	beat2Cache, _ := newMessageCache(generateBeat2Bytes, int(cacheSize))
-	beatCache, _ := newMessageCache(generateBeatBytes, int(cacheSize))
-	blockCache, _ := newMessageCache(generateBlockBytes, int(cacheSize))
+	beat2Cache, _ := newMessageCache(generateBeat2Message, int(cacheSize))
+	beatCache, _ := newMessageCache(generateBeatMessage, int(cacheSize))
+	blockCache, _ := newMessageCache(generateBlockMessage, int(cacheSize))
 
 	sub := &Subscriptions{
 		backtraceLimit: backtraceLimit,

--- a/api/subscriptions/transfer_reader.go
+++ b/api/subscriptions/transfer_reader.go
@@ -6,6 +6,8 @@
 package subscriptions
 
 import (
+	"encoding/json"
+
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/thor"
 )
@@ -24,12 +26,12 @@ func newTransferReader(repo *chain.Repository, position thor.Bytes32, filter *Tr
 	}
 }
 
-func (tr *transferReader) Read() ([]interface{}, bool, error) {
+func (tr *transferReader) Read() ([][]byte, bool, error) {
 	blocks, err := tr.blockReader.Read()
 	if err != nil {
 		return nil, false, err
 	}
-	var msgs []interface{}
+	var msgs [][]byte
 	for _, block := range blocks {
 		receipts, err := tr.repo.GetBlockReceipts(block.Header().ID())
 		if err != nil {
@@ -48,7 +50,11 @@ func (tr *transferReader) Read() ([]interface{}, bool, error) {
 						if err != nil {
 							return nil, false, err
 						}
-						msgs = append(msgs, msg)
+						bytes, err := json.Marshal(msg)
+						if err != nil {
+							return nil, false, err
+						}
+						msgs = append(msgs, bytes)
 					}
 				}
 			}

--- a/api/subscriptions/transfer_reader_test.go
+++ b/api/subscriptions/transfer_reader_test.go
@@ -6,6 +6,7 @@
 package subscriptions
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,14 +27,13 @@ func TestTransferReader_Read(t *testing.T) {
 	// Assert
 	assert.NoError(t, err)
 	assert.True(t, ok)
-	if transferMsg, ok := res[0].(*TransferMessage); !ok {
-		t.Fatal("unexpected type")
-	} else {
-		assert.Equal(t, newBlock.Header().Number(), transferMsg.Meta.BlockNumber)
-		assert.Equal(t, newBlock.Header().ID(), transferMsg.Meta.BlockID)
-		assert.Equal(t, newBlock.Header().Timestamp(), transferMsg.Meta.BlockTimestamp)
-		assert.Equal(t, newBlock.Transactions()[0].ID(), transferMsg.Meta.TxID)
-	}
+	transferMsg := &TransferMessage{}
+	assert.NoError(t, json.Unmarshal(res[0], transferMsg))
+
+	assert.Equal(t, newBlock.Header().Number(), transferMsg.Meta.BlockNumber)
+	assert.Equal(t, newBlock.Header().ID(), transferMsg.Meta.BlockID)
+	assert.Equal(t, newBlock.Header().Timestamp(), transferMsg.Meta.BlockTimestamp)
+	assert.Equal(t, newBlock.Transactions()[0].ID(), transferMsg.Meta.TxID)
 }
 
 func TestTransferReader_Read_NoNewBlocksToRead(t *testing.T) {


### PR DESCRIPTION
# Description

This PR leverages an LRU cache for `beat`, `beat2` and `block` subscription endpoints. It generates the messages, marshals them and caches the bytes against thor block ID.

This improves CPU performance a lot when:
- There are a high amount of transactions, eg 90% gas utilization
- There are high number of beat/ beat2 websocket connections

# How Has This Been Tested?

- [x] Performance tested using https://github.com/darrenvechain/toolchain & a simple k6 script to create 10,000 websockets with an isolated node on testnet.
- [ ] Unit tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
