### PR TITLE
fix: Get Devnet ID after the Thor flags are set

### DIFF
--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -57,7 +57,7 @@ import (
 	"gopkg.in/urfave/cli.v1"
 )
 
-var devNetGenesisID = genesis.NewDevnet().ID()
+var devNetGenesisID thor.Bytes32
 
 func initLogger(lvl int, jsonLogs bool) *slog.LevelVar {
 	logLevel := log.FromLegacyLevel(lvl)
@@ -632,6 +632,13 @@ func printStartupMessage1(
 	)
 }
 
+func getOrCreateDevnetID() thor.Bytes32 {
+	if devNetGenesisID == (thor.Bytes32{}) {
+		devNetGenesisID = genesis.NewDevnet().ID()
+	}
+	return devNetGenesisID
+}
+
 func printStartupMessage2(
 	gene *genesis.Genesis,
 	apiURL string,
@@ -670,7 +677,7 @@ func printStartupMessage2(
 		}(),
 		func() string {
 			// print default dev net's dev accounts info
-			if gene.ID() == devNetGenesisID {
+			if gene.ID() == getOrCreateDevnetID() {
 				return `
 ┌──────────────────┬───────────────────────────────────────────────────────────────────────────────┐
 │  Mnemonic Words  │  denial kitchen pet squirrel other broom bar gas better priority spoil cross  │

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -633,7 +633,7 @@ func printStartupMessage1(
 }
 
 func getOrCreateDevnetID() thor.Bytes32 {
-	if devNetGenesisID == (thor.Bytes32{}) {
+	if devNetGenesisID.IsZero() {
 		devNetGenesisID = genesis.NewDevnet().ID()
 	}
 	return devNetGenesisID


### PR DESCRIPTION
# Description

Due to the previous implementation, when creating `metrics` in `state` the value was initialised to `noop` rather than `prometheus` since Devnet was initialising the State before Prometheus was set as metrics provider via `enable-metrics` in the command line.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested though the creation of metrics in the `state` package.

**Test Configuration**:

* Go Version: 1.23.3
* Hardware: macOS Sequoia
* Docker Version: 20.10.17

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
