### PR TITLE
add go1.23 on ubuntu tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         go-version: [1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - go-version: 1.23.x
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ dep:| go_version_check
 
 go_version_check:
 	@if test $(MAJOR) -lt 1; then \
-		echo "Go 1.19 or higher required"; \
+		echo "Go 1.22 or higher required"; \
 		exit 1; \
 	else \
-		if test $(MAJOR) -eq 1 -a $(MINOR) -lt 19; then \
-			echo "Go 1.19 or higher required"; \
+		if test $(MAJOR) -eq 1 -a $(MINOR) -lt 22; then \
+			echo "Go 1.22 or higher required"; \
 			exit 1; \
 		fi \
 	fi


### PR DESCRIPTION
# Description

Add go1.23 on Ubuntu tests and set Makefile to test minimum go version to go1.22.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
