### PR TITLE
ehancement(Bytes32): apply left hand padding in UnmarshalJSON

### DIFF
--- a/thor/bytes32.go
+++ b/thor/bytes32.go
@@ -55,6 +55,11 @@ func (b *Bytes32) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &hex); err != nil {
 		return err
 	}
+	hex = strings.TrimPrefix(hex, "0x")
+	// apply left padding
+	for i := len(hex); i < 32*2; i++ {
+		hex = "0" + hex
+	}
 	parsed, err := ParseBytes32(hex)
 	if err != nil {
 		return err

--- a/thor/bytes32.go
+++ b/thor/bytes32.go
@@ -8,7 +8,6 @@ package thor
 import (
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -55,11 +54,6 @@ func (b *Bytes32) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &hex); err != nil {
 		return err
 	}
-	hex = strings.TrimPrefix(hex, "0x")
-	// apply left padding
-	for i := len(hex); i < 32*2; i++ {
-		hex = "0" + hex
-	}
 	parsed, err := ParseBytes32(hex)
 	if err != nil {
 		return err
@@ -70,14 +64,14 @@ func (b *Bytes32) UnmarshalJSON(data []byte) error {
 
 // ParseBytes32 convert string presented into Bytes32 type
 func ParseBytes32(s string) (Bytes32, error) {
-	if len(s) == 32*2 {
-	} else if len(s) == 32*2+2 {
-		if strings.ToLower(s[:2]) != "0x" {
-			return Bytes32{}, errors.New("invalid prefix")
-		}
-		s = s[2:]
-	} else {
-		return Bytes32{}, errors.New("invalid length")
+	s = strings.TrimPrefix(s, "0x")
+	// if the string is too long, return error
+	if len(s) > 32*2 {
+		return Bytes32{}, fmt.Errorf("invalid length %d", len(s))
+	}
+	// if the string is too short, add padding
+	if len(s) < 32*2 {
+		s = strings.Repeat("0", 32*2-len(s)) + s
 	}
 
 	var b Bytes32

--- a/thor/bytes32_test.go
+++ b/thor/bytes32_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMarshalUnmarshal(t *testing.T) {
+func TestBytes32_UnmarshalJSON(t *testing.T) {
 	// Example hex string representing the value 100
 	originalHex := `"0x00000000000000000000000000000000000000000000000000006d6173746572"` // Note the enclosing double quotes for valid JSON string
 
@@ -49,4 +49,16 @@ func TestMarshalUnmarshal(t *testing.T) {
 	j, err := b.MarshalJSON()
 	assert.NoError(t, err, "Marshaling should not produce an error")
 	assert.Equal(t, `"0x0000000000000000000000000000000000000000000000000000000000000000"`, string(j))
+}
+
+func TestBytes32_UnmarshalJSON_ShouldApplyPadding(t *testing.T) {
+	// Example hex string representing the value 100
+	originalHex := `"0x01"`
+
+	// Unmarshal JSON into HexOrDecimal256
+	var unmarshaledValue Bytes32
+	err := unmarshaledValue.UnmarshalJSON([]byte(originalHex))
+	assert.NoError(t, err)
+
+	assert.Equal(t, MustParseBytes32("0x0000000000000000000000000000000000000000000000000000000000000001"), unmarshaledValue)
 }

--- a/thor/bytes32_test.go
+++ b/thor/bytes32_test.go
@@ -51,14 +51,11 @@ func TestBytes32_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, `"0x0000000000000000000000000000000000000000000000000000000000000000"`, string(j))
 }
 
-func TestBytes32_UnmarshalJSON_ShouldApplyPadding(t *testing.T) {
+func TestParseBytes32(t *testing.T) {
 	// Example hex string representing the value 100
-	originalHex := `"0x01"`
-
-	// Unmarshal JSON into HexOrDecimal256
-	var unmarshaledValue Bytes32
-	err := unmarshaledValue.UnmarshalJSON([]byte(originalHex))
+	expected := MustParseBytes32("0x0000000000000000000000006d95e6dca01d109882fe1726a2fb9865fa41e7aa")
+	trimmed := "0x6d95e6dca01d109882fe1726a2fb9865fa41e7aa"
+	parsed, err := ParseBytes32(trimmed)
 	assert.NoError(t, err)
-
-	assert.Equal(t, MustParseBytes32("0x0000000000000000000000000000000000000000000000000000000000000001"), unmarshaledValue)
+	assert.Equal(t, expected, parsed)
 }


### PR DESCRIPTION
# Description

Applies left hand padding when parsing `thor.Bytes32`

Copies ethereum form a client perspective, because now clients can call with actual values:

```bash
curl --request POST \
  --url https://mainnet.vechain.org/logs/event \
  --header 'Accept: application/json, text/plain' \
  --header 'Content-Type: application/json' \
  --data '{
  "range": {
    "unit": "block",
    "from": 17240365,
    "to": 17289864
  },
  "options": {
    "offset": 0,
    "limit": 100
  },
  "criteriaSet": [
    {
      "address": "0x0000000000000000000000000000456E65726779",
      "topic0": "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
      "topic1": "0x6d95e6dca01d109882fe1726a2fb9865fa41e7aa"
    }
  ],
  "order": "asc"
}'
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] bytes32_test.go

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
