### PR TITLE
Metrics: Cache hit/miss

### DIFF
--- a/muxdb/cache.go
+++ b/muxdb/cache.go
@@ -179,12 +179,8 @@ type cacheStats struct {
 	flag      atomic.Int32
 }
 
-func (cs *cacheStats) Hit() int64  {
-	return cs.hit.Add(1) 
-}
-func (cs *cacheStats) Miss() int64 {
-	return cs.miss.Add(1) 
-}
+func (cs *cacheStats) Hit() int64  { return cs.hit.Add(1) }
+func (cs *cacheStats) Miss() int64 { return cs.miss.Add(1) }
 
 func (cs *cacheStats) shouldLog(msg string) (func(), bool) {
 	hit := cs.hit.Load()

--- a/muxdb/cache.go
+++ b/muxdb/cache.go
@@ -51,8 +51,8 @@ func (c *cache) log() {
 	last := c.lastLogTime.Swap(now)
 
 	if now-last > int64(time.Second*20) {
-		log1, ok1 := c.nodeStats.ShouldLog("node cache stats")
-		log2, ok2 := c.rootStats.ShouldLog("root cache stats")
+		log1, ok1 := c.nodeStats.shouldLog("node cache stats")
+		log2, ok2 := c.rootStats.shouldLog("root cache stats")
 
 		if ok1 || ok2 {
 			log1()
@@ -109,6 +109,7 @@ func (c *cache) GetNodeBlob(keyBuf *[]byte, name string, path []byte, ver trie.V
 	}, peek) && len(blob) > 0 {
 		if !peek {
 			c.nodeStats.Hit()
+			metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "node", "event": "hit"})
 		}
 		return blob
 	}
@@ -119,11 +120,13 @@ func (c *cache) GetNodeBlob(keyBuf *[]byte, name string, path []byte, ver trie.V
 	}, peek) && len(blob) > 0 {
 		if !peek {
 			c.nodeStats.Hit()
+			metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "node", "event": "hit"})
 		}
 		return blob
 	}
 	if !peek {
 		c.nodeStats.Miss()
+		metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "node", "event": "miss"})
 	}
 	return nil
 }
@@ -162,10 +165,12 @@ func (c *cache) GetRootNode(name string, ver trie.Version) trie.Node {
 			if c.rootStats.Hit()%2000 == 0 {
 				c.log()
 			}
+			metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "root", "event": "hit"})
 			return r
 		}
 	}
 	c.rootStats.Miss()
+	metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "root", "event": "miss"})
 	return nil
 }
 
@@ -174,10 +179,14 @@ type cacheStats struct {
 	flag      atomic.Int32
 }
 
-func (cs *cacheStats) Hit() int64  { return cs.hit.Add(1) }
-func (cs *cacheStats) Miss() int64 { return cs.miss.Add(1) }
+func (cs *cacheStats) Hit() int64  {
+	return cs.hit.Add(1) 
+}
+func (cs *cacheStats) Miss() int64 {
+	return cs.miss.Add(1) 
+}
 
-func (cs *cacheStats) ShouldLog(msg string) (func(), bool) {
+func (cs *cacheStats) shouldLog(msg string) (func(), bool) {
 	hit := cs.hit.Load()
 	miss := cs.miss.Load()
 	lookups := hit + miss

--- a/muxdb/metrics.go
+++ b/muxdb/metrics.go
@@ -1,0 +1,7 @@
+package muxdb
+
+import (
+	"github.com/vechain/thor/v2/metrics"
+)
+
+var metricCacheHitMissCounterVec = metrics.LazyLoadCounterVec("cache_hit_miss_count", []string{"type", "event"})


### PR DESCRIPTION
# Description

Covers the metrics for cache hit/miss for root and node cache. In the diagram below:

1. Yellow line is a hit for the root one (in-memory representation of the trie)
2. Green line is a hit for a node one
3. Blue one is a miss for a node one
4. Red one is a miss for the root one

The formula in Grafana is `rate(thor_metrics_cache_hit_miss_count[$__rate_interval])`

<img width="1171" alt="Screenshot 2024-11-19 at 10 42 57" src="https://github.com/user-attachments/assets/9a41b62c-6062-40a3-b493-d063661f0ec3">

