### PR TITLE
add 'raw' query parameter to the blocks

### DIFF
--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -60,7 +60,7 @@ func (b *Blocks) handleGetBlock(w http.ResponseWriter, req *http.Request) error 
 			return err
 		}
 		return utils.WriteJSON(w, &JSONRawBlockSummary{
-			fmt.Sprintf("0x%s", hex.EncodeToString(rlpEncodedSummary)),
+			fmt.Sprintf("0x%s", hex.EncodeToString(rlpEncoded)),
 		})
 	}
 

--- a/api/blocks/blocks.go
+++ b/api/blocks/blocks.go
@@ -55,7 +55,7 @@ func (b *Blocks) handleGetBlock(w http.ResponseWriter, req *http.Request) error 
 	}
 
 	if raw == "true" {
-		rlpEncodedSummary, err := rlp.EncodeToBytes(summary)
+		rlpEncoded, err := rlp.EncodeToBytes(summary.Header)
 		if err != nil {
 			return err
 		}

--- a/api/blocks/blocks_test.go
+++ b/api/blocks/blocks_test.go
@@ -6,6 +6,7 @@
 package blocks_test
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"math"
 	"math/big"
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -55,6 +57,8 @@ func TestBlock(t *testing.T) {
 		"testGetFinalizedBlock":                 testGetFinalizedBlock,
 		"testGetJustifiedBlock":                 testGetJustifiedBlock,
 		"testGetBlockWithRevisionNumberTooHigh": testGetBlockWithRevisionNumberTooHigh,
+		"testMutuallyExclusiveQueries":          testMutuallyExclusiveQueries,
+		"testGetRawBlock":                       testGetRawBlock,
 	} {
 		t.Run(name, tt)
 	}
@@ -67,6 +71,23 @@ func testBadQueryParams(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, "expanded: should be boolean", strings.TrimSpace(string(res)))
+
+	badQueryParams = "?raw=1"
+	res, statusCode, err = tclient.RawHTTPClient().RawHTTPGet("/blocks/best" + badQueryParams)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, statusCode)
+	assert.Equal(t, "raw: should be boolean", strings.TrimSpace(string(res)))
+}
+
+func testMutuallyExclusiveQueries(t *testing.T) {
+	badQueryParams := "?expanded=true&raw=true"
+	res, statusCode, err := tclient.RawHTTPClient().RawHTTPGet("/blocks/best" + badQueryParams)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusBadRequest, statusCode)
+	assert.Equal(t, "raw&expanded: Raw and Expanded are mutually exclusive", strings.TrimSpace(string(res)))
+
 }
 
 func testGetBestBlock(t *testing.T) {
@@ -77,6 +98,41 @@ func testGetBestBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkCollapsedBlock(t, blk, rb)
+	assert.Equal(t, http.StatusOK, statusCode)
+}
+
+func testGetRawBlock(t *testing.T) {
+	res, statusCode, err := tclient.RawHTTPClient().RawHTTPGet("/blocks/best?raw=true")
+	require.NoError(t, err)
+	rawBlock := new(blocks.JSONRawBlockSummary)
+	if err := json.Unmarshal(res, &rawBlock); err != nil {
+		t.Fatal(err)
+	}
+
+	blockBytes, err := hex.DecodeString(rawBlock.Raw[2:len(rawBlock.Raw)])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := block.Header{}
+	err = rlp.DecodeBytes(blockBytes, &header)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expHeader := blk.Header()
+	assert.Equal(t, expHeader.Number(), header.Number(), "Number should be equal")
+	assert.Equal(t, expHeader.ID(), header.ID(), "Hash should be equal")
+	assert.Equal(t, expHeader.ParentID(), header.ParentID(), "ParentID should be equal")
+	assert.Equal(t, expHeader.Timestamp(), header.Timestamp(), "Timestamp should be equal")
+	assert.Equal(t, expHeader.TotalScore(), header.TotalScore(), "TotalScore should be equal")
+	assert.Equal(t, expHeader.GasLimit(), header.GasLimit(), "GasLimit should be equal")
+	assert.Equal(t, expHeader.GasUsed(), header.GasUsed(), "GasUsed should be equal")
+	assert.Equal(t, expHeader.Beneficiary(), header.Beneficiary(), "Beneficiary should be equal")
+	assert.Equal(t, expHeader.TxsRoot(), header.TxsRoot(), "TxsRoot should be equal")
+	assert.Equal(t, expHeader.StateRoot(), header.StateRoot(), "StateRoot should be equal")
+	assert.Equal(t, expHeader.ReceiptsRoot(), header.ReceiptsRoot(), "ReceiptsRoot should be equal")
+
 	assert.Equal(t, http.StatusOK, statusCode)
 }
 

--- a/api/blocks/blocks_test.go
+++ b/api/blocks/blocks_test.go
@@ -87,7 +87,6 @@ func testMutuallyExclusiveQueries(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, "raw&expanded: Raw and Expanded are mutually exclusive", strings.TrimSpace(string(res)))
-
 }
 
 func testGetBestBlock(t *testing.T) {

--- a/api/blocks/types.go
+++ b/api/blocks/types.go
@@ -33,6 +33,10 @@ type JSONBlockSummary struct {
 	IsFinalized  bool         `json:"isFinalized"`
 }
 
+type JSONRawBlockSummary struct {
+	Raw string `json:"raw"`
+}
+
 type JSONCollapsedBlock struct {
 	*JSONBlockSummary
 	Transactions []thor.Bytes32 `json:"transactions"`

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -292,6 +292,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/RevisionInPath'
         - $ref: '#/components/parameters/ExpandedInQuery'
+        - $ref: '#/components/parameters/RawBlockInQuery'
       tags:
         - Blocks
       summary: Retrieve a block
@@ -2349,6 +2350,18 @@ components:
         Whether the returned block is expanded. 
         - `true` returns `transactions` as an array of objects with the transaction details and outputs
         - `false` returns `transactions` as an array of transaction IDs (hex strings)
+      schema:
+        type: boolean
+      example: false
+
+    RawBlockInQuery:
+      name: raw
+      in: query
+      required: false
+      description: |
+        Whether the block should be returned in RLP encoding or not. 
+        - `true` returns `block` as an RLP encoded object
+        - `false` returns `block` as a structured JSON object
       schema:
         type: boolean
       example: false

--- a/api/utils/http.go
+++ b/api/utils/http.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 type httpError struct {
@@ -34,6 +36,17 @@ func BadRequest(cause error) error {
 		cause:  cause,
 		status: http.StatusBadRequest,
 	}
+}
+
+func StringToBoolean(boolStr string, defaultVal bool) (bool, error) {
+	if boolStr == "" {
+		return defaultVal, nil
+	} else if boolStr == "false" {
+		return false, nil
+	} else if boolStr == "true" {
+		return true, nil
+	}
+	return false, errors.New("should be boolean")
 }
 
 // Forbidden convenience method to create http forbidden error.


### PR DESCRIPTION
# Description

This PR adds a `raw` query parameter to the `/blocks` endpoint, which returns RLP encoded block.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
