### PR TITLE
Metrics (Database locking): Added counter

### DIFF
--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vechain/thor/v2/consensus"
 	"github.com/vechain/thor/v2/log"
 	"github.com/vechain/thor/v2/logdb"
+	"github.com/vechain/thor/v2/muxdb"
 	"github.com/vechain/thor/v2/packer"
 	"github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/thor"
@@ -235,6 +236,7 @@ func (n *Node) txStashLoop(ctx context.Context) {
 
 	db, err := leveldb.OpenFile(n.txStashPath, nil)
 	if err != nil {
+		muxdb.AddMetricsIfLocked(err, "open-file-tx-stash")
 		logger.Error("create tx stash", "err", err)
 		return
 	}

--- a/muxdb/metrics.go
+++ b/muxdb/metrics.go
@@ -11,4 +11,7 @@ import (
 	"github.com/vechain/thor/v2/metrics"
 )
 
-var metricCacheHitMiss = metrics.LazyLoadGaugeVec("cache_hit_miss_count", []string{"type", "event"})
+var (
+	metricCacheHitMiss = metrics.LazyLoadGaugeVec("cache_hit_miss_count", []string{"type", "event"})
+	metricLeveldbLock  = metrics.LazyLoadCounterVec("leveldb_lock_count", []string{"event"})
+)

--- a/muxdb/muxdb.go
+++ b/muxdb/muxdb.go
@@ -65,7 +65,7 @@ type MuxDB struct {
 }
 
 // Adds metrics if the error is due to file/db lock.
-func addMetricsIfLocked(err error, event string) {
+func AddMetricsIfLocked(err error, event string) {
 	if err == nil {
 		return
 	}
@@ -102,10 +102,10 @@ func Open(path string, options *Options) (*MuxDB, error) {
 
 	// open leveldb
 	ldb, err := leveldb.OpenFile(path, &ldbOpts)
-	addMetricsIfLocked(err, "open-file")
+	AddMetricsIfLocked(err, "open-file")
 	if _, corrupted := err.(*dberrors.ErrCorrupted); corrupted {
 		ldb, err = leveldb.RecoverFile(path, &ldbOpts)
-		addMetricsIfLocked(err, "recover-file")
+		AddMetricsIfLocked(err, "recover-file")
 	}
 
 	if err != nil {
@@ -144,7 +144,7 @@ func Open(path string, options *Options) (*MuxDB, error) {
 func NewMem() *MuxDB {
 	storage := storage.NewMemStorage()
 	ldb, err := leveldb.Open(storage, nil)
-	addMetricsIfLocked(err, "open-memory-backed-db")
+	AddMetricsIfLocked(err, "open-memory-backed-db")
 
 	engine := engine.NewLevelEngine(ldb)
 	return &MuxDB{


### PR DESCRIPTION
# Description

Adds a metric for LevelDB locking given the behaviour of the library `"github.com/syndtr/goleveldb/leveldb"`.

Covers `Level of Database Locking` from here https://github.com/vechain/protocol-board-repo/issues/340.
