### PR TITLE
enhancement(logging): leverage trace level

### DIFF
--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -266,7 +266,7 @@ func (n *Node) txStashLoop(ctx context.Context) {
 			if err := stash.Save(txEv.Tx); err != nil {
 				logger.Warn("stash tx", "id", txEv.Tx.ID(), "err", err)
 			} else {
-				logger.Debug("stashed tx", "id", txEv.Tx.ID())
+				logger.Trace("stashed tx", "id", txEv.Tx.ID())
 			}
 		}
 	}
@@ -392,7 +392,7 @@ func (n *Node) processBlock(newBlock *block.Block, stats *blockStats) (bool, err
 		commitElapsed := mclock.Now() - startTime - execElapsed
 
 		if v, updated := n.bandwidth.Update(newBlock.Header(), time.Duration(realElapsed)); updated {
-			logger.Debug("bandwidth updated", "gps", v)
+			logger.Trace("bandwidth updated", "gps", v)
 		}
 		stats.UpdateProcessed(1, len(receipts), execElapsed, commitElapsed, realElapsed, newBlock.Header().GasUsed())
 

--- a/cmd/thor/node/packer_loop.go
+++ b/cmd/thor/node/packer_loop.go
@@ -205,7 +205,7 @@ func (n *Node) pack(flow *packer.Flow) (err error) {
 		)
 
 		if v, updated := n.bandwidth.Update(newBlock.Header(), time.Duration(realElapsed)); updated {
-			logger.Debug("bandwidth updated", "gps", v)
+			logger.Trace("bandwidth updated", "gps", v)
 		}
 
 		metricBlockProcessedTxs().SetWithLabel(int64(len(receipts)), map[string]string{"type": "proposed"})

--- a/comm/handle_rpc.go
+++ b/comm/handle_rpc.go
@@ -21,7 +21,7 @@ import (
 // peer will be disconnected if error returned
 func (c *Communicator) handleRPC(peer *Peer, msg *p2p.Msg, write func(interface{}), txsToSync *txsToSync) (err error) {
 	log := peer.logger.New("msg", proto.MsgName(msg.Code))
-	log.Debug("received RPC call")
+	log.Trace("received RPC call")
 	defer func() {
 		if err != nil {
 			log.Debug("failed to handle RPC call", "err", err)

--- a/comm/sync.go
+++ b/comm/sync.go
@@ -196,7 +196,7 @@ func findCommonAncestor(ctx context.Context, repo *chain.Repository, peer *Peer,
 
 func (c *Communicator) syncTxs(peer *Peer) {
 	for i := 0; ; i++ {
-		peer.logger.Debug(fmt.Sprintf("sync txs loop %v", i))
+		peer.logger.Trace(fmt.Sprintf("sync txs loop %v", i))
 		result, err := proto.GetTxs(c.ctx, peer)
 		if err != nil {
 			peer.logger.Debug("failed to request txs", "err", err)

--- a/p2psrv/server.go
+++ b/p2psrv/server.go
@@ -87,7 +87,7 @@ func (s *Server) Start(protocols []*p2p.Protocol, topic discv5.Topic) error {
 			}
 			log := logger.New("peer", peer, "dir", dir)
 
-			log.Debug("peer connected")
+			log.Trace("peer connected")
 			metricConnectedPeers().Add(1)
 
 			startTime := mclock.Now()
@@ -252,7 +252,7 @@ func (s *Server) discoverLoop(topic discv5.Topic) {
 			if _, found := s.discoveredNodes.Get(node.ID); !found {
 				metricDiscoveredNodes().Add(1)
 				s.discoveredNodes.Set(node.ID, node)
-				logger.Debug("discovered node", "node", node)
+				logger.Trace("discovered node", "node", node)
 			}
 		case <-s.done:
 			close(setPeriod)


### PR DESCRIPTION
# Description

Leverage the trace log level so we can enable `Debug` without getting spammed with logs.

# Testing 

```bash
make thor
./bin/thor --network main --verbosity 4
```

Restarting a node that is nearly synced before starting:

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/237ee763-2089-4cde-be08-6711365dd2e2">

Starting a node with a lot of blocks to sync:

<img width="1804" alt="image" src="https://github.com/user-attachments/assets/05d4bb21-5841-4e4d-a878-b20452741d0c">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
