### PR TITLE
chore: docker attestations

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -83,7 +83,8 @@ jobs:
           platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
-          provenance: false
+          provenance: ${{ github.event_name != 'pull_request' }}
+          sbom: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
# Description

Adding attestations as per https://docs.docker.com/scout/policy/#supply-chain-attestations when publishing in Docker Hub.

Partially addresses https://github.com/vechain/protocol-board-repo/issues/360
