### PR TITLE
Metrics: Reuse `shouldLog` so we get cache hit/miss data at the same pace

### DIFF
--- a/muxdb/cache.go
+++ b/muxdb/cache.go
@@ -109,7 +109,6 @@ func (c *cache) GetNodeBlob(keyBuf *[]byte, name string, path []byte, ver trie.V
 	}, peek) && len(blob) > 0 {
 		if !peek {
 			c.nodeStats.Hit()
-			metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "node", "event": "hit"})
 		}
 		return blob
 	}
@@ -120,13 +119,11 @@ func (c *cache) GetNodeBlob(keyBuf *[]byte, name string, path []byte, ver trie.V
 	}, peek) && len(blob) > 0 {
 		if !peek {
 			c.nodeStats.Hit()
-			metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "node", "event": "hit"})
 		}
 		return blob
 	}
 	if !peek {
 		c.nodeStats.Miss()
-		metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "node", "event": "miss"})
 	}
 	return nil
 }
@@ -162,12 +159,10 @@ func (c *cache) GetRootNode(name string, ver trie.Version) trie.Node {
 			if c.rootStats.Hit()%2000 == 0 {
 				c.log()
 			}
-			metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "root", "event": "hit"})
 			return r
 		}
 	}
 	c.rootStats.Miss()
-	metricCacheHitMissCounterVec().AddWithLabel(1, map[string]string{"type": "root", "event": "miss"})
 	return nil
 }
 
@@ -187,6 +182,9 @@ func (cs *cacheStats) shouldLog(msg string) (func(), bool) {
 	hitrate := float64(hit) / float64(lookups)
 	flag := int32(hitrate * 1000)
 	return func() {
+		metricCacheHitMissGaugeVec().SetWithLabel(hit, map[string]string{"type": "root", "event": "hit"})
+		metricCacheHitMissGaugeVec().SetWithLabel(miss, map[string]string{"type": "root", "event": "miss"})
+
 		var str string
 		if lookups > 0 {
 			str = fmt.Sprintf("%.3f", hitrate)

--- a/muxdb/metrics.go
+++ b/muxdb/metrics.go
@@ -4,4 +4,4 @@ import (
 	"github.com/vechain/thor/v2/metrics"
 )
 
-var metricCacheHitMissCounterVec = metrics.LazyLoadCounterVec("cache_hit_miss_count", []string{"type", "event"})
+var metricCacheHitMissGaugeVec = metrics.LazyLoadGaugeVec("cache_hit_miss_count", []string{"type", "event"})


### PR DESCRIPTION
# Description

After a conversation with @libotony in a previous PR, creating this one so we get the metrics data at the same pace as we log the hit rate.

1. Raw hit/miss by number

<img width="1190" alt="Screenshot 2024-11-20 at 14 43 26" src="https://github.com/user-attachments/assets/d1dfc617-9ceb-4e3e-8c4b-60384ed10af4">

- Yellow line: Root node hit rate
- Green line: Other trie node hit rate
- Orange line: Root node miss rate
- Blue line: Other trie node miss rate

2. Rate in percentage (hits over lookups)

<img width="1110" alt="Screenshot 2024-11-20 at 15 01 48" src="https://github.com/user-attachments/assets/7757de51-802d-491e-a2a2-b06f5a52eba3">

- Yellow line: Root trie node
- Green line: Other trie node