### PR TITLE
fix: set range.To to max logDB block

### DIFF
--- a/logdb/logdb.go
+++ b/logdb/logdb.go
@@ -117,6 +117,9 @@ FROM (%v) e
 
 	if filter.Range != nil {
 		subQuery += " AND seq >= ?"
+		if filter.Range.To > blockNumMask {
+			filter.Range.To = blockNumMask
+		}
 		args = append(args, newSequence(filter.Range.From, 0, 0))
 		if filter.Range.To >= filter.Range.From {
 			subQuery += " AND seq <= ?"
@@ -183,6 +186,9 @@ FROM (%v) t
 
 	if filter.Range != nil {
 		subQuery += " AND seq >= ?"
+		if filter.Range.To > blockNumMask {
+			filter.Range.To = blockNumMask
+		}
 		args = append(args, newSequence(filter.Range.From, 0, 0))
 		if filter.Range.To >= filter.Range.From {
 			subQuery += " AND seq <= ?"


### PR DESCRIPTION
# Description

This PR fixes a bug where a client requests a large `to` in logs filters

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
