### PR TITLE
feat: e2e tests on release branches

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -43,8 +43,10 @@ jobs:
       - name: Set e2e repo reference
         id: set-ref
         run: |
-          if [[ "${{ github.event.pull_request.base.ref }}" == release/* ]]; then
+          if [[ "${{ startsWith(github.event.pull_request.base.ref, 'release/*') }} ]]; then
             echo "ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ startsWith(github.head_ref, 'release/*') }} ]]; then
+            echo "ref=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=956b34bcf5b0b072cd7c8fd2e546a9beb66a866a" >> "$GITHUB_OUTPUT"
           fi 

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -49,7 +49,10 @@ jobs:
             echo "ref=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=956b34bcf5b0b072cd7c8fd2e546a9beb66a866a" >> "$GITHUB_OUTPUT"
-          fi 
+          fi
+      
+      - name: Print ref
+        run:  echo ${{ steps.set-ref.outputs.ref }} 
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -43,9 +43,9 @@ jobs:
       - name: Set e2e repo reference
         id: set-ref
         run: |
-          if [[ "${{ startsWith(github.event.pull_request.base.ref, 'release*') }} ]]; then
+          if [[ "${{ github.event.pull_request.base.ref }}" == release/* ]]; then
             echo "ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ startsWith(github.head_ref, 'release*') }} ]]; then
+          elif [[ "${{ github.head_ref }}" ==  release/* ]]; then
             echo "ref=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=956b34bcf5b0b072cd7c8fd2e546a9beb66a866a" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -38,13 +38,22 @@ jobs:
       THOR_IMAGE: vechain/thor:${{ github.sha }}
     name: Run Tests
     steps:
+      # Main: https://github.com/vechain/thor-e2e-tests/tree/956b34bcf5b0b072cd7c8fd2e546a9beb66a866a
+      # For release branches, names in the thor and thor-e2e-tests repos should match
+      - name: Set e2e repo reference
+        id: set-ref
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" == release/* ]]; then
+            echo "ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=956b34bcf5b0b072cd7c8fd2e546a9beb66a866a" >> "$GITHUB_OUTPUT"
+          fi 
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           repository: vechain/thor-e2e-tests
-          # https://github.com/vechain/thor-e2e-tests/tree/956b34bcf5b0b072cd7c8fd2e546a9beb66a866a
-          ref: 956b34bcf5b0b072cd7c8fd2e546a9beb66a866a
+          ref: ${{ steps.set-ref.outputs.ref }}
 
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -45,17 +45,11 @@ jobs:
         run: |
           if [[ "${{ github.event.pull_request.base.ref }}" == release/* ]]; then
             echo "ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.head_ref }}" ==  release/* ]]; then
+          elif [[ "${{ github.head_ref }}" == release/* ]]; then
             echo "ref=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=956b34bcf5b0b072cd7c8fd2e546a9beb66a866a" >> "$GITHUB_OUTPUT"
           fi
-      
-      - name: Print ref
-        run:  |
-          echo ${{ steps.set-ref.outputs.ref }} 
-          echo ${{ github.event.pull_request.base.ref }}
-          echo ${{ github.head_ref }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -52,7 +52,10 @@ jobs:
           fi
       
       - name: Print ref
-        run:  echo ${{ steps.set-ref.outputs.ref }} 
+        run:  |
+          echo ${{ steps.set-ref.outputs.ref }} 
+          echo ${{ github.event.pull_request.base.ref }}
+          echo ${{ github.head_ref }}
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -43,9 +43,9 @@ jobs:
       - name: Set e2e repo reference
         id: set-ref
         run: |
-          if [[ "${{ startsWith(github.event.pull_request.base.ref, 'release/*') }} ]]; then
+          if [[ "${{ startsWith(github.event.pull_request.base.ref, 'release*') }} ]]; then
             echo "ref=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ startsWith(github.head_ref, 'release/*') }} ]]; then
+          elif [[ "${{ startsWith(github.head_ref, 'release*') }} ]]; then
             echo "ref=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
           else
             echo "ref=956b34bcf5b0b072cd7c8fd2e546a9beb66a866a" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

GH actions config so e2e tests run on the `release/*` branches on the `thor-e2e-tests` repo.

[Example of execution using `release/galactica` on both repos](https://github.com/vechain/thor/actions/runs/12791470289/job/35659774316?pr=946) for pull requests (tests yet to be adapted, that is why the Shanghai tests are the only ones failing).
