### PR TITLE
Update Convert Filter to match BlockMask bit space

### DIFF
--- a/api/events/types.go
+++ b/api/events/types.go
@@ -173,8 +173,21 @@ func ConvertRange(chain *chain.Chain, r *Range) (*logdb.Range, error) {
 			To:   toHeader.Number(),
 		}, nil
 	}
+
+	// Units are blocks, locked a max of 28bits in the logdb
+	maxRange := uint32(1<<28 - 1) // Maximum value for 28 bits: 2^28 - 1
+	from := uint32(r.From)
+	to := uint32(r.To)
+
+	// Ensure the values are capped at the 28-bit maximum
+	if uint32(r.From) > maxRange {
+		from = maxRange
+	}
+	if uint32(r.To) > maxRange {
+		to = maxRange
+	}
 	return &logdb.Range{
-		From: uint32(r.From),
-		To:   uint32(r.To),
+		From: from,
+		To:   to,
 	}, nil
 }

--- a/api/events/types.go
+++ b/api/events/types.go
@@ -175,16 +175,15 @@ func ConvertRange(chain *chain.Chain, r *Range) (*logdb.Range, error) {
 	}
 
 	// Units are blocks, locked a max of 28bits in the logdb
-	maxRange := uint32(1<<28 - 1) // Maximum value for 28 bits: 2^28 - 1
 	from := uint32(r.From)
 	to := uint32(r.To)
 
 	// Ensure the values are capped at the 28-bit maximum
-	if uint32(r.From) > maxRange {
-		from = maxRange
+	if uint32(r.From) > logdb.BlockNumMask {
+		from = logdb.BlockNumMask
 	}
-	if uint32(r.To) > maxRange {
-		to = maxRange
+	if uint32(r.To) > logdb.BlockNumMask {
+		to = logdb.BlockNumMask
 	}
 	return &logdb.Range{
 		From: from,

--- a/logdb/logdb.go
+++ b/logdb/logdb.go
@@ -117,7 +117,7 @@ FROM (%v) e
 
 	if filter.Range != nil {
 		subQuery += " AND seq >= ?"
-		if filter.Range.To > blockNumMask {
+		if filter.Range.To > BlockNumMask {
 			return nil, fmt.Errorf("invalid block number range")
 		}
 		args = append(args, newSequence(filter.Range.From, 0, 0))
@@ -186,7 +186,7 @@ FROM (%v) t
 
 	if filter.Range != nil {
 		subQuery += " AND seq >= ?"
-		if filter.Range.To > blockNumMask {
+		if filter.Range.To > BlockNumMask {
 			return nil, fmt.Errorf("invalid block number range")
 		}
 		args = append(args, newSequence(filter.Range.From, 0, 0))

--- a/logdb/logdb.go
+++ b/logdb/logdb.go
@@ -118,7 +118,7 @@ FROM (%v) e
 	if filter.Range != nil {
 		subQuery += " AND seq >= ?"
 		if filter.Range.To > blockNumMask {
-			filter.Range.To = blockNumMask
+			return nil, fmt.Errorf("invalid block number range")
 		}
 		args = append(args, newSequence(filter.Range.From, 0, 0))
 		if filter.Range.To >= filter.Range.From {
@@ -187,7 +187,7 @@ FROM (%v) t
 	if filter.Range != nil {
 		subQuery += " AND seq >= ?"
 		if filter.Range.To > blockNumMask {
-			filter.Range.To = blockNumMask
+			return nil, fmt.Errorf("invalid block number range")
 		}
 		args = append(args, newSequence(filter.Range.From, 0, 0))
 		if filter.Range.To >= filter.Range.From {

--- a/logdb/sequence.go
+++ b/logdb/sequence.go
@@ -12,8 +12,8 @@ const (
 	blockNumBits = 28
 	txIndexBits  = 15
 	logIndexBits = 21
-	// Max = 2^28 - 1 = 268,435,455
-	blockNumMask = (1 << blockNumBits) - 1
+	// BlockNumMask Max = 2^28 - 1 = 268,435,455 (unsigned int 28)
+	BlockNumMask = (1 << blockNumBits) - 1
 	// Max = 2^15 - 1 = 32,767
 	txIndexMask = (1 << txIndexBits) - 1
 	// Max = 2^21 - 1 = 2,097,151
@@ -21,7 +21,7 @@ const (
 )
 
 func newSequence(blockNum uint32, txIndex uint32, logIndex uint32) sequence {
-	if blockNum > blockNumMask {
+	if blockNum > BlockNumMask {
 		panic("block number too large")
 	}
 	if txIndex > txIndexMask {
@@ -36,7 +36,7 @@ func newSequence(blockNum uint32, txIndex uint32, logIndex uint32) sequence {
 }
 
 func (s sequence) BlockNumber() uint32 {
-	return uint32(s>>(txIndexBits+logIndexBits)) & blockNumMask
+	return uint32(s>>(txIndexBits+logIndexBits)) & BlockNumMask
 }
 
 func (s sequence) TxIndex() uint32 {

--- a/logdb/sequence_test.go
+++ b/logdb/sequence_test.go
@@ -20,10 +20,10 @@ func TestSequence(t *testing.T) {
 		args args
 	}{
 		{"regular", args{1, 2, 3}},
-		{"max bn", args{blockNumMask, 1, 2}},
+		{"max bn", args{BlockNumMask, 1, 2}},
 		{"max tx index", args{5, txIndexMask, 4}},
 		{"max log index", args{5, 4, logIndexMask}},
-		{"both max", args{blockNumMask, txIndexMask, logIndexMask}},
+		{"both max", args{BlockNumMask, txIndexMask, logIndexMask}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description

Modifies the `ConvertFilter` method to take into account that the max block byte space is of 28 bytes instead of 32.

Now returns error if a direct access to the DB requests more than `blockNumMask`
