### PR TITLE
fix(docker): using AWS docker repo for trivy

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -105,3 +105,6 @@ jobs:
           repository: vechain/thor-internal-ci
           event-type: internal-thor-ci
           client-payload: '{"thor_image": "${{ fromJSON(steps.build-and-push-image.outputs.meta.json).tags[0] }}"}'
+        env:
+          # See https://github.com/aquasecurity/trivy/discussions/7538
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -95,6 +95,9 @@ jobs:
           annotations: true
           severity: LOW
           dockerfile: ./Dockerfile
+        env:
+          # See https://github.com/aquasecurity/trivy/discussions/7538
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
       - name: Internal CI
         uses: peter-evans/repository-dispatch@v3
@@ -105,6 +108,3 @@ jobs:
           repository: vechain/thor-internal-ci
           event-type: internal-thor-ci
           client-payload: '{"thor_image": "${{ fromJSON(steps.build-and-push-image.outputs.meta.json).tags[0] }}"}'
-        env:
-          # See https://github.com/aquasecurity/trivy/discussions/7538
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2


### PR DESCRIPTION
# Description

Use different trivy image for docker scanning: [public.ecr.aws/aquasecurity/trivy-db:2](https://github.com/aquasecurity/trivy/discussions/7538)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
