### PR TITLE
Add the dynamic fee tx and support for typed txs

### DIFF
--- a/api/accounts/accounts_test.go
+++ b/api/accounts/accounts_test.go
@@ -297,16 +297,16 @@ func initAccountServer(t *testing.T) {
 	ts = httptest.NewServer(router)
 }
 
-func buildTxWithClauses(chaiTag byte, clauses ...*tx.Clause) *tx.Transaction {
+func buildTxWithClauses(chainTag byte, clauses ...*tx.Clause) *tx.Transaction {
 	builder := new(tx.Builder).
-		ChainTag(chaiTag).
+		ChainTag(chainTag).
 		Expiration(10).
 		Gas(1000000)
 	for _, c := range clauses {
 		builder.Clause(c)
 	}
 
-	trx := builder.Build()
+	trx := builder.BuildLegacy()
 
 	return tx.MustSign(trx, genesis.DevAccounts()[0].PrivateKey)
 }

--- a/api/blocks/blocks_test.go
+++ b/api/blocks/blocks_test.go
@@ -184,7 +184,7 @@ func initBlockServer(t *testing.T) {
 			Nonce(1).
 			Clause(cla).
 			BlockRef(tx.NewBlockRef(0)).
-			Build(),
+			BuildLegacy(),
 		genesis.DevAccounts()[0].PrivateKey,
 	)
 

--- a/api/blocks/types.go
+++ b/api/blocks/types.go
@@ -6,6 +6,8 @@
 package blocks
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/vechain/thor/v2/chain"
@@ -63,18 +65,20 @@ type JSONOutput struct {
 }
 
 type JSONEmbeddedTx struct {
-	ID           thor.Bytes32        `json:"id"`
-	ChainTag     byte                `json:"chainTag"`
-	BlockRef     string              `json:"blockRef"`
-	Expiration   uint32              `json:"expiration"`
-	Clauses      []*JSONClause       `json:"clauses"`
-	GasPriceCoef uint8               `json:"gasPriceCoef"`
-	Gas          uint64              `json:"gas"`
-	Origin       thor.Address        `json:"origin"`
-	Delegator    *thor.Address       `json:"delegator"`
-	Nonce        math.HexOrDecimal64 `json:"nonce"`
-	DependsOn    *thor.Bytes32       `json:"dependsOn"`
-	Size         uint32              `json:"size"`
+	ID                   thor.Bytes32        `json:"id"`
+	ChainTag             byte                `json:"chainTag"`
+	BlockRef             string              `json:"blockRef"`
+	Expiration           uint32              `json:"expiration"`
+	Clauses              []*JSONClause       `json:"clauses"`
+	GasPriceCoef         uint8               `json:"gasPriceCoef"`
+	MaxFeePerGas         *big.Int            `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas *big.Int            `json:"maxPriorityFeePerGas,omitempty"`
+	Gas                  uint64              `json:"gas"`
+	Origin               thor.Address        `json:"origin"`
+	Delegator            *thor.Address       `json:"delegator"`
+	Nonce                math.HexOrDecimal64 `json:"nonce"`
+	DependsOn            *thor.Bytes32       `json:"dependsOn"`
+	Size                 uint32              `json:"size"`
 
 	// receipt part
 	GasUsed  uint64                `json:"gasUsed"`
@@ -144,13 +148,13 @@ func buildJSONOutput(txID thor.Bytes32, index uint32, c *tx.Clause, o *tx.Output
 
 func buildJSONEmbeddedTxs(txs tx.Transactions, receipts tx.Receipts) []*JSONEmbeddedTx {
 	jTxs := make([]*JSONEmbeddedTx, 0, len(txs))
-	for itx, tx := range txs {
+	for itx, trx := range txs {
 		receipt := receipts[itx]
 
-		clauses := tx.Clauses()
-		blockRef := tx.BlockRef()
-		origin, _ := tx.Origin()
-		delegator, _ := tx.Delegator()
+		clauses := trx.Clauses()
+		blockRef := trx.BlockRef()
+		origin, _ := trx.Origin()
+		delegator, _ := trx.Delegator()
 
 		jcs := make([]*JSONClause, 0, len(clauses))
 		jos := make([]*JSONOutput, 0, len(receipt.Outputs))
@@ -162,23 +166,22 @@ func buildJSONEmbeddedTxs(txs tx.Transactions, receipts tx.Receipts) []*JSONEmbe
 				hexutil.Encode(c.Data()),
 			})
 			if !receipt.Reverted {
-				jos = append(jos, buildJSONOutput(tx.ID(), uint32(i), c, receipt.Outputs[i]))
+				jos = append(jos, buildJSONOutput(trx.ID(), uint32(i), c, receipt.Outputs[i]))
 			}
 		}
 
-		jTxs = append(jTxs, &JSONEmbeddedTx{
-			ID:           tx.ID(),
-			ChainTag:     tx.ChainTag(),
-			BlockRef:     hexutil.Encode(blockRef[:]),
-			Expiration:   tx.Expiration(),
-			Clauses:      jcs,
-			GasPriceCoef: tx.GasPriceCoef(),
-			Gas:          tx.Gas(),
-			Origin:       origin,
-			Delegator:    delegator,
-			Nonce:        math.HexOrDecimal64(tx.Nonce()),
-			DependsOn:    tx.DependsOn(),
-			Size:         uint32(tx.Size()),
+		embedTx := &JSONEmbeddedTx{
+			ID:         trx.ID(),
+			ChainTag:   trx.ChainTag(),
+			BlockRef:   hexutil.Encode(blockRef[:]),
+			Expiration: trx.Expiration(),
+			Clauses:    jcs,
+			Gas:        trx.Gas(),
+			Origin:     origin,
+			Delegator:  delegator,
+			Nonce:      math.HexOrDecimal64(trx.Nonce()),
+			DependsOn:  trx.DependsOn(),
+			Size:       uint32(trx.Size()),
 
 			GasUsed:  receipt.GasUsed,
 			GasPayer: receipt.GasPayer,
@@ -186,7 +189,14 @@ func buildJSONEmbeddedTxs(txs tx.Transactions, receipts tx.Receipts) []*JSONEmbe
 			Reward:   (*math.HexOrDecimal256)(receipt.Reward),
 			Reverted: receipt.Reverted,
 			Outputs:  jos,
-		})
+		}
+		if trx.Type() == tx.LegacyTxType {
+			embedTx.GasPriceCoef = trx.GasPriceCoef()
+		} else {
+			embedTx.MaxFeePerGas = trx.MaxFeePerGas()
+			embedTx.MaxPriorityFeePerGas = trx.MaxPriorityFeePerGas()
+		}
+		jTxs = append(jTxs, embedTx)
 	}
 	return jTxs
 }

--- a/api/debug/debug_test.go
+++ b/api/debug/debug_test.go
@@ -523,7 +523,7 @@ func initDebugServer(t *testing.T) {
 		ChainTag(thorChain.Repo().ChainTag()).
 		Expiration(10).
 		Gas(21000).
-		Build()
+		BuildLegacy()
 	noClausesTx = tx.MustSign(noClausesTx, genesis.DevAccounts()[0].PrivateKey)
 
 	cla := tx.NewClause(&addr).WithValue(big.NewInt(10000))
@@ -537,7 +537,7 @@ func initDebugServer(t *testing.T) {
 		Clause(cla).
 		Clause(cla2).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 	transaction = tx.MustSign(transaction, genesis.DevAccounts()[0].PrivateKey)
 
 	require.NoError(t, thorChain.MintTransactions(genesis.DevAccounts()[0], transaction, noClausesTx))

--- a/api/subscriptions/block_reader_test.go
+++ b/api/subscriptions/block_reader_test.go
@@ -72,7 +72,7 @@ func initChain(t *testing.T) *testchain.Chain {
 		Nonce(1).
 		Clause(cla).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 	tr = tx.MustSign(tr, genesis.DevAccounts()[0].PrivateKey)
 
 	txDeploy := new(tx.Builder).
@@ -83,7 +83,7 @@ func initChain(t *testing.T) *testchain.Chain {
 		Nonce(3).
 		Clause(tx.NewClause(nil).WithData(common.Hex2Bytes(eventcontract.HexBytecode))).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 	sigTxDeploy, err := crypto.Sign(txDeploy.SigningHash().Bytes(), genesis.DevAccounts()[1].PrivateKey)
 	require.NoError(t, err)
 	txDeploy = txDeploy.WithSignature(sigTxDeploy)

--- a/api/subscriptions/pending_tx_test.go
+++ b/api/subscriptions/pending_tx_test.go
@@ -154,7 +154,7 @@ func createTx(repo *chain.Repository, addressNumber uint) *tx.Transaction {
 			Nonce(1).
 			Clause(cla).
 			BlockRef(tx.NewBlockRef(0)).
-			Build(),
+			BuildLegacy(),
 		genesis.DevAccounts()[addressNumber].PrivateKey,
 	)
 }

--- a/api/subscriptions/subscriptions_test.go
+++ b/api/subscriptions/subscriptions_test.go
@@ -236,7 +236,7 @@ func initSubscriptionsServer(t *testing.T) {
 		Nonce(1).
 		Clause(cla).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 
 	sig, err := crypto.Sign(tr.SigningHash().Bytes(), genesis.DevAccounts()[0].PrivateKey)
 	if err != nil {
@@ -252,7 +252,7 @@ func initSubscriptionsServer(t *testing.T) {
 		Nonce(3).
 		Clause(tx.NewClause(nil).WithData(common.Hex2Bytes(eventcontract.HexBytecode))).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 	sigTxDeploy, err := crypto.Sign(txDeploy.SigningHash().Bytes(), genesis.DevAccounts()[1].PrivateKey)
 	require.NoError(t, err)
 	txDeploy = txDeploy.WithSignature(sigTxDeploy)
@@ -288,7 +288,7 @@ func TestSubscriptionsBacktrace(t *testing.T) {
 		Nonce(1).
 		Clause(cla).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 
 	sig, err := crypto.Sign(tr.SigningHash().Bytes(), genesis.DevAccounts()[0].PrivateKey)
 	if err != nil {
@@ -304,7 +304,7 @@ func TestSubscriptionsBacktrace(t *testing.T) {
 		Nonce(3).
 		Clause(tx.NewClause(nil).WithData(common.Hex2Bytes(eventcontract.HexBytecode))).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 	sigTxDeploy, err := crypto.Sign(txDeploy.SigningHash().Bytes(), genesis.DevAccounts()[1].PrivateKey)
 	require.NoError(t, err)
 	txDeploy = txDeploy.WithSignature(sigTxDeploy)

--- a/api/subscriptions/types_test.go
+++ b/api/subscriptions/types_test.go
@@ -102,7 +102,7 @@ func TestConvertTransfer(t *testing.T) {
 		Gas(21000).
 		Nonce(1).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 	transaction = tx.MustSign(transaction, genesis.DevAccounts()[0].PrivateKey)
 
 	// New block
@@ -150,7 +150,7 @@ func TestConvertEventWithBadSignature(t *testing.T) {
 		Gas(21000).
 		Nonce(1).
 		BlockRef(tx.NewBlockRef(0)).
-		Build().
+		BuildLegacy().
 		WithSignature(badSig[:])
 
 	// New block
@@ -190,7 +190,7 @@ func TestConvertEvent(t *testing.T) {
 			Gas(21000).
 			Nonce(1).
 			BlockRef(tx.NewBlockRef(0)).
-			Build(),
+			BuildLegacy(),
 		genesis.DevAccounts()[0].PrivateKey,
 	)
 

--- a/api/transactions/transactions_test.go
+++ b/api/transactions/transactions_test.go
@@ -29,11 +29,12 @@ import (
 )
 
 var (
-	ts          *httptest.Server
-	transaction *tx.Transaction
-	mempoolTx   *tx.Transaction
-	tclient     *thorclient.Client
-	chainTag    byte
+	ts        *httptest.Server
+	legacyTx  *tx.Transaction
+	dynFeeTx  *tx.Transaction
+	mempoolTx *tx.Transaction
+	tclient   *thorclient.Client
+	chainTag  byte
 )
 
 func TestTransaction(t *testing.T) {
@@ -43,16 +44,18 @@ func TestTransaction(t *testing.T) {
 	// Send tx
 	tclient = thorclient.New(ts.URL)
 	for name, tt := range map[string]func(*testing.T){
-		"sendTx":              sendTx,
-		"sendTxWithBadFormat": sendTxWithBadFormat,
+		"sendLegacyTx":                             sendLegacyTx,
+		"sendTxWithBadFormat":                      sendTxWithBadFormat,
 		"sendTxThatCannotBeAcceptedInLocalMempool": sendTxThatCannotBeAcceptedInLocalMempool,
+
+		"sendDynamicFeeTx": sendDynamicFeeTx,
 	} {
 		t.Run(name, tt)
 	}
 
 	// Get tx
 	for name, tt := range map[string]func(*testing.T){
-		"getTx":           getTx,
+		"getLegacyTx":     getLegacyTx,
 		"getTxWithBadID":  getTxWithBadID,
 		"txWithBadHeader": txWithBadHeader,
 		"getNonExistingRawTransactionWhenTxStillInMempool": getNonExistingRawTransactionWhenTxStillInMempool,
@@ -62,6 +65,8 @@ func TestTransaction(t *testing.T) {
 		"getTransactionByIDPendingTxNotFound":              getTransactionByIDPendingTxNotFound,
 		"handleGetTransactionByIDWithBadQueryParams":       handleGetTransactionByIDWithBadQueryParams,
 		"handleGetTransactionByIDWithNonExistingHead":      handleGetTransactionByIDWithNonExistingHead,
+
+		"getDynamicFeeTx": getDynamicFeeTx,
 	} {
 		t.Run(name, tt)
 	}
@@ -76,20 +81,40 @@ func TestTransaction(t *testing.T) {
 	}
 }
 
-func getTx(t *testing.T) {
-	res := httpGetAndCheckResponseStatus(t, "/transactions/"+transaction.ID().String(), 200)
+func getLegacyTx(t *testing.T) {
+	res := httpGetAndCheckResponseStatus(t, "/transactions/"+legacyTx.ID().String(), 200)
 	var rtx *transactions.Transaction
 	if err := json.Unmarshal(res, &rtx); err != nil {
 		t.Fatal(err)
 	}
-	checkMatchingTx(t, transaction, rtx)
+	checkMatchingTx(t, legacyTx, rtx)
 
-	res = httpGetAndCheckResponseStatus(t, "/transactions/"+transaction.ID().String()+"?raw=true", 200)
+	res = httpGetAndCheckResponseStatus(t, "/transactions/"+legacyTx.ID().String()+"?raw=true", 200)
 	var rawTx map[string]interface{}
 	if err := json.Unmarshal(res, &rawTx); err != nil {
 		t.Fatal(err)
 	}
-	rlpTx, err := rlp.EncodeToBytes(transaction)
+	rlpTx, err := rlp.EncodeToBytes(legacyTx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, hexutil.Encode(rlpTx), rawTx["raw"], "should be equal raw")
+}
+
+func getDynamicFeeTx(t *testing.T) {
+	res := httpGetAndCheckResponseStatus(t, "/transactions/"+dynFeeTx.ID().String(), 200)
+	var rtx *transactions.Transaction
+	if err := json.Unmarshal(res, &rtx); err != nil {
+		t.Fatal(err)
+	}
+	checkMatchingTx(t, dynFeeTx, rtx)
+
+	res = httpGetAndCheckResponseStatus(t, "/transactions/"+dynFeeTx.ID().String()+"?raw=true", 200)
+	var rawTx map[string]interface{}
+	if err := json.Unmarshal(res, &rawTx); err != nil {
+		t.Fatal(err)
+	}
+	rlpTx, err := rlp.EncodeToBytes(dynFeeTx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,15 +122,15 @@ func getTx(t *testing.T) {
 }
 
 func getTxReceipt(t *testing.T) {
-	r := httpGetAndCheckResponseStatus(t, "/transactions/"+transaction.ID().String()+"/receipt", 200)
+	r := httpGetAndCheckResponseStatus(t, "/transactions/"+legacyTx.ID().String()+"/receipt", 200)
 	var receipt *transactions.Receipt
 	if err := json.Unmarshal(r, &receipt); err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, receipt.GasUsed, transaction.Gas(), "receipt gas used not equal to transaction gas")
+	assert.Equal(t, receipt.GasUsed, legacyTx.Gas(), "receipt gas used not equal to transaction gas")
 }
 
-func sendTx(t *testing.T) {
+func sendLegacyTx(t *testing.T) {
 	var blockRef = tx.NewBlockRef(0)
 	var expiration = uint32(10)
 	var gas = uint64(21000)
@@ -116,11 +141,41 @@ func sendTx(t *testing.T) {
 			ChainTag(chainTag).
 			Expiration(expiration).
 			Gas(gas).
-			Build(),
+			BuildLegacy(),
 		genesis.DevAccounts()[0].PrivateKey,
 	)
 
-	rlpTx, err := rlp.EncodeToBytes(trx)
+	rlpTx, err := trx.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := httpPostAndCheckResponseStatus(t, "/transactions", transactions.RawTx{Raw: hexutil.Encode(rlpTx)}, 200)
+	var txObj map[string]string
+	if err = json.Unmarshal(res, &txObj); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, trx.ID().String(), txObj["id"], "should be the same transaction id")
+}
+
+func sendDynamicFeeTx(t *testing.T) {
+	var blockRef = tx.NewBlockRef(0)
+	var expiration = uint32(10)
+	var gas = uint64(21000)
+	var maxFeePerGas = big.NewInt(128)
+
+	trx := tx.MustSign(
+		new(tx.Builder).
+			BlockRef(blockRef).
+			ChainTag(chainTag).
+			Expiration(expiration).
+			Gas(gas).
+			MaxFeePerGas(maxFeePerGas).
+			BuildDynamicFee(),
+		genesis.DevAccounts()[0].PrivateKey,
+	)
+
+	rlpTx, err := trx.MarshalBinary()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,8 +198,8 @@ func getTxWithBadID(t *testing.T) {
 
 func txWithBadHeader(t *testing.T) {
 	badHeaderURL := []string{
-		"/transactions/" + transaction.ID().String() + "?head=badHead",
-		"/transactions/" + transaction.ID().String() + "/receipt?head=badHead",
+		"/transactions/" + legacyTx.ID().String() + "?head=badHead",
+		"/transactions/" + legacyTx.ID().String() + "/receipt?head=badHead",
 	}
 
 	for _, url := range badHeaderURL {
@@ -223,7 +278,7 @@ func sendTxWithBadFormat(t *testing.T) {
 }
 
 func sendTxThatCannotBeAcceptedInLocalMempool(t *testing.T) {
-	tx := new(tx.Builder).Build()
+	tx := new(tx.Builder).BuildLegacy()
 	rlpTx, err := rlp.EncodeToBytes(tx)
 	if err != nil {
 		t.Fatal(err)
@@ -242,18 +297,18 @@ func handleGetTransactionByIDWithBadQueryParams(t *testing.T) {
 	}
 
 	for _, badQueryParam := range badQueryParams {
-		res := httpGetAndCheckResponseStatus(t, "/transactions/"+transaction.ID().String()+badQueryParam, 400)
+		res := httpGetAndCheckResponseStatus(t, "/transactions/"+legacyTx.ID().String()+badQueryParam, 400)
 		assert.Contains(t, string(res), "should be boolean")
 	}
 }
 
 func handleGetTransactionByIDWithNonExistingHead(t *testing.T) {
-	res := httpGetAndCheckResponseStatus(t, "/transactions/"+transaction.ID().String()+"?head=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 400)
+	res := httpGetAndCheckResponseStatus(t, "/transactions/"+legacyTx.ID().String()+"?head=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 400)
 	assert.Equal(t, "head: leveldb: not found", strings.TrimSpace(string(res)))
 }
 
 func handleGetTransactionReceiptByIDWithNonExistingHead(t *testing.T) {
-	res := httpGetAndCheckResponseStatus(t, "/transactions/"+transaction.ID().String()+"/receipt?head=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 400)
+	res := httpGetAndCheckResponseStatus(t, "/transactions/"+legacyTx.ID().String()+"/receipt?head=0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 400)
 	assert.Equal(t, "head: leveldb: not found", strings.TrimSpace(string(res)))
 }
 
@@ -273,7 +328,7 @@ func initTransactionServer(t *testing.T) {
 
 	addr := thor.BytesToAddress([]byte("to"))
 	cla := tx.NewClause(&addr).WithValue(big.NewInt(10000))
-	transaction = new(tx.Builder).
+	legacyTx = new(tx.Builder).
 		ChainTag(chainTag).
 		GasPriceCoef(1).
 		Expiration(10).
@@ -281,10 +336,22 @@ func initTransactionServer(t *testing.T) {
 		Nonce(1).
 		Clause(cla).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
-	transaction = tx.MustSign(transaction, genesis.DevAccounts()[0].PrivateKey)
+		BuildLegacy()
+	legacyTx = tx.MustSign(legacyTx, genesis.DevAccounts()[0].PrivateKey)
 
-	require.NoError(t, thorChain.MintTransactions(genesis.DevAccounts()[0], transaction))
+	dynFeeTx = new(tx.Builder).
+		ChainTag(chainTag).
+		MaxFeePerGas(new(big.Int).SetInt64(1)).
+		MaxPriorityFeePerGas(new(big.Int).SetInt64(10)).
+		Expiration(10).
+		Gas(21000).
+		Nonce(1).
+		Clause(cla).
+		BlockRef(tx.NewBlockRef(0)).
+		BuildDynamicFee()
+	dynFeeTx = tx.MustSign(dynFeeTx, genesis.DevAccounts()[0].PrivateKey)
+
+	require.NoError(t, thorChain.MintTransactions(genesis.DevAccounts()[0], legacyTx, dynFeeTx))
 
 	mempool := txpool.New(thorChain.Repo(), thorChain.Stater(), txpool.Options{Limit: 10000, LimitPerAccount: 16, MaxLifetime: 10 * time.Minute})
 
@@ -293,7 +360,7 @@ func initTransactionServer(t *testing.T) {
 		Expiration(10).
 		Gas(21000).
 		Nonce(1).
-		Build()
+		BuildLegacy()
 	mempoolTx = tx.MustSign(mempoolTx, genesis.DevAccounts()[0].PrivateKey)
 
 	// Add a tx to the mempool to have both pending and non-pending transactions
@@ -316,6 +383,8 @@ func checkMatchingTx(t *testing.T, expectedTx *tx.Transaction, actualTx *transac
 	assert.Equal(t, origin, actualTx.Origin)
 	assert.Equal(t, expectedTx.ID(), actualTx.ID)
 	assert.Equal(t, expectedTx.GasPriceCoef(), actualTx.GasPriceCoef)
+	assert.Equal(t, expectedTx.MaxFeePerGas(), actualTx.MaxFeePerGas)
+	assert.Equal(t, expectedTx.MaxPriorityFeePerGas(), actualTx.MaxPriorityFeePerGas)
 	assert.Equal(t, expectedTx.Gas(), actualTx.Gas)
 	for i, c := range expectedTx.Clauses() {
 		assert.Equal(t, hexutil.Encode(c.Data()), actualTx.Clauses[i].Data)

--- a/api/transactions/types_test.go
+++ b/api/transactions/types_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestErrorWhileRetrievingTxOriginInConvertReceipt(t *testing.T) {
-	tr := &tx.Transaction{}
+	tr := new(tx.Builder).BuildLegacy()
 	header := &block.Header{}
 	receipt := &tx.Receipt{
 		Reward: big.NewInt(100),
@@ -102,7 +102,7 @@ func newReceipt() *tx.Receipt {
 func newTx(clause *tx.Clause) *tx.Transaction {
 	tx := new(tx.Builder).
 		Clause(clause).
-		Build()
+		BuildLegacy()
 	pk, _ := crypto.GenerateKey()
 	sig, _ := crypto.Sign(tx.SigningHash().Bytes(), pk)
 	return tx.WithSignature(sig)

--- a/block/block_test.go
+++ b/block/block_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 func TestBlock(t *testing.T) {
-	tx1 := new(tx.Builder).Clause(tx.NewClause(&thor.Address{})).Clause(tx.NewClause(&thor.Address{})).Build()
-	tx2 := new(tx.Builder).Clause(tx.NewClause(nil)).Build()
+	tx1 := new(tx.Builder).Clause(tx.NewClause(&thor.Address{})).Clause(tx.NewClause(&thor.Address{})).BuildLegacy()
+	tx2 := new(tx.Builder).Clause(tx.NewClause(nil)).BuildLegacy()
 
 	privKey := string("dce1443bd2ef0c2631adc1c67e5c93f13dc23a41c18b536effbbdcbcdb96fb65")
 

--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func newTx() *tx.Transaction {
-	tx := new(tx.Builder).Build()
+	tx := new(tx.Builder).BuildLegacy()
 	pk, _ := crypto.GenerateKey()
 	sig, _ := crypto.Sign(tx.SigningHash().Bytes(), pk)
 	return tx.WithSignature(sig)

--- a/chain/repository_test.go
+++ b/chain/repository_test.go
@@ -71,7 +71,7 @@ func TestRepository(t *testing.T) {
 	assert.Equal(t, b0summary, repo1.BestBlockSummary())
 	assert.Equal(t, repo1.GenesisBlock().Header().ID()[31], repo1.ChainTag())
 
-	tx1 := new(tx.Builder).Build()
+	tx1 := new(tx.Builder).BuildLegacy()
 	receipt1 := &tx.Receipt{}
 
 	b1 := newBlock(repo1.GenesisBlock(), 10, tx1)

--- a/cmd/thor/node/node_benchmark_test.go
+++ b/cmd/thor/node/node_benchmark_test.go
@@ -270,7 +270,7 @@ func createOneClausePerTx(signerPK *ecdsa.PrivateKey, thorChain *testchain.Chain
 			Nonce(uint64(datagen.RandInt())).
 			Clause(cla).
 			BlockRef(tx.NewBlockRef(0)).
-			Build()
+			BuildLegacy()
 
 		sig, err := crypto.Sign(transaction.SigningHash().Bytes(), signerPK)
 		if err != nil {
@@ -301,7 +301,7 @@ func createManyClausesPerTx(signerPK *ecdsa.PrivateKey, thorChain *testchain.Cha
 		transactionBuilder.Clause(tx.NewClause(&toAddr).WithValue(big.NewInt(10000)))
 	}
 
-	transaction := transactionBuilder.Gas(gasUsed).Build()
+	transaction := transactionBuilder.Gas(gasUsed).BuildLegacy()
 
 	sig, err := crypto.Sign(transaction.SigningHash().Bytes(), signerPK)
 	if err != nil {

--- a/cmd/thor/node/tx_stash.go
+++ b/cmd/thor/node/tx_stash.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"container/list"
 
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
 	"github.com/vechain/thor/v2/thor"
@@ -37,7 +36,7 @@ func (ts *txStash) Save(tx *tx.Transaction) error {
 		return nil
 	}
 
-	data, err := rlp.EncodeToBytes(tx)
+	data, err := tx.MarshalBinary()
 	if err != nil {
 		return err
 	}
@@ -66,7 +65,7 @@ func (ts *txStash) LoadAll() tx.Transactions {
 
 	for it.Next() {
 		var tx tx.Transaction
-		if err := rlp.DecodeBytes(it.Value(), &tx); err != nil {
+		if err := tx.UnmarshalBinary(it.Value()); err != nil {
 			logger.Warn("decode stashed tx", "err", err)
 			batch.Delete(it.Key())
 		} else {

--- a/cmd/thor/node/tx_stash_test.go
+++ b/cmd/thor/node/tx_stash_test.go
@@ -18,9 +18,16 @@ import (
 	"github.com/vechain/thor/v2/tx"
 )
 
-func newTx() *tx.Transaction {
+func newLegacyTx() *tx.Transaction {
 	return tx.MustSign(
-		new(tx.Builder).Nonce(rand.Uint64()).Build(), //#nosec
+		new(tx.Builder).Nonce(rand.Uint64()).BuildLegacy(), //#nosec
+		genesis.DevAccounts()[0].PrivateKey,
+	)
+}
+
+func newDynFeeTx() *tx.Transaction {
+	return tx.MustSign(
+		new(tx.Builder).Nonce(rand.Uint64()).BuildDynamicFee(), //#nosec
 		genesis.DevAccounts()[0].PrivateKey,
 	)
 }
@@ -29,18 +36,24 @@ func TestTxStash(t *testing.T) {
 	db, _ := leveldb.Open(storage.NewMemStorage(), nil)
 	defer db.Close()
 
-	stash := newTxStash(db, 10)
+	stash := newTxStash(db, 20)
 
 	var saved tx.Transactions
 	for i := 0; i < 11; i++ {
-		tx := newTx()
+		tx := newLegacyTx()
 		assert.Nil(t, stash.Save(tx))
 		saved = append(saved, tx)
 	}
 
-	loaded := newTxStash(db, 10).LoadAll()
+	for i := 0; i < 11; i++ {
+		tx := newDynFeeTx()
+		assert.Nil(t, stash.Save(tx))
+		saved = append(saved, tx)
+	}
 
-	saved = saved[1:]
+	loaded := newTxStash(db, 20).LoadAll()
+
+	saved = saved[2:]
 	sort.Slice(saved, func(i, j int) bool {
 		return bytes.Compare(saved[i].ID().Bytes(), saved[j].ID().Bytes()) < 0
 	})

--- a/cmd/thor/solo/solo.go
+++ b/cmd/thor/solo/solo.go
@@ -265,6 +265,6 @@ func (s *Solo) newTx(clauses []*tx.Clause, from genesis.DevAccount) (*tx.Transac
 		Nonce(rand.Uint64()). //#nosec G404
 		DependsOn(nil).
 		Gas(1_000_000).
-		Build()
+		BuildLegacy()
 	return tx.Sign(trx, from.PrivateKey)
 }

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -39,7 +39,7 @@ func txBuilder(tag byte) *tx.Builder {
 }
 
 func txSign(builder *tx.Builder) *tx.Transaction {
-	transaction := builder.Build()
+	transaction := builder.BuildLegacy()
 	sig, _ := crypto.Sign(transaction.SigningHash().Bytes(), genesis.DevAccounts()[0].PrivateKey)
 	return transaction.WithSignature(sig)
 }
@@ -626,7 +626,7 @@ func TestValidateBlockBody(t *testing.T) {
 		{
 			"TxOriginBlocked", func(t *testing.T) {
 				thor.MockBlocklist([]string{genesis.DevAccounts()[9].Address.String()})
-				trx := txBuilder(tc.tag).Build()
+				trx := txBuilder(tc.tag).BuildLegacy()
 				trx = tx.MustSign(trx, genesis.DevAccounts()[9].PrivateKey)
 
 				blk, err := tc.sign(
@@ -644,7 +644,7 @@ func TestValidateBlockBody(t *testing.T) {
 		},
 		{
 			"TxSignerUnavailable", func(t *testing.T) {
-				tx := txBuilder(tc.tag).Build()
+				tx := txBuilder(tc.tag).BuildLegacy()
 				var sig [65]byte
 				tx = tx.WithSignature(sig[:])
 
@@ -663,7 +663,7 @@ func TestValidateBlockBody(t *testing.T) {
 		},
 		{
 			"UnsupportedFeatures", func(t *testing.T) {
-				tx := txBuilder(tc.tag).Features(tx.Features(2)).Build()
+				tx := txBuilder(tc.tag).Features(tx.Features(2)).BuildLegacy()
 				sig, _ := crypto.Sign(tx.SigningHash().Bytes(), genesis.DevAccounts()[2].PrivateKey)
 				tx = tx.WithSignature(sig)
 

--- a/logdb/logdb_test.go
+++ b/logdb/logdb_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func newTx() *tx.Transaction {
-	tx := new(tx.Builder).Build()
+	tx := new(tx.Builder).BuildLegacy()
 	pk, _ := crypto.GenerateKey()
 
 	sig, _ := crypto.Sign(tx.Hash().Bytes(), pk)

--- a/packer/flow_test.go
+++ b/packer/flow_test.go
@@ -32,7 +32,7 @@ func createTx(chainTag byte, gasPriceCoef uint8, expiration uint32, gas uint64, 
 		Clause(clause).
 		BlockRef(br)
 
-	transaction := builder.Build()
+	transaction := builder.BuildLegacy()
 
 	signature, _ := crypto.Sign(transaction.SigningHash().Bytes(), genesis.DevAccounts()[0].PrivateKey)
 

--- a/packer/packer_test.go
+++ b/packer/packer_test.go
@@ -53,7 +53,7 @@ func (ti *txIterator) Next() *tx.Transaction {
 	trx := new(tx.Builder).
 		ChainTag(ti.chainTag).
 		Clause(tx.NewClause(&builtin.Energy.Address).WithData(data)).
-		Gas(300000).GasPriceCoef(0).Nonce(nonce).Expiration(math.MaxUint32).Build()
+		Gas(300000).GasPriceCoef(0).Nonce(nonce).Expiration(math.MaxUint32).BuildLegacy()
 	trx = tx.MustSign(trx, a0.PrivateKey)
 	nonce++
 
@@ -210,7 +210,7 @@ func TestBlocklist(t *testing.T) {
 	tx0 := new(tx.Builder).
 		ChainTag(repo.ChainTag()).
 		Clause(tx.NewClause(&a1.Address)).
-		Gas(300000).GasPriceCoef(0).Nonce(0).Expiration(math.MaxUint32).Build()
+		Gas(300000).GasPriceCoef(0).Nonce(0).Expiration(math.MaxUint32).BuildLegacy()
 	sig0, _ := crypto.Sign(tx0.SigningHash().Bytes(), a0.PrivateKey)
 	tx0 = tx0.WithSignature(sig0)
 

--- a/runtime/resolved_tx_test.go
+++ b/runtime/resolved_tx_test.go
@@ -80,7 +80,7 @@ func (tr *testResolvedTransaction) TestResolveTransaction() {
 		return txBuilder(tr.repo.ChainTag())
 	}
 
-	_, err := runtime.ResolveTransaction(txBuild().Build())
+	_, err := runtime.ResolveTransaction(txBuild().BuildLegacy())
 	tr.assert.Equal(secp256k1.ErrInvalidSignatureLen.Error(), err.Error())
 
 	_, err = runtime.ResolveTransaction(txSign(txBuild().Gas(21000 - 1)))
@@ -185,6 +185,6 @@ func txBuilder(tag byte) *tx.Builder {
 }
 
 func txSign(builder *tx.Builder) *tx.Transaction {
-	transaction := builder.Build()
+	transaction := builder.BuildLegacy()
 	return tx.MustSign(transaction, genesis.DevAccounts()[0].PrivateKey)
 }

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -404,7 +404,7 @@ func GetMockTx(repo *chain.Repository, t *testing.T) tx.Transaction {
 		Clause(tx.NewClause(&to).WithValue(big.NewInt(20000)).WithData([]byte{0, 0, 0, 0x60, 0x60, 0x60})).
 		Expiration(expiration).
 		Gas(gas).
-		Build()
+		BuildLegacy()
 	sig, err := crypto.Sign(tx.SigningHash().Bytes(), genesis.DevAccounts()[0].PrivateKey)
 	if err != nil {
 		t.Fatal(err)
@@ -424,7 +424,7 @@ func GetMockFailedTx() tx.Transaction {
 		GasPriceCoef(128).
 		Gas(21000).
 		DependsOn(nil).
-		Nonce(12345678).Build()
+		Nonce(12345678).BuildLegacy()
 
 	return *trx
 }

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -82,7 +82,7 @@ func mintTransactions(t *testing.T, thorChain *testchain.Chain) {
 		ChainTag(thorChain.Repo().ChainTag()).
 		Expiration(10).
 		Gas(21000).
-		Build()
+		BuildLegacy()
 	sig, err := crypto.Sign(noClausesTx.SigningHash().Bytes(), genesis.DevAccounts()[0].PrivateKey)
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func mintTransactions(t *testing.T, thorChain *testchain.Chain) {
 		Clause(cla).
 		Clause(cla2).
 		BlockRef(tx.NewBlockRef(0)).
-		Build()
+		BuildLegacy()
 
 	sig, err = crypto.Sign(transaction.SigningHash().Bytes(), genesis.DevAccounts()[0].PrivateKey)
 	if err != nil {

--- a/thorclient/thorclient_test.go
+++ b/thorclient/thorclient_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestConvertToBatchCallData(t *testing.T) {
 	// Test case 1: Empty transaction
-	tx1 := &tx.Transaction{}
+	tx1 := tx.NewTx(&tx.LegacyTransaction{})
 	addr1 := &thor.Address{}
 	expected1 := &accounts.BatchCallData{
 		Clauses:    make(accounts.Clauses, 0),

--- a/tx/builder.go
+++ b/tx/builder.go
@@ -7,76 +7,105 @@ package tx
 
 import (
 	"encoding/binary"
+	"math/big"
 
 	"github.com/vechain/thor/v2/thor"
 )
 
 // Builder to make it easy to build transaction.
 type Builder struct {
-	body body
+	legacyTx     LegacyTransaction
+	dynamicFeeTx DynamicFeeTransaction
 }
 
 // ChainTag set chain tag.
 func (b *Builder) ChainTag(tag byte) *Builder {
-	b.body.ChainTag = tag
+	b.legacyTx.ChainTag = tag
+	b.dynamicFeeTx.ChainTag = tag
 	return b
 }
 
 // Clause add a clause.
 func (b *Builder) Clause(c *Clause) *Builder {
-	b.body.Clauses = append(b.body.Clauses, c)
+	b.legacyTx.Clauses = append(b.legacyTx.Clauses, c)
+	b.dynamicFeeTx.Clauses = append(b.dynamicFeeTx.Clauses, c)
 	return b
 }
 
 // GasPriceCoef set gas price coef.
 func (b *Builder) GasPriceCoef(coef uint8) *Builder {
-	b.body.GasPriceCoef = coef
+	b.legacyTx.GasPriceCoef = coef
 	return b
 }
 
 // Gas set gas provision for tx.
 func (b *Builder) Gas(gas uint64) *Builder {
-	b.body.Gas = gas
+	b.legacyTx.Gas = gas
+	b.dynamicFeeTx.Gas = gas
+	return b
+}
+
+// MaxFeePerGas set max fee per gas.
+func (b *Builder) MaxFeePerGas(maxFeePerGas *big.Int) *Builder {
+	b.dynamicFeeTx.MaxFeePerGas = maxFeePerGas
+	return b
+}
+
+// MaxPriorityFeePerGas set max priority fee per gas.
+func (b *Builder) MaxPriorityFeePerGas(maxPriorityFeePerGas *big.Int) *Builder {
+	b.dynamicFeeTx.MaxPriorityFeePerGas = maxPriorityFeePerGas
 	return b
 }
 
 // BlockRef set block reference.
 func (b *Builder) BlockRef(br BlockRef) *Builder {
-	b.body.BlockRef = binary.BigEndian.Uint64(br[:])
+	b.legacyTx.BlockRef = binary.BigEndian.Uint64(br[:])
+	b.dynamicFeeTx.BlockRef = binary.BigEndian.Uint64(br[:])
 	return b
 }
 
 // Expiration set expiration.
 func (b *Builder) Expiration(exp uint32) *Builder {
-	b.body.Expiration = exp
+	b.legacyTx.Expiration = exp
+	b.dynamicFeeTx.Expiration = exp
 	return b
 }
 
 // Nonce set nonce.
 func (b *Builder) Nonce(nonce uint64) *Builder {
-	b.body.Nonce = nonce
+	b.legacyTx.Nonce = nonce
+	b.dynamicFeeTx.Nonce = nonce
 	return b
 }
 
 // DependsOn set depended tx.
 func (b *Builder) DependsOn(txID *thor.Bytes32) *Builder {
 	if txID == nil {
-		b.body.DependsOn = nil
+		b.legacyTx.DependsOn = nil
+		b.dynamicFeeTx.DependsOn = nil
 	} else {
 		cpy := *txID
-		b.body.DependsOn = &cpy
+		b.legacyTx.DependsOn = &cpy
+		b.dynamicFeeTx.DependsOn = &cpy
 	}
 	return b
 }
 
 // Features set features.
 func (b *Builder) Features(feat Features) *Builder {
-	b.body.Reserved.Features = feat
+	b.legacyTx.Reserved.Features = feat
+	b.dynamicFeeTx.Reserved.Features = feat
 	return b
 }
 
-// Build build tx object.
-func (b *Builder) Build() *Transaction {
-	tx := Transaction{body: b.body}
+// BuildLegacy builds legacy tx object.
+func (b *Builder) BuildLegacy() *Transaction {
+	tx := Transaction{body: &b.legacyTx}
+	return &tx
+}
+
+// BuildDynamicFee builds dynamic fee tx object.
+func (b *Builder) BuildDynamicFee() *Transaction {
+	tx := Transaction{body: &b.dynamicFeeTx}
 	return &tx
 }

--- a/tx/hashing.go
+++ b/tx/hashing.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2018 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package tx
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/vechain/thor/v2/thor"
+)
+
+// deriveBufferPool holds temporary encoder buffers for DeriveSha and TX encoding.
+var encodeBufferPool = sync.Pool{
+	New: func() interface{} { return new(bytes.Buffer) },
+}
+
+func rlpHash(x interface{}) thor.Bytes32 {
+	return thor.Blake2bFn(func(w io.Writer) {
+		rlp.Encode(w, x)
+	})
+}
+
+// prefixedRlpHash writes the prefix into the hasher before rlp-encoding the
+// given interface. It's used for typed transactions.
+func prefixedRlpHash(prefix byte, x interface{}) thor.Bytes32 {
+	return thor.Blake2bFn(func(w io.Writer) {
+		w.Write([]byte{prefix})
+		rlp.Encode(w, x)
+	})
+}

--- a/tx/signer_test.go
+++ b/tx/signer_test.go
@@ -19,7 +19,7 @@ func TestSign(t *testing.T) {
 	pk, err := crypto.GenerateKey()
 	assert.NoError(t, err)
 
-	tx := new(Builder).Build()
+	tx := new(Builder).BuildLegacy()
 
 	// Sign the transaction
 	signedTx, err := Sign(tx, pk)
@@ -47,7 +47,7 @@ func TestSignDelegated(t *testing.T) {
 	originPK, err := crypto.GenerateKey()
 	assert.NoError(t, err)
 
-	tx := new(Builder).Build()
+	tx := new(Builder).BuildLegacy()
 
 	// Feature not enabled
 	signedTx, err := SignDelegated(tx, originPK, delegatorPK)
@@ -57,7 +57,7 @@ func TestSignDelegated(t *testing.T) {
 	// enable the feature
 	var features Features
 	features.SetDelegated(true)
-	tx = new(Builder).Features(features).Build()
+	tx = new(Builder).Features(features).BuildLegacy()
 
 	// Sign the transaction as a delegator
 	signedTx, err = SignDelegated(tx, originPK, delegatorPK)

--- a/tx/transaction.go
+++ b/tx/transaction.go
@@ -24,11 +24,19 @@ import (
 
 var (
 	errIntrinsicGasOverflow = errors.New("intrinsic gas overflow")
+	ErrInvalidTxType        = errors.New("transaction type not valid in this context")
+	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
+	errEmptyTypedTx         = errors.New("empty typed transaction bytes")
+)
+
+const (
+	LegacyTxType     = 0x00
+	DynamicFeeTxType = 0x01
 )
 
 // Transaction is an immutable tx type.
 type Transaction struct {
-	body body
+	body TxData
 
 	cache struct {
 		signingHash  atomic.Value
@@ -42,33 +50,53 @@ type Transaction struct {
 	}
 }
 
-// body describes details of a tx.
-type body struct {
-	ChainTag     byte
-	BlockRef     uint64
-	Expiration   uint32
-	Clauses      []*Clause
-	GasPriceCoef uint8
-	Gas          uint64
-	DependsOn    *thor.Bytes32 `rlp:"nil"`
-	Nonce        uint64
-	Reserved     reserved
-	Signature    []byte
+// TxData describes details of a tx.
+type TxData interface {
+	txType() byte
+	copy() TxData
+
+	chainTag() byte
+	blockRef() uint64
+	expiration() uint32
+	clauses() []*Clause
+	gasPriceCoef() uint8
+	gas() uint64
+	maxFeePerGas() *big.Int
+	maxPriorityFeePerGas() *big.Int
+	dependsOn() *thor.Bytes32
+	nonce() uint64
+	reserved() reserved
+	signature() []byte
+	setSignature(sig []byte)
+
+	encode(w io.Writer) error
+}
+
+// NewTx creates a new transaction.
+func NewTx(body TxData) *Transaction {
+	tx := new(Transaction)
+	tx.setDecoded(body.copy(), 0)
+	return tx
+}
+
+// Type returns the transaction type.
+func (tx *Transaction) Type() uint8 {
+	return tx.body.txType()
 }
 
 // ChainTag returns chain tag.
 func (t *Transaction) ChainTag() byte {
-	return t.body.ChainTag
+	return t.body.chainTag()
 }
 
 // Nonce returns nonce value.
 func (t *Transaction) Nonce() uint64 {
-	return t.body.Nonce
+	return t.body.nonce()
 }
 
 // BlockRef returns block reference, which is first 8 bytes of block hash.
 func (t *Transaction) BlockRef() (br BlockRef) {
-	binary.BigEndian.PutUint64(br[:], t.body.BlockRef)
+	binary.BigEndian.PutUint64(br[:], t.body.blockRef())
 	return
 }
 
@@ -76,12 +104,12 @@ func (t *Transaction) BlockRef() (br BlockRef) {
 // A valid transaction requires:
 // blockNum in [blockRef.Num... blockRef.Num + Expiration]
 func (t *Transaction) Expiration() uint32 {
-	return t.body.Expiration
+	return t.body.expiration()
 }
 
 // IsExpired returns whether the tx is expired according to the given blockNum.
 func (t *Transaction) IsExpired(blockNum uint32) bool {
-	return uint64(blockNum) > uint64(t.BlockRef().Number())+uint64(t.body.Expiration) // cast to uint64 to prevent potential overflow
+	return uint64(blockNum) > uint64(t.BlockRef().Number())+uint64(t.body.expiration()) // cast to uint64 to prevent potential overflow
 }
 
 // ID returns id of tx.
@@ -107,9 +135,11 @@ func (t *Transaction) Hash() (hash thor.Bytes32) {
 		return cached.(thor.Bytes32)
 	}
 	defer func() { t.cache.hash.Store(hash) }()
-	return thor.Blake2bFn(func(w io.Writer) {
-		rlp.Encode(w, t)
-	})
+
+	if t.Type() == LegacyTxType {
+		return rlpHash(t)
+	}
+	return prefixedRlpHash(t.Type(), t.body)
 }
 
 // UnprovedWork returns unproved work of this tx.
@@ -126,24 +156,20 @@ func (t *Transaction) UnprovedWork() (w *big.Int) {
 	if err != nil {
 		return &big.Int{}
 	}
-	return t.EvaluateWork(origin)(t.body.Nonce)
+	return t.EvaluateWork(origin)(t.body.nonce())
 }
 
 // EvaluateWork try to compute work when tx origin assumed.
 func (t *Transaction) EvaluateWork(origin thor.Address) func(nonce uint64) *big.Int {
-	hashWithoutNonce := thor.Blake2bFn(func(w io.Writer) {
-		rlp.Encode(w, []interface{}{
-			t.body.ChainTag,
-			t.body.BlockRef,
-			t.body.Expiration,
-			t.body.Clauses,
-			t.body.GasPriceCoef,
-			t.body.Gas,
-			t.body.DependsOn,
-			&t.body.Reserved,
-			origin,
-		})
-	})
+	var hashWithoutNonce *thor.Bytes32
+	switch t.Type() {
+	case LegacyTxType:
+		hashWithoutNonce = t.hashWithoutNonceLegacyTx(origin)
+	case DynamicFeeTxType:
+		hashWithoutNonce = t.hashWithoutNonceDynamicFeeTx(origin)
+	default:
+		panic(ErrInvalidTxType)
+	}
 
 	return func(nonce uint64) *big.Int {
 		var nonceBytes [8]byte
@@ -154,6 +180,41 @@ func (t *Transaction) EvaluateWork(origin thor.Address) func(nonce uint64) *big.
 	}
 }
 
+func (t *Transaction) hashWithoutNonceLegacyTx(origin thor.Address) *thor.Bytes32 {
+	b := thor.Blake2bFn(func(w io.Writer) {
+		rlp.Encode(w, []interface{}{
+			t.body.chainTag(),
+			t.body.blockRef(),
+			t.body.expiration(),
+			t.body.clauses(),
+			t.body.gasPriceCoef(),
+			t.body.dependsOn(),
+			t.body.nonce(),
+			t.body.reserved(),
+			origin,
+		})
+	})
+	return &b
+}
+
+func (t *Transaction) hashWithoutNonceDynamicFeeTx(origin thor.Address) *thor.Bytes32 {
+	b := thor.Blake2bFn(func(w io.Writer) {
+		rlp.Encode(w, []interface{}{
+			t.body.chainTag(),
+			t.body.blockRef(),
+			t.body.expiration(),
+			t.body.clauses(),
+			t.body.maxFeePerGas(),
+			t.body.maxPriorityFeePerGas(),
+			t.body.dependsOn(),
+			t.body.nonce(),
+			t.body.reserved(),
+			origin,
+		})
+	})
+	return &b
+}
+
 // SigningHash returns hash of tx excludes signature.
 func (t *Transaction) SigningHash() (hash thor.Bytes32) {
 	if cached := t.cache.signingHash.Load(); cached != nil {
@@ -162,53 +223,51 @@ func (t *Transaction) SigningHash() (hash thor.Bytes32) {
 	defer func() { t.cache.signingHash.Store(hash) }()
 
 	return thor.Blake2bFn(func(w io.Writer) {
-		rlp.Encode(w, []interface{}{
-			t.body.ChainTag,
-			t.body.BlockRef,
-			t.body.Expiration,
-			t.body.Clauses,
-			t.body.GasPriceCoef,
-			t.body.Gas,
-			t.body.DependsOn,
-			t.body.Nonce,
-			&t.body.Reserved,
-		})
+		t.body.encode(w)
 	})
+}
+
+// Gas returns gas provision for this tx.
+func (t *Transaction) Gas() uint64 {
+	return t.body.gas()
 }
 
 // GasPriceCoef returns gas price coef.
 // gas price = bgp + bgp * gpc / 255.
 func (t *Transaction) GasPriceCoef() uint8 {
-	return t.body.GasPriceCoef
+	return t.body.gasPriceCoef()
 }
 
-// Gas returns gas provision for this tx.
-func (t *Transaction) Gas() uint64 {
-	return t.body.Gas
+func (t *Transaction) MaxFeePerGas() *big.Int {
+	return t.body.maxFeePerGas()
+}
+
+func (t *Transaction) MaxPriorityFeePerGas() *big.Int {
+	return t.body.maxPriorityFeePerGas()
 }
 
 // Clauses returns clauses in tx.
 func (t *Transaction) Clauses() []*Clause {
-	return append([]*Clause(nil), t.body.Clauses...)
+	return append([]*Clause(nil), t.body.clauses()...)
 }
 
 // DependsOn returns depended tx hash.
 func (t *Transaction) DependsOn() *thor.Bytes32 {
-	if t.body.DependsOn == nil {
+	if t.body.dependsOn() == nil {
 		return nil
 	}
-	cpy := *t.body.DependsOn
+	cpy := *t.body.dependsOn()
 	return &cpy
 }
 
 // Signature returns signature.
 func (t *Transaction) Signature() []byte {
-	return append([]byte(nil), t.body.Signature...)
+	return append([]byte(nil), t.body.signature()...)
 }
 
 // Features returns features.
 func (t *Transaction) Features() Features {
-	return t.body.Reserved.Features
+	return t.body.reserved().Features
 }
 
 // Origin extract address of tx originator from signature.
@@ -221,7 +280,7 @@ func (t *Transaction) Origin() (thor.Address, error) {
 		return cached.(thor.Address), nil
 	}
 
-	pub, err := crypto.SigToPub(t.SigningHash().Bytes(), t.body.Signature[:65])
+	pub, err := crypto.SigToPub(t.SigningHash().Bytes(), t.body.signature()[:65])
 	if err != nil {
 		return thor.Address{}, err
 	}
@@ -256,7 +315,7 @@ func (t *Transaction) Delegator() (*thor.Address, error) {
 		return nil, err
 	}
 
-	pub, err := crypto.SigToPub(t.DelegatorSigningHash(origin).Bytes(), t.body.Signature[65:])
+	pub, err := crypto.SigToPub(t.DelegatorSigningHash(origin).Bytes(), t.body.signature()[65:])
 	if err != nil {
 		return nil, err
 	}
@@ -271,17 +330,17 @@ func (t *Transaction) Delegator() (*thor.Address, error) {
 // For delegated tx, sig is joined with signatures of originator and delegator.
 func (t *Transaction) WithSignature(sig []byte) *Transaction {
 	newTx := Transaction{
-		body: t.body,
+		body: t.body.copy(),
 	}
 	// copy sig
-	newTx.body.Signature = append([]byte(nil), sig...)
+	newTx.body.setSignature(append([]byte(nil), sig...))
 	return &newTx
 }
 
 // TestFeatures test if the tx is compatible with given supported features.
 // An error returned if it is incompatible.
 func (t *Transaction) TestFeatures(supported Features) error {
-	r := &t.body.Reserved
+	r := t.body.reserved()
 	if r.Features&supported != r.Features {
 		return errors.New("unsupported features")
 	}
@@ -292,22 +351,115 @@ func (t *Transaction) TestFeatures(supported Features) error {
 	return nil
 }
 
+// encodeTyped writes the canonical encoding of a typed transaction to w.
+func (t *Transaction) encodeTyped(w *bytes.Buffer) error {
+	w.WriteByte(t.Type())
+	return rlp.Encode(w, t.body)
+}
+
+// MarshalBinary returns the canonical encoding of the transaction.
+// For legacy transactions, it returns the RLP encoding. For typed
+// transactions, it returns the type and payload.
+func (tx *Transaction) MarshalBinary() ([]byte, error) {
+	if tx.Type() == LegacyTxType {
+		return rlp.EncodeToBytes(tx.body)
+	}
+	var buf bytes.Buffer
+	err := tx.encodeTyped(&buf)
+	return buf.Bytes(), err
+}
+
+// UnmarshalBinary decodes the canonical encoding of transactions.
+// It supports legacy RLP transactions and typed transactions.
+func (t *Transaction) UnmarshalBinary(b []byte) error {
+	if len(b) > 0 && b[0] > 0x7f {
+		// It's a legacy transaction.
+		var data LegacyTransaction
+		err := rlp.DecodeBytes(b, &data)
+		if err != nil {
+			return err
+		}
+		t.setDecoded(&data, len(b))
+		return nil
+	}
+	// It's a typed transaction envelope.
+	inner, err := t.decodeTyped(b)
+	if err != nil {
+		return err
+	}
+	t.setDecoded(inner, len(b))
+	return nil
+}
+
 // EncodeRLP implements rlp.Encoder
 func (t *Transaction) EncodeRLP(w io.Writer) error {
-	return rlp.Encode(w, &t.body)
+	if t.Type() == LegacyTxType {
+		return rlp.Encode(w, &t.body)
+	}
+	buf := encodeBufferPool.Get().(*bytes.Buffer)
+	defer encodeBufferPool.Put(buf)
+	buf.Reset()
+
+	if err := t.encodeTyped(buf); err != nil {
+		return err
+	}
+	return rlp.Encode(w, buf.Bytes())
 }
 
 // DecodeRLP implements rlp.Decoder
 func (t *Transaction) DecodeRLP(s *rlp.Stream) error {
-	_, size, _ := s.Kind()
-	var body body
-	if err := s.Decode(&body); err != nil {
-		return err
-	}
-	*t = Transaction{body: body}
+	kind, size, err := s.Kind()
 
-	t.cache.size.Store(thor.StorageSize(rlp.ListSize(size)))
-	return nil
+	switch {
+	case err != nil:
+		return err
+	case kind == rlp.List:
+		// It's a legacy transaction.
+		var body LegacyTransaction
+		if err := s.Decode(&body); err != nil {
+			return err
+		}
+		*t = Transaction{body: &body}
+
+		t.cache.size.Store(thor.StorageSize(rlp.ListSize(size)))
+		return nil
+	case kind == rlp.String:
+		// It's a typed TX.
+		var b []byte
+		if b, err = s.Bytes(); err != nil {
+			return err
+		}
+		inner, err := t.decodeTyped(b)
+		if err == nil {
+			t.setDecoded(inner, len(b))
+		}
+		return err
+	default:
+		return rlp.ErrExpectedList
+	}
+}
+
+// decodeTyped decodes a typed transaction from the canonical format.
+func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
+	if len(b) == 0 {
+		return nil, errEmptyTypedTx
+	}
+	switch b[0] {
+	case DynamicFeeTxType:
+		var body DynamicFeeTransaction
+		err := rlp.DecodeBytes(b[1:], &body)
+		return &body, err
+	default:
+		return nil, ErrTxTypeNotSupported
+	}
+}
+
+// setDecoded sets the inner transaction and size after decoding.
+func (t *Transaction) setDecoded(body TxData, size int) {
+	t.body = body
+	if size > 0 {
+		t.cache.size.Store(thor.StorageSize(rlp.ListSize(uint64(size))))
+	}
 }
 
 // Size returns size in bytes when RLP encoded.
@@ -327,7 +479,7 @@ func (t *Transaction) IntrinsicGas() (uint64, error) {
 		return cached.(uint64), nil
 	}
 
-	gas, err := IntrinsicGas(t.body.Clauses...)
+	gas, err := IntrinsicGas(t.body.clauses()...)
 	if err != nil {
 		return 0, err
 	}
@@ -338,7 +490,7 @@ func (t *Transaction) IntrinsicGas() (uint64, error) {
 // GasPrice returns gas price.
 // gasPrice = baseGasPrice + baseGasPrice * gasPriceCoef / 255
 func (t *Transaction) GasPrice(baseGasPrice *big.Int) *big.Int {
-	x := big.NewInt(int64(t.body.GasPriceCoef))
+	x := new(big.Int).Set(t.body.maxFeePerGas())
 	x.Mul(x, baseGasPrice)
 	x.Div(x, big.NewInt(math.MaxUint8))
 	return x.Add(x, baseGasPrice)
@@ -381,13 +533,13 @@ func (t *Transaction) OverallGasPrice(baseGasPrice *big.Int, provedWork *big.Int
 	if wgas == 0 {
 		return gasPrice
 	}
-	if wgas > t.body.Gas {
-		wgas = t.body.Gas
+	if wgas > t.body.gas() {
+		wgas = t.body.gas()
 	}
 
 	x := new(big.Int).SetUint64(wgas)
 	x.Mul(x, baseGasPrice)
-	x.Div(x, new(big.Int).SetUint64(t.body.Gas))
+	x.Div(x, new(big.Int).SetUint64(t.body.gas()))
 	return x.Add(x, gasPrice)
 }
 
@@ -405,16 +557,15 @@ func (t *Transaction) String() string {
 		delegatorStr = delegator.String()
 	}
 
-	binary.BigEndian.PutUint64(br[:], t.body.BlockRef)
-	if t.body.DependsOn != nil {
-		dependsOn = t.body.DependsOn.String()
+	binary.BigEndian.PutUint64(br[:], t.body.blockRef())
+	if t.body.dependsOn() != nil {
+		dependsOn = t.body.dependsOn().String()
 	}
 
-	return fmt.Sprintf(`
+	s := fmt.Sprintf(`
 	Tx(%v, %v)
 	Origin:         %v
 	Clauses:        %v
-	GasPriceCoef:   %v
 	Gas:            %v
 	ChainTag:       %v
 	BlockRef:       %v-%x
@@ -424,8 +575,19 @@ func (t *Transaction) String() string {
 	UnprovedWork:   %v
 	Delegator:      %v
 	Signature:      0x%x
-`, t.ID(), t.Size(), originStr, t.body.Clauses, t.body.GasPriceCoef, t.body.Gas,
-		t.body.ChainTag, br.Number(), br[4:], t.body.Expiration, dependsOn, t.body.Nonce, t.UnprovedWork(), delegatorStr, t.body.Signature)
+`, t.ID(), t.Size(), originStr, t.body.clauses(), t.body.gas(),
+		t.body.chainTag(), br.Number(), br[4:], t.body.expiration(), dependsOn, t.body.nonce(), t.UnprovedWork(), delegatorStr, t.body.signature())
+
+	if t.Type() == LegacyTxType {
+		return fmt.Sprintf(`%v
+		GasPriceCoef:   %v
+		`, s, t.body.gasPriceCoef())
+	}
+
+	return fmt.Sprintf(`%v
+		MaxFeePerGas:   %v
+		MaxPriorityFeePerGas: %v
+		`, s, t.body.maxFeePerGas(), t.body.maxPriorityFeePerGas())
 }
 
 func (t *Transaction) validateSignatureLength() error {
@@ -434,7 +596,7 @@ func (t *Transaction) validateSignatureLength() error {
 		expectedSigLen *= 2
 	}
 
-	if len(t.body.Signature) != expectedSigLen {
+	if len(t.body.signature()) != expectedSigLen {
 		return secp256k1.ErrInvalidSignatureLen
 	}
 	return nil

--- a/tx/transaction_test.go
+++ b/tx/transaction_test.go
@@ -7,6 +7,7 @@ package tx_test
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -17,7 +18,7 @@ import (
 	"github.com/vechain/thor/v2/tx"
 )
 
-func GetMockTx() tx.Transaction {
+func GetMockLegacyTx() tx.Transaction {
 	to, _ := thor.ParseAddress("0x7567d83b7b8d80addcb281a71d54fc7b3364ffed")
 	trx := new(tx.Builder).ChainTag(1).
 		BlockRef(tx.BlockRef{0, 0, 0, 0, 0xaa, 0xbb, 0xcc, 0xdd}).
@@ -27,61 +28,82 @@ func GetMockTx() tx.Transaction {
 		GasPriceCoef(128).
 		Gas(21000).
 		DependsOn(nil).
-		Nonce(12345678).Build()
+		Nonce(12345678).BuildLegacy()
+
+	return *trx
+}
+
+func getMockDynFeeTx() tx.Transaction {
+	to, _ := thor.ParseAddress("0x7567d83b7b8d80addcb281a71d54fc7b3364ffed")
+	trx := new(tx.Builder).ChainTag(1).
+		BlockRef(tx.BlockRef{0, 0, 0, 0, 0xaa, 0xbb, 0xcc, 0xdd}).
+		Expiration(32).
+		Clause(tx.NewClause(&to).WithValue(big.NewInt(10000)).WithData([]byte{0, 0, 0, 0x60, 0x60, 0x60})).
+		Clause(tx.NewClause(&to).WithValue(big.NewInt(20000)).WithData([]byte{0, 0, 0, 0x60, 0x60, 0x60})).
+		Gas(21000).
+		MaxFeePerGas(big.NewInt(10000000)).
+		MaxPriorityFeePerGas(big.NewInt(20000)).
+		DependsOn(nil).
+		Nonce(12345678).BuildDynamicFee()
 
 	return *trx
 }
 
 func TestIsExpired(t *testing.T) {
-	tx := GetMockTx()
+	tx := GetMockLegacyTx()
 	res := tx.IsExpired(10)
 	assert.Equal(t, res, false)
 }
 
-func TestHash(t *testing.T) {
-	tx := GetMockTx()
-	res := tx.Hash()
-	assert.Equal(t, res, thor.Bytes32{0x4b, 0xff, 0x70, 0x1, 0xfe, 0xc4, 0x2, 0x84, 0xd9, 0x3b, 0x4c, 0x45, 0x61, 0x7d, 0xc7, 0x41, 0xb9, 0xa8, 0x8e, 0xd5, 0x9d, 0xf, 0x1, 0xa3, 0x76, 0x39, 0x4c, 0x7b, 0xfe, 0xa6, 0xed, 0x24})
-}
-
 func TestDependsOn(t *testing.T) {
-	tx := GetMockTx()
+	tx := GetMockLegacyTx()
 	res := tx.DependsOn()
 	var expected *thor.Bytes32
 	assert.Equal(t, expected, res)
 }
 
 func TestTestFeatures(t *testing.T) {
-	txx := GetMockTx()
+	txx := GetMockLegacyTx()
 	supportedFeatures := tx.Features(1)
 	res := txx.TestFeatures(supportedFeatures)
 	assert.Equal(t, res, nil)
 }
 
 func TestToString(t *testing.T) {
-	tx := GetMockTx() // Ensure this mock transaction has all the necessary fields populated
+	// Legacy transaction
+	tx := GetMockLegacyTx() // Ensure this mock transaction has all the necessary fields populated
 
 	// Construct the expected string representation of the transaction
 	// This should match the format used in the String() method of the Transaction struct
 	// and should reflect the actual state of the mock transaction
-	expectedString := "\n\tTx(0x0000000000000000000000000000000000000000000000000000000000000000, 87 B)\n\tOrigin:         N/A\n\tClauses:        [\n\t\t(To:\t0x7567d83b7b8d80addcb281a71d54fc7b3364ffed\n\t\t Value:\t10000\n\t\t Data:\t0x000000606060) \n\t\t(To:\t0x7567d83b7b8d80addcb281a71d54fc7b3364ffed\n\t\t Value:\t20000\n\t\t Data:\t0x000000606060)]\n\tGasPriceCoef:   128\n\tGas:            21000\n\tChainTag:       1\n\tBlockRef:       0-aabbccdd\n\tExpiration:     32\n\tDependsOn:      nil\n\tNonce:          12345678\n\tUnprovedWork:   0\n\tDelegator:      N/A\n\tSignature:      0x\n"
+	expectedString := "\n\tTx(0x0000000000000000000000000000000000000000000000000000000000000000, 87 B)\n\tOrigin:         N/A\n\tClauses:        [\n\t\t(To:\t0x7567d83b7b8d80addcb281a71d54fc7b3364ffed\n\t\t Value:\t10000\n\t\t Data:\t0x000000606060) \n\t\t(To:\t0x7567d83b7b8d80addcb281a71d54fc7b3364ffed\n\t\t Value:\t20000\n\t\t Data:\t0x000000606060)]\n\tGas:            21000\n\tChainTag:       1\n\tBlockRef:       0-aabbccdd\n\tExpiration:     32\n\tDependsOn:      nil\n\tNonce:          12345678\n\tUnprovedWork:   0\n\tDelegator:      N/A\n\tSignature:      0x\n\n\t\tGasPriceCoef:   128\n\t\t"
 
 	res := tx.String()
 
 	// Use assert.Equal to compare the actual result with the expected string
 	assert.Equal(t, expectedString, res)
+
+	// Dynamic fee transaction
+	tx = getMockDynFeeTx()
+	expectedString = "\n\tTx(0x0000000000000000000000000000000000000000000000000000000000000000, 95 B)\n\tOrigin:         N/A\n\tClauses:        [\n\t\t(To:\t0x7567d83b7b8d80addcb281a71d54fc7b3364ffed\n\t\t Value:\t10000\n\t\t Data:\t0x000000606060) \n\t\t(To:\t0x7567d83b7b8d80addcb281a71d54fc7b3364ffed\n\t\t Value:\t20000\n\t\t Data:\t0x000000606060)]\n\tGas:            21000\n\tChainTag:       1\n\tBlockRef:       0-aabbccdd\n\tExpiration:     32\n\tDependsOn:      nil\n\tNonce:          12345678\n\tUnprovedWork:   0\n\tDelegator:      N/A\n\tSignature:      0x\n\n\t\tMaxFeePerGas:   10000000\n\t\tMaxPriorityFeePerGas: 20000\n\t\t"
+	res = tx.String()
+	assert.Equal(t, expectedString, res)
 }
 
 func TestTxSize(t *testing.T) {
-	tx := GetMockTx()
+	tx := GetMockLegacyTx()
 
 	size := tx.Size()
 	assert.Equal(t, size, thor.StorageSize(87))
+
+	tx = getMockDynFeeTx()
+	size = tx.Size()
+	assert.Equal(t, size, thor.StorageSize(95))
 }
 
 func TestProvedWork(t *testing.T) {
 	// Mock the transaction
-	tx := GetMockTx()
+	tx := GetMockLegacyTx()
 
 	// Define a head block number
 	headBlockNum := uint32(20)
@@ -102,20 +124,20 @@ func TestProvedWork(t *testing.T) {
 }
 
 func TestChainTag(t *testing.T) {
-	tx := GetMockTx()
+	tx := GetMockLegacyTx()
 	res := tx.ChainTag()
 	assert.Equal(t, res, uint8(0x1))
 }
 
 func TestNonce(t *testing.T) {
-	tx := GetMockTx()
+	tx := GetMockLegacyTx()
 	res := tx.Nonce()
 	assert.Equal(t, res, uint64(0xbc614e))
 }
 
 func TestOverallGasPrice(t *testing.T) {
 	// Mock or create a Transaction with necessary fields initialized
-	tx := GetMockTx()
+	tx := GetMockLegacyTx()
 
 	// Define test cases
 	testCases := []struct {
@@ -154,7 +176,7 @@ func TestOverallGasPrice(t *testing.T) {
 
 func TestEvaluateWork(t *testing.T) {
 	origin := thor.BytesToAddress([]byte("origin"))
-	tx := GetMockTx()
+	tx := GetMockLegacyTx()
 
 	// Returns a function
 	evaluate := tx.EvaluateWork(origin)
@@ -169,7 +191,7 @@ func TestEvaluateWork(t *testing.T) {
 	}
 }
 
-func TestTx(t *testing.T) {
+func LegacyTx(t *testing.T) {
 	to, _ := thor.ParseAddress("0x7567d83b7b8d80addcb281a71d54fc7b3364ffed")
 	trx := new(tx.Builder).ChainTag(1).
 		BlockRef(tx.BlockRef{0, 0, 0, 0, 0xaa, 0xbb, 0xcc, 0xdd}).
@@ -179,12 +201,12 @@ func TestTx(t *testing.T) {
 		GasPriceCoef(128).
 		Gas(21000).
 		DependsOn(nil).
-		Nonce(12345678).Build()
+		Nonce(12345678).BuildLegacy()
 
 	assert.Equal(t, "0x2a1c25ce0d66f45276a5f308b99bf410e2fc7d5b6ea37a49f2ab9f1da9446478", trx.SigningHash().String())
 	assert.Equal(t, thor.Bytes32{}, trx.ID())
 
-	assert.Equal(t, uint64(21000), func() uint64 { g, _ := new(tx.Builder).Build().IntrinsicGas(); return g }())
+	assert.Equal(t, uint64(21000), func() uint64 { g, _ := new(tx.Builder).BuildLegacy().IntrinsicGas(); return g }())
 	assert.Equal(t, uint64(37432), func() uint64 { g, _ := trx.IntrinsicGas(); return g }())
 
 	assert.Equal(t, big.NewInt(150), trx.GasPrice(big.NewInt(100)))
@@ -200,6 +222,7 @@ func TestTx(t *testing.T) {
 	sig, _ := crypto.Sign(trx.SigningHash().Bytes(), priv)
 
 	trx = trx.WithSignature(sig)
+	fmt.Println(trx.ID())
 	assert.Equal(t, "0xd989829d88b0ed1b06edf5c50174ecfa64f14a64", func() string { s, _ := trx.Origin(); return s.String() }())
 	assert.Equal(t, "0xda90eaea52980bc4bb8d40cb2ff84d78433b3b4a6e7d50b75736c5e3e77b71ec", trx.ID().String())
 
@@ -225,7 +248,7 @@ func TestDelegatedTx(t *testing.T) {
 		Gas(210000).
 		DependsOn(nil).
 		Features(feat).
-		Nonce(12345678).Build()
+		Nonce(12345678).BuildLegacy()
 
 	assert.Equal(t, "0x96c4cd08584994f337946f950eca5511abe15b152bc879bf47c2227901f9f2af", trx.SigningHash().String())
 	assert.Equal(t, true, trx.Features().IsDelegated())
@@ -251,8 +274,8 @@ func TestDelegatedTx(t *testing.T) {
 	)
 
 	raw, _ := hex.DecodeString("f8db81a484aabbccdd20f840df947567d83b7b8d80addcb281a71d54fc7b3364ffed82271086000000606060df947567d83b7b8d80addcb281a71d54fc7b3364ffed824e20860000006060608180830334508083bc614ec101b882bad4d4401b1fb1c41d61727d7fd2aeb2bb3e65a27638a5326ca98404c0209ab159eaeb37f0ac75ed1ac44d92c3d17402d7d64b4c09664ae2698e1102448040c000f043fafeaf60343248a37e4f1d2743b4ab9116df6d627b4d8a874e4f48d3ae671c4e8d136eb87c544bea1763673a5f1762c2266364d1b22166d16e3872b5a9c700")
-	var newTx *tx.Transaction
-	if err := rlp.DecodeBytes(raw, &newTx); err != nil {
+	newTx := new(tx.Transaction)
+	if err := newTx.UnmarshalBinary(raw); err != nil {
 		t.Error(err)
 	}
 	assert.Equal(t, true, newTx.Features().IsDelegated())
@@ -281,7 +304,7 @@ func TestIntrinsicGas(t *testing.T) {
 }
 
 func BenchmarkTxMining(b *testing.B) {
-	tx := new(tx.Builder).Build()
+	tx := new(tx.Builder).BuildLegacy()
 	signer := thor.BytesToAddress([]byte("acc1"))
 	maxWork := &big.Int{}
 	eval := tx.EvaluateWork(signer)

--- a/tx/transactions_test.go
+++ b/tx/transactions_test.go
@@ -16,7 +16,7 @@ import (
 func MockTransactions(n int) tx.Transactions {
 	txs := make(tx.Transactions, n)
 	for i := range txs {
-		mockTx := GetMockTx()
+		mockTx := GetMockLegacyTx()
 		txs[i] = &mockTx
 	}
 	return txs

--- a/tx/tx_dynamic_fee.go
+++ b/tx/tx_dynamic_fee.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2024 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package tx
+
+import (
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/vechain/thor/v2/thor"
+)
+
+type DynamicFeeTransaction struct {
+	ChainTag             byte
+	BlockRef             uint64
+	Expiration           uint32
+	Clauses              []*Clause
+	Gas                  uint64
+	MaxFeePerGas         *big.Int
+	MaxPriorityFeePerGas *big.Int
+	DependsOn            *thor.Bytes32 `rlp:"nil"`
+	Nonce                uint64
+	Reserved             reserved
+	Signature            []byte
+}
+
+func (t *DynamicFeeTransaction) txType() byte {
+	return DynamicFeeTxType
+}
+
+func (t *DynamicFeeTransaction) copy() TxData {
+	cpy := &DynamicFeeTransaction{
+		ChainTag:             t.ChainTag,
+		BlockRef:             t.BlockRef,
+		Expiration:           t.Expiration,
+		Clauses:              make([]*Clause, len(t.Clauses)),
+		Gas:                  t.Gas,
+		MaxFeePerGas:         new(big.Int),
+		MaxPriorityFeePerGas: new(big.Int),
+		DependsOn:            t.DependsOn,
+		Nonce:                t.Nonce,
+		Reserved:             t.Reserved,
+		Signature:            t.Signature,
+	}
+	copy(cpy.Clauses, t.Clauses)
+	if t.MaxFeePerGas != nil {
+		cpy.MaxFeePerGas.Set(t.MaxFeePerGas)
+	}
+	if t.MaxPriorityFeePerGas != nil {
+		cpy.MaxPriorityFeePerGas.Set(t.MaxPriorityFeePerGas)
+	}
+	return cpy
+}
+
+func (t *DynamicFeeTransaction) chainTag() byte {
+	return t.ChainTag
+}
+
+func (t *DynamicFeeTransaction) blockRef() uint64 {
+	return t.BlockRef
+}
+
+func (t *DynamicFeeTransaction) expiration() uint32 {
+	return t.Expiration
+}
+
+func (t *DynamicFeeTransaction) clauses() []*Clause {
+	return t.Clauses
+}
+
+func (t *DynamicFeeTransaction) gas() uint64 {
+	return t.Gas
+}
+
+func (t *DynamicFeeTransaction) gasPriceCoef() uint8 {
+	// TODO: should this panic instead?
+	return 0
+}
+
+func (t *DynamicFeeTransaction) maxFeePerGas() *big.Int {
+	return t.MaxFeePerGas
+}
+
+func (t *DynamicFeeTransaction) maxPriorityFeePerGas() *big.Int {
+	return t.MaxPriorityFeePerGas
+}
+
+func (t *DynamicFeeTransaction) dependsOn() *thor.Bytes32 {
+	return t.DependsOn
+}
+
+func (t *DynamicFeeTransaction) nonce() uint64 {
+	return t.Nonce
+}
+
+func (t *DynamicFeeTransaction) reserved() reserved {
+	return t.Reserved
+}
+
+func (t *DynamicFeeTransaction) signature() []byte {
+	return t.Signature
+}
+
+func (t *DynamicFeeTransaction) setSignature(sig []byte) {
+	t.Signature = sig
+}
+
+func (t *DynamicFeeTransaction) encode(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{
+		t.ChainTag,
+		t.BlockRef,
+		t.Expiration,
+		t.Clauses,
+		t.Gas,
+		t.MaxFeePerGas,
+		t.MaxPriorityFeePerGas,
+		t.DependsOn,
+		t.Nonce,
+		&t.Reserved,
+	})
+}

--- a/tx/tx_legacy.go
+++ b/tx/tx_legacy.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2024 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package tx
+
+import (
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/vechain/thor/v2/thor"
+)
+
+type LegacyTransaction struct {
+	ChainTag     byte
+	BlockRef     uint64
+	Expiration   uint32
+	Clauses      []*Clause
+	GasPriceCoef uint8
+	Gas          uint64
+	DependsOn    *thor.Bytes32 `rlp:"nil"`
+	Nonce        uint64
+	Reserved     reserved
+	Signature    []byte
+}
+
+func (t *LegacyTransaction) txType() byte {
+	return LegacyTxType
+}
+
+func (t *LegacyTransaction) copy() TxData {
+	cpy := &LegacyTransaction{
+		ChainTag:     t.ChainTag,
+		BlockRef:     t.BlockRef,
+		Expiration:   t.Expiration,
+		Clauses:      make([]*Clause, len(t.Clauses)),
+		GasPriceCoef: t.GasPriceCoef,
+		Gas:          t.Gas,
+		DependsOn:    t.DependsOn,
+		Nonce:        t.Nonce,
+		Reserved:     t.Reserved,
+		Signature:    t.Signature,
+	}
+	copy(cpy.Clauses, t.Clauses)
+	return cpy
+}
+
+func (t *LegacyTransaction) chainTag() byte {
+	return t.ChainTag
+}
+
+func (t *LegacyTransaction) blockRef() uint64 {
+	return t.BlockRef
+}
+
+func (t *LegacyTransaction) expiration() uint32 {
+	return t.Expiration
+}
+
+func (t *LegacyTransaction) clauses() []*Clause {
+	return t.Clauses
+}
+
+func (t *LegacyTransaction) gas() uint64 {
+	return t.Gas
+}
+
+func (t *LegacyTransaction) gasPriceCoef() uint8 {
+	return t.GasPriceCoef
+}
+
+func (t *LegacyTransaction) maxFeePerGas() *big.Int {
+	// For legacy transactions, maxFeePerGas is determined by GasPriceCoef
+	return new(big.Int).SetUint64(uint64(t.GasPriceCoef))
+}
+
+func (t *LegacyTransaction) maxPriorityFeePerGas() *big.Int {
+	// For legacy transactions, maxPriorityFeePerGas is determined by GasPriceCoef
+	return new(big.Int).SetUint64(uint64(t.GasPriceCoef))
+}
+
+func (t *LegacyTransaction) dependsOn() *thor.Bytes32 {
+	return t.DependsOn
+}
+
+func (t *LegacyTransaction) nonce() uint64 {
+	return t.Nonce
+}
+
+func (t *LegacyTransaction) reserved() reserved {
+	return t.Reserved
+}
+
+func (t *LegacyTransaction) signature() []byte {
+	return t.Signature
+}
+
+func (t *LegacyTransaction) setSignature(sig []byte) {
+	t.Signature = sig
+}
+
+func (t *LegacyTransaction) encode(w io.Writer) error {
+	return rlp.Encode(w, []interface{}{
+		t.ChainTag,
+		t.BlockRef,
+		t.Expiration,
+		t.Clauses,
+		t.GasPriceCoef,
+		t.Gas,
+		t.DependsOn,
+		t.Nonce,
+		&t.Reserved,
+	})
+}

--- a/txpool/tx_object_test.go
+++ b/txpool/tx_object_test.go
@@ -40,7 +40,7 @@ func newTx(chainTag byte, clauses []*tx.Clause, gas uint64, blockRef tx.BlockRef
 		DependsOn(dependsOn).
 		Features(features).
 		Gas(gas).
-		Build(),
+		BuildLegacy(),
 		from.PrivateKey,
 	)
 }
@@ -60,7 +60,7 @@ func newDelegatedTx(chainTag byte, clauses []*tx.Clause, gas uint64, blockRef tx
 		DependsOn(dependsOn).
 		Features(features).
 		Gas(gas).
-		Build()
+		BuildLegacy()
 
 	trx = tx.MustSignDelegated(
 		trx,

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
 	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/builtin"
@@ -364,8 +363,8 @@ func TestAdd(t *testing.T) {
 	raw, _ := hex.DecodeString(fmt.Sprintf("f8dc81%v84aabbccdd20f840df947567d83b7b8d80addcb281a71d54fc7b3364ffed82271086000000606060df947567d83b7b8d80addcb281a71d54fc7b3364ffed824e20860000006060608180830334508083bc614ec20108b88256e32450c1907f627d2c11fe5a9d0216be1712f4938b5feb04e37edef236c56266c3378acf97994beff22698b70023f486645d29cb23b479a7b044f7c6b104d2000584fcb3964446d4d832dcc849e2d76ea7e04a4ebdc3a4b61e7997e93277363d4e7fe9315e7f6dd8d9c0a8bff5879503f5c04adab8b08772499e74d34f67923501",
 		hex.EncodeToString([]byte{pool.repo.ChainTag()}),
 	))
-	var badReserved *Tx.Transaction
-	if err := rlp.DecodeBytes(raw, &badReserved); err != nil {
+	badReserved := new(tx.Transaction)
+	if err := badReserved.UnmarshalBinary(raw); err != nil {
 		t.Error(err)
 	}
 


### PR DESCRIPTION
# Description

This PR refers to a part of the [dynamic fee market feature](https://github.com/vechain/protocol-board-repo/issues/336) and it introduces a new typed transaction: `DynamicFeeTransaction`. This also allows the introduction of new transaction types. The typed tx model follows the [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718).

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Unit tests [still in progress]
- Integration tests [still in progress]

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
