### PR TITLE
Metrics (Block processing lock): Number of times + duration

### DIFF
--- a/cmd/thor/node/metrics.go
+++ b/cmd/thor/node/metrics.go
@@ -10,10 +10,12 @@ import (
 )
 
 var (
-	metricBlockProcessedCount    = metrics.LazyLoadCounterVec("block_processed_count", []string{"type", "success"})
-	metricBlockProcessedTxs      = metrics.LazyLoadGaugeVec("block_processed_tx_gauge", []string{"type"})
-	metricBlockProcessedGas      = metrics.LazyLoadGaugeVec("block_processed_gas_gauge", []string{"type"})
-	metricBlockProcessedDuration = metrics.LazyLoadHistogram("block_processed_duration_ms", metrics.Bucket10s)
-	metricChainForkCount         = metrics.LazyLoadCounter("chain_fork_count")
-	metricChainForkSize          = metrics.LazyLoadGauge("chain_fork_gauge")
+	metricBlockProcessedCount         = metrics.LazyLoadCounterVec("block_processed_count", []string{"type", "success"})
+	metricBlockProcessedTxs           = metrics.LazyLoadGaugeVec("block_processed_tx_gauge", []string{"type"})
+	metricBlockProcessedGas           = metrics.LazyLoadGaugeVec("block_processed_gas_gauge", []string{"type"})
+	metricBlockProcessedDuration      = metrics.LazyLoadHistogram("block_processed_duration_ms", metrics.Bucket10s)
+	metricChainForkCount              = metrics.LazyLoadCounter("chain_fork_count")
+	metricChainForkSize               = metrics.LazyLoadGauge("chain_fork_gauge")
+	metricBlockProcessingLockCount    = metrics.LazyLoadCounterVec("block_processing_lock_count", []string{"type"})
+	metricBlockProcessingLockDuration = metrics.LazyLoadHistogram("block_processing_lock_duration_ms", metrics.Bucket10s)
 )

--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -280,8 +280,8 @@ func (n *Node) guardBlockProcessing(blockNum uint32, process func(conflicts uint
 	defer func() {
 		n.processLock.Unlock()
 		metricBlockProcessingLockCount().AddWithLabel(1, map[string]string{"type": "released"})
-		timeElapsed := mclock.Now() - startTime
-		metricBlockProcessingLockDuration().Observe(time.Duration(timeElapsed).Milliseconds())
+		lockElapsed := mclock.Now() - startTime
+		metricBlockProcessingLockDuration().Observe(time.Duration(lockElapsed).Milliseconds())
 	}()
 
 	if blockNum > n.maxBlockNum {

--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -274,13 +274,13 @@ func (n *Node) txStashLoop(ctx context.Context) {
 
 // guardBlockProcessing adds lock on block processing and maintains block conflicts.
 func (n *Node) guardBlockProcessing(blockNum uint32, process func(conflicts uint32) error) error {
-	startTime := mclock.Now()
 	n.processLock.Lock()
+	startTime := mclock.Now()
 	metricBlockProcessingLockCount().AddWithLabel(1, map[string]string{"type": "acquired"})
 	defer func() {
 		n.processLock.Unlock()
-		metricBlockProcessingLockCount().AddWithLabel(1, map[string]string{"type": "released"})
 		lockElapsed := mclock.Now() - startTime
+		metricBlockProcessingLockCount().AddWithLabel(1, map[string]string{"type": "released"})
 		metricBlockProcessingLockDuration().Observe(time.Duration(lockElapsed).Milliseconds())
 	}()
 

--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -274,8 +274,15 @@ func (n *Node) txStashLoop(ctx context.Context) {
 
 // guardBlockProcessing adds lock on block processing and maintains block conflicts.
 func (n *Node) guardBlockProcessing(blockNum uint32, process func(conflicts uint32) error) error {
+	startTime := mclock.Now()
 	n.processLock.Lock()
-	defer n.processLock.Unlock()
+	metricBlockProcessingLockCount().AddWithLabel(1, map[string]string{"type": "acquired"})
+	defer func() {
+		n.processLock.Unlock()
+		metricBlockProcessingLockCount().AddWithLabel(1, map[string]string{"type": "released"})
+		timeElapsed := mclock.Now() - startTime
+		metricBlockProcessingLockDuration().Observe(time.Duration(timeElapsed).Milliseconds())
+	}()
 
 	if blockNum > n.maxBlockNum {
 		if blockNum > n.maxBlockNum+1 {


### PR DESCRIPTION
# Description

Metrics taken based on the description for `Block processing lock` here https://github.com/vechain/protocol-board-repo/issues/340 and taking `metricBlockProcessedCount` and `metricBlockProcessedDuration` as a reference.
