### PR TITLE
Metrics: Disk IO reads and writes

### DIFF
--- a/metrics/noop.go
+++ b/metrics/noop.go
@@ -5,7 +5,10 @@
 
 package metrics
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 // noopMetrics implements a no operations metrics service
 type noopMetrics struct{}
@@ -48,3 +51,5 @@ func (n noopMeters) Set(int64) {}
 func (n noopMeters) Observe(int64) {}
 
 func (n *noopMetrics) ObserveWithLabels(int64, map[string]string) {}
+
+func (n *noopMetrics) collectDiskIO(refresh time.Duration) {}

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -6,8 +6,14 @@
 package metrics
 
 import (
+	"bufio"
+	"fmt"
 	"net/http"
+	"os"
+	"strconv"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -24,6 +30,8 @@ func InitializePrometheusMetrics() {
 	// don't allow for reset
 	if _, ok := metrics.(*prometheusMetrics); !ok {
 		metrics = newPrometheusMetrics()
+		// collection disk io metrics every 5 seconds
+		go metrics.(*prometheusMetrics).collectDiskIO(5 * time.Second)
 	}
 }
 
@@ -144,6 +152,63 @@ func (o *prometheusMetrics) newHistogramMeter(name string, buckets []int64) Hist
 
 	return &promHistogramMeter{
 		histogram: meter,
+	}
+}
+
+func getIOLineValue(line string) (int64) {
+	fields := strings.Fields(line)
+	if len(fields) != 2 {
+		logger.Warn("this io file line is malformed", "err", line)
+		return 0
+	}
+	value, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		logger.Warn("unable to parse int", "err", err)
+		return 0
+	}
+
+	return value
+}
+
+func getDiskIOData() (int64, int64, error) {
+	pid := os.Getpid()
+	ioFilePath := fmt.Sprintf("/proc/%d/io", pid)
+	file, err := os.Open(ioFilePath)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// Parse the file line by line
+	scanner := bufio.NewScanner(file)
+	var reads, writes int64
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "syscr") {
+			reads = getIOLineValue(line)
+		} else if strings.HasPrefix(line, "syscw") {
+			writes = getIOLineValue(line)
+		}
+	}
+
+	return reads, writes, nil
+}
+
+func (o *prometheusMetrics) collectDiskIO(refresh time.Duration) {
+	for {
+		reads, writes, err := getDiskIOData()
+		if err != nil {
+			continue
+		}
+
+		logger.Info("LLEGA", "reads", reads, "writes", writes)
+
+		readsMeter := o.GetOrCreateGaugeMeter("disk_reads")
+		readsMeter.Set(reads)
+
+		writesMeter := o.GetOrCreateGaugeMeter("disk_writes")
+		writesMeter.Set(writes)
+
+		time.Sleep(refresh)
 	}
 }
 

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -196,9 +196,7 @@ func getDiskIOData() (int64, int64, error) {
 func (o *prometheusMetrics) collectDiskIO(refresh time.Duration) {
 	for {
 		reads, writes, err := getDiskIOData()
-		if err != nil {
-			continue
-		} else {
+		if err == nil {
 			readsMeter := o.GetOrCreateGaugeMeter("disk_reads")
 			readsMeter.Set(reads)
 

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -200,8 +200,6 @@ func (o *prometheusMetrics) collectDiskIO(refresh time.Duration) {
 			continue
 		}
 
-		logger.Info("LLEGA", "reads", reads, "writes", writes)
-
 		readsMeter := o.GetOrCreateGaugeMeter("disk_reads")
 		readsMeter.Set(reads)
 

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -198,13 +198,13 @@ func (o *prometheusMetrics) collectDiskIO(refresh time.Duration) {
 		reads, writes, err := getDiskIOData()
 		if err != nil {
 			continue
+		} else {
+			readsMeter := o.GetOrCreateGaugeMeter("disk_reads")
+			readsMeter.Set(reads)
+
+			writesMeter := o.GetOrCreateGaugeMeter("disk_writes")
+			writesMeter.Set(writes)
 		}
-
-		readsMeter := o.GetOrCreateGaugeMeter("disk_reads")
-		readsMeter.Set(reads)
-
-		writesMeter := o.GetOrCreateGaugeMeter("disk_writes")
-		writesMeter.Set(writes)
 
 		time.Sleep(refresh)
 	}


### PR DESCRIPTION
# Description

Collecting Disk I/O data (reads and writes only, not bytes for now) every 5 seconds. In the following graph we are applying `rate` as usual (please suggest any other representation).

If you want to reproduce it on your side, run it with Docker (the code assumes that your are running `thor` in Linux - I have a macOS - , use your local `data` folder):

```
docker run -d\
  -v /Users/miguel_rojo/.org.vechain.thor:/home/thor/.org.vechain.thor\
 --network thor-node-monitoring_monitoring\
  -p 127.0.0.1:8669:8669 -p 11235:11235 -p 11235:11235/udp -p 127.0.0.1:2112:2112\
  --name thor-node thor-local --network test --metrics-addr 0.0.0.0:2112 --enable-metrics
```

1. Yellow line: Writes
2. Green line: Reads

![Screenshot 2024-11-22 at 12 49 45](https://github.com/user-attachments/assets/11e2aa30-bc97-4554-b30d-5cd192661455)

Some logs (not part of the current code, follow `LLEGA`):

```
INFO [11-22|12:50:36.538] LLEGA                                    pkg=metrics reads=36548 writes=673,004
INFO [11-22|12:50:37.965] imported blocks (176)                    pkg=node    txs=69  mgas=29.672 et=19.696ms|2.005s mgas/s=14.655 id="[#346490…53e713a5]"
INFO [11-22|12:50:38.083] node cache stats                         pkg=muxdb   lookups=22301   hitrate=0.984
INFO [11-22|12:50:38.083] root cache stats                         pkg=muxdb   lookups=367,395 hitrate=0.980
INFO [11-22|12:50:39.968] imported blocks (417)                    pkg=node    txs=30  mgas=7.167  et=14.894ms|1.973s mgas/s=3.605  id="[#346907…d8eda663]"
INFO [11-22|12:50:41.540] LLEGA                                    pkg=metrics reads=36649 writes=677,781
INFO [11-22|12:50:41.970] imported blocks (618)                    pkg=node    txs=0   mgas=0.000  et=13.127ms|1.969s mgas/s=0.000  id="[#347525…7871864d]"
INFO [11-22|12:50:43.974] imported blocks (562)                    pkg=node    txs=0   mgas=0.000  et=14.233ms|1.966s mgas/s=0.000  id="[#348087…04241646]"
INFO [11-22|12:50:45.975] imported blocks (536)                    pkg=node    txs=0   mgas=0.000  et=13.339ms|1.969s mgas/s=0.000  id="[#348623…40ec144b]"
INFO [11-22|12:50:46.541] LLEGA                                    pkg=metrics reads=36772 writes=682,067
INFO [11-22|12:50:47.978] imported blocks (607)                    pkg=node    txs=0   mgas=0.000  et=14.965ms|1.969s mgas/s=0.000  id="[#349230…670ef206]"
INFO [11-22|12:50:49.980] imported blocks (575)                    pkg=node    txs=1   mgas=0.053  et=13.604ms|1.967s mgas/s=0.027  id="[#349805…1a1e84cf]"
INFO [11-22|12:50:51.542] LLEGA                                    pkg=metrics reads=36808 writes=686,689
INFO [11-22|12:50:51.983] imported blocks (549)                    pkg=node    txs=13  mgas=0.526  et=13.360ms|1.973s mgas/s=0.265  id="[#350354…4aec381c]"
INFO [11-22|12:50:53.983] imported blocks (465)                    pkg=node    txs=5   mgas=0.137  et=10.630ms|1.972s mgas/s=0.069  id="[#350819…d1347dec]"
INFO [11-22|12:50:55.985] imported blocks (420)                    pkg=node    txs=30  mgas=0.865  et=15.612ms|1.973s mgas/s=0.435  id="[#351239…8b8d05f5]"
INFO [11-22|12:50:56.543] LLEGA                                    pkg=metrics reads=37110 writes=691,189
```
