### PR TITLE
fix(documentation): use absolute links in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://www.vechain.org/vechainthor/">
     <picture style="padding: 80px;">
-        <source srcset="docs/assets/banner-dark-mode.png"  media="(prefers-color-scheme: dark)" >
-        <img src="docs/assets/banner-light-mode.png" style="padding: 20px;">
+        <source srcset="https://github.com/vechain/thor/blob/master/docs/assets/banner-dark-mode.png"  media="(prefers-color-scheme: dark)" >
+        <img src="https://github.com/vechain/thor/blob/master/docs/assets/banner-light-mode.png" style="padding: 20px;">
     </picture>
   </a>
 </p>
@@ -44,9 +44,9 @@ ___
 
 ## Documentation
 
-- [Build](./docs/build.md) - How to build the `thor` binary.
-- [Usage](./docs/usage.md) - How to run thor with different configurations.
-- [Hosting a Node](./docs/hosting-a-node.md) - Considerations and requirements for hosting a node.
+- [Build](https://github.com/vechain/thor/blob/master/docs/build.md) - How to build the `thor` binary.
+- [Usage](https://github.com/vechain/thor/blob/master/docs/usage.md) - How to run thor with different configurations.
+- [Hosting a Node](https://github.com/vechain/thor/blob/master/docs/hosting-a-node.md) - Considerations and requirements for hosting a node.
 - [Core Concepts](https://docs.vechain.org/core-concepts) - Core concepts of the VeChainThor blockchain.
 - [API Reference](https://mainnet.vechain.org) - The API reference for the VeChainThor blockchain.
 
@@ -67,7 +67,7 @@ To chat with other community members you can join:
     <a href="https://www.reddit.com/r/Vechain"><img src="https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white"/></a>
 </p>
 
-Do note that our [Code of Conduct](./docs/CODE_OF_CONDUCT.md) applies to all VeChain community channels. Users are
+Do note that our [Code of Conduct](https://github.com/vechain/thor/blob/master/docs/CODE_OF_CONDUCT.md) applies to all VeChain community channels. Users are
 **highly encouraged** to read and adhere to them to avoid repercussions.
 
 ---
@@ -75,7 +75,7 @@ Do note that our [Code of Conduct](./docs/CODE_OF_CONDUCT.md) applies to all VeC
 ## Contributing
 
 Contributions to VeChainThor are welcome and highly appreciated. However, before you jump right into it, we would like
-you to review our [Contribution Guidelines](./docs/CONTRIBUTING.md) to make sure you have a smooth experience
+you to review our [Contribution Guidelines](https://github.com/vechain/thor/blob/master/docs/CONTRIBUTING.md) to make sure you have a smooth experience
 contributing to VeChainThor.
 
 ---

--- a/api/doc/README.md
+++ b/api/doc/README.md
@@ -1,7 +1,7 @@
 ## Swagger
 
 swagger-ui from https://github.com/swagger-api/swagger-ui @v5.11.2
-- Created [window-observer.js](swagger-ui/window-observer.js) to remove `Try it out` functionality for subscription endpoints
+- Created [window-observer.js](./swagger-ui/window-observer.js) to remove `Try it out` functionality for subscription endpoints
 
 ```bash
 curl https://unpkg.com/swagger-ui-dist@5.11.2/swagger-ui.css > swagger-ui/swagger-ui.css
@@ -11,7 +11,7 @@ curl https://unpkg.com/swagger-ui-dist@5.11.2/swagger-ui-standalone-preset.js > 
 
 ## Stoplight
 Spotlight UI from https://github.com/stoplightio/elements @v8.0.3
-- Created [window-observer.js](stoplight-ui/window-observer.js) to remove `Send API Request` functionality for subscription endpoints
+- Created [window-observer.js](./stoplight-ui/window-observer.js) to remove `Send API Request` functionality for subscription endpoints
 
 ```bash
 curl https://unpkg.com/@stoplight/elements@8.0.3/styles.min.css > stoplight-ui/styles.min.css

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to VechainThor
 
 Welcome to VechainThor! We appreciate your interest in contributing. By participating in this project, you agree to
-abide by our [Code of Conduct](https://github.com/vechain/thor/blob/master/CODE_OF_CONDUCT.md).
+abide by our [Code of Conduct](https://github.com/vechain/thor/blob/master/docs/CODE_OF_CONDUCT.md).
 
 ## VeChain Improvement Proposals (VIPs)
 

--- a/docs/hosting-a-node.md
+++ b/docs/hosting-a-node.md
@@ -21,7 +21,7 @@ state, including the disk space required for various node types.
 
 ### Command Line Options
 
-Please refer to [Command Line Options](./usage.md#command-line-options) in the usage documentation to see a list of all
+Please refer to [Command Line Options](https://github.com/vechain/thor/blob/master/docs/usage.md#command-line-options) in the usage documentation to see a list of all
 available options.
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ ___
 
 ### Running from source
 
-- To install the `thor` binary, follow the instructions in the [build](build) guide.
+- To install the `thor` binary, follow the instructions in the [build](https://github.com/vechain/thor/blob/master/docs/build.md) guide.
 
 Connect to vechain's mainnet:
 
@@ -47,7 +47,7 @@ ___
 
 ### Running a discovery node
 
-- To install the `disco` binary, follow the instructions in the [build](build) guide.
+- To install the `disco` binary, follow the instructions in the [build](https://github.com/vechain/thor/blob/master/docs/build.md) guide.
 
 Start a discovery node:
 


### PR DESCRIPTION
# Description

- Fix broken link
- Use absolute links

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
