### PR TITLE
extract cachestats to record cache stats 

### DIFF
--- a/chain/cache.go
+++ b/chain/cache.go
@@ -18,14 +18,14 @@ func newCache(maxSize int) *cache {
 	return &cache{c}
 }
 
-func (c *cache) GetOrLoad(key interface{}, load func() (interface{}, error)) (interface{}, error) {
+func (c *cache) GetOrLoad(key interface{}, load func() (interface{}, error)) (interface{}, bool, error) {
 	if value, ok := c.Get(key); ok {
-		return value, nil
+		return value, true, nil
 	}
 	value, err := load()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	c.Add(key, value)
-	return value, nil
+	return value, false, nil
 }

--- a/chain/metric.go
+++ b/chain/metric.go
@@ -8,5 +8,5 @@ package chain
 import "github.com/vechain/thor/v2/metrics"
 
 var (
-	metricCacheHitMiss = metrics.LazyLoadCounterVec("repo_cache_hit_miss_count", []string{"type", "event"})
+	metricCacheHitMiss = metrics.LazyLoadGaugeVec("repo_cache_hit_miss_count", []string{"type", "event"})
 )

--- a/muxdb/internal/trie/metrics.go
+++ b/muxdb/internal/trie/metrics.go
@@ -9,4 +9,4 @@ import (
 	"github.com/vechain/thor/v2/metrics"
 )
 
-var metricCacheHitMissGaugeVec = metrics.LazyLoadGaugeVec("cache_hit_miss_count", []string{"type", "event"})
+var metricCacheHitMiss = metrics.LazyLoadGaugeVec("cache_hit_miss_count", []string{"type", "event"})

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -6,6 +6,7 @@
 package runtime
 
 import (
+	"fmt"
 	"math/big"
 	"sync/atomic"
 
@@ -249,50 +250,54 @@ func (rt *Runtime) newEVM(stateDB *statedb.StateDB, clauseIndex uint32, txCtx *x
 		},
 		OnSuicideContract: func(_ *vm.EVM, contractAddr, tokenReceiver common.Address) {
 			// it's IMPORTANT to process energy before token
-			amount, err := rt.state.GetEnergy(thor.Address(contractAddr), rt.ctx.Time)
+			energy, err := rt.state.GetEnergy(thor.Address(contractAddr), rt.ctx.Time)
 			if err != nil {
 				panic(err)
 			}
-			if amount.Sign() != 0 {
-				// add remained energy of suiciding contract to receiver.
-				// no need to clear contract's energy, vm will delete the whole contract later.
+			bal := stateDB.GetBalance(contractAddr)
+
+			if bal.Sign() != 0 || energy.Sign() != 0 {
 				receiverEnergy, err := rt.state.GetEnergy(thor.Address(tokenReceiver), rt.ctx.Time)
 				if err != nil {
 					panic(err)
 				}
+				// touch the receiver's energy
+				// no need to clear contract's energy, vm will delete the whole contract later.
 				if err := rt.state.SetEnergy(
 					thor.Address(tokenReceiver),
-					new(big.Int).Add(receiverEnergy, amount),
+					new(big.Int).Add(receiverEnergy, energy),
 					rt.ctx.Time); err != nil {
 					panic(err)
 				}
+				// emit event if there is energy in the account
+				if energy.Sign() != 0 {
+					// see ERC20's Transfer event
+					topics := []common.Hash{
+						common.Hash(energyTransferEvent.ID()),
+						common.BytesToHash(contractAddr[:]),
+						common.BytesToHash(tokenReceiver[:]),
+					}
 
-				// see ERC20's Transfer event
-				topics := []common.Hash{
-					common.Hash(energyTransferEvent.ID()),
-					common.BytesToHash(contractAddr[:]),
-					common.BytesToHash(tokenReceiver[:]),
+					data, err := energyTransferEvent.Encode(energy)
+					if err != nil {
+						panic(err)
+					}
+
+					stateDB.AddLog(&types.Log{
+						Address: common.Address(builtin.Energy.Address),
+						Topics:  topics,
+						Data:    data,
+					})
 				}
-
-				data, err := energyTransferEvent.Encode(amount)
-				if err != nil {
-					panic(err)
-				}
-
-				stateDB.AddLog(&types.Log{
-					Address: common.Address(builtin.Energy.Address),
-					Topics:  topics,
-					Data:    data,
-				})
 			}
 
-			if amount := stateDB.GetBalance(contractAddr); amount.Sign() != 0 {
-				stateDB.AddBalance(tokenReceiver, amount)
+			if bal.Sign() != 0 {
+				stateDB.AddBalance(tokenReceiver, bal)
 
 				stateDB.AddTransfer(&tx.Transfer{
 					Sender:    thor.Address(contractAddr),
 					Recipient: thor.Address(tokenReceiver),
-					Amount:    amount,
+					Amount:    bal,
 				})
 			}
 		},
@@ -328,7 +333,14 @@ func (rt *Runtime) PrepareClause(
 		defer func() {
 			if e := recover(); e != nil {
 				// caught state error
-				err = e.(error)
+				switch e := e.(type) {
+				case error:
+					err = e
+				case string:
+					err = errors.New(e)
+				default:
+					err = fmt.Errorf("runtime: unknown error: %v", e)
+				}
 			}
 		}()
 

--- a/thor/cachestats.go
+++ b/thor/cachestats.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+package thor
+
+import "sync/atomic"
+
+// CacheStats is a utility for collecting cache hit/miss.
+type CacheStats struct {
+	hit, miss atomic.Int64
+	flag      atomic.Int32
+}
+
+// Hit records a hit.
+func (cs *CacheStats) Hit() int64 { return cs.hit.Add(1) }
+
+// Miss records a miss.
+func (cs *CacheStats) Miss() int64 { return cs.miss.Add(1) }
+
+// Stats returns the number of hits and misses and whether
+// the hit rate was changed comparing to the last call.
+func (cs *CacheStats) Stats() (bool, int64, int64) {
+	hit := cs.hit.Load()
+	miss := cs.miss.Load()
+	lookups := hit + miss
+
+	hitRate := float64(0)
+	if lookups > 0 {
+		hitRate = float64(hit) / float64(lookups)
+	}
+	flag := int32(hitRate * 1000)
+
+	return cs.flag.Swap(flag) != flag, hit, miss
+}

--- a/thor/cachestats_test.go
+++ b/thor/cachestats_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package thor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheStats(t *testing.T) {
+	cs := &CacheStats{}
+	cs.Hit()
+	cs.Miss()
+	_, hit, miss := cs.Stats()
+
+	assert.Equal(t, int64(1), hit)
+	assert.Equal(t, int64(1), miss)
+
+	changed, _, _ := cs.Stats()
+	assert.False(t, changed)
+
+	cs.Hit()
+	cs.Miss()
+	assert.Equal(t, int64(3), cs.Hit())
+
+	changed, hit, miss = cs.Stats()
+
+	assert.Equal(t, int64(3), hit)
+	assert.Equal(t, int64(2), miss)
+	assert.True(t, changed)
+}


### PR DESCRIPTION
# Description

This PR moves cachestats to a standalone file to make it available globally and applies cachestats to muxdb and chain to track cache miss/hit. 

A notable change here is this PR changes the metric type in package chain to `GaugeVec`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
