### PR TITLE
Cache hit/miss metrics

### DIFF
--- a/muxdb/cache.go
+++ b/muxdb/cache.go
@@ -174,8 +174,14 @@ type cacheStats struct {
 	flag      atomic.Int32
 }
 
-func (cs *cacheStats) Hit() int64  { return cs.hit.Add(1) }
-func (cs *cacheStats) Miss() int64 { return cs.miss.Add(1) }
+func (cs *cacheStats) Hit() int64  {
+	metricCacheHitMissGauge().AddWithLabel(1, map[string]string{"type": "hit"})
+	return cs.hit.Add(1) 
+}
+func (cs *cacheStats) Miss() int64 {
+	metricCacheHitMissGauge().AddWithLabel(1, map[string]string{"type": "miss"})
+	return cs.miss.Add(1) 
+}
 
 func (cs *cacheStats) ShouldLog(msg string) (func(), bool) {
 	hit := cs.hit.Load()

--- a/muxdb/cache.go
+++ b/muxdb/cache.go
@@ -51,8 +51,8 @@ func (c *cache) log() {
 	last := c.lastLogTime.Swap(now)
 
 	if now-last > int64(time.Second*20) {
-		log1, ok1 := c.nodeStats.ShouldLog("node cache stats")
-		log2, ok2 := c.rootStats.ShouldLog("root cache stats")
+		log1, ok1 := c.nodeStats.shouldLog("node cache stats")
+		log2, ok2 := c.rootStats.shouldLog("root cache stats")
 
 		if ok1 || ok2 {
 			log1()
@@ -183,7 +183,7 @@ func (cs *cacheStats) Miss() int64 {
 	return cs.miss.Add(1) 
 }
 
-func (cs *cacheStats) ShouldLog(msg string) (func(), bool) {
+func (cs *cacheStats) shouldLog(msg string) (func(), bool) {
 	hit := cs.hit.Load()
 	miss := cs.miss.Load()
 	lookups := hit + miss

--- a/muxdb/metrics.go
+++ b/muxdb/metrics.go
@@ -1,0 +1,7 @@
+package muxdb
+
+import (
+	"github.com/vechain/thor/v2/metrics"
+)
+
+var metricCacheHitMissGauge = metrics.LazyLoadGaugeVec("cache_hit_miss_count", []string{"type"})


### PR DESCRIPTION
# Description

Introduces a metric to show data about cache hit/miss. This would be a sample Grafana dashboard relying on this data to show the rate:

<img width="893" alt="Screenshot 2024-11-18 at 17 49 09" src="https://github.com/user-attachments/assets/3131a386-6446-428b-a9de-6cc7d463312d">

Since it is my first PR in this repo I was looking for some checks before addressing the others.