### PR TITLE
Metrics (Compaction): Do not call the DB if metrics are disabled

### DIFF
--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -31,8 +31,8 @@ func HTTPHandler() http.Handler {
 }
 
 func NoOp() bool {
-	_, ok := metrics.(*noopMetrics)
-	return ok
+	_, isNoOp := metrics.(*noopMetrics)
+	return isNoOp
 }
 
 // Define standard buckets for histograms

--- a/metrics/telemetry.go
+++ b/metrics/telemetry.go
@@ -30,6 +30,11 @@ func HTTPHandler() http.Handler {
 	return metrics.GetOrCreateHandler()
 }
 
+func NoOp() bool {
+	_, ok := metrics.(*noopMetrics)
+	return ok
+}
+
 // Define standard buckets for histograms
 var (
 	Bucket10s      = []int64{0, 500, 1000, 2000, 3000, 4000, 5000, 7500, 10_000}

--- a/muxdb/metrics.go
+++ b/muxdb/metrics.go
@@ -8,15 +8,12 @@
 package muxdb
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 	"text/tabwriter"
-	"time"
 
-	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/vechain/thor/v2/metrics"
 )
 
@@ -50,32 +47,6 @@ Compactions
  Total |       7203 |   27425.29804 |      20.26837 |    5089.71648 |    6705.68758
 
 */
-// collectCompactionMetrics collects compaction metrics periodically.
-func collectCompactionMetrics(ctx context.Context, ldb *leveldb.DB) {
-	if metrics.NoOp() {
-		// We avoid calling the db if metrics are disabled
-		return
-	}
-
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			// stats is a table in a single string, so we need to parse it
-			stats, err := ldb.GetProperty("leveldb.stats")
-			if err != nil {
-				logger.Error("Failed to get LevelDB stats: %v", err)
-			} else {
-				collectCompactionValues(stats)
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
 func collectCompactionValues(stats string) {
 	// Create a new tabwriter
 	var sb strings.Builder

--- a/muxdb/metrics.go
+++ b/muxdb/metrics.go
@@ -8,12 +8,15 @@
 package muxdb
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
+	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/vechain/thor/v2/metrics"
 )
 
@@ -47,6 +50,32 @@ Compactions
  Total |       7203 |   27425.29804 |      20.26837 |    5089.71648 |    6705.68758
 
 */
+// collectCompactionMetrics collects compaction metrics periodically.
+func collectCompactionMetrics(ctx context.Context, ldb *leveldb.DB) {
+	if metrics.NoOp() {
+		// We avoid calling the db if metrics are disabled
+		return
+	}
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			// stats is a table in a single string, so we need to parse it
+			stats, err := ldb.GetProperty("leveldb.stats")
+			if err != nil {
+				logger.Error("Failed to get LevelDB stats: %v", err)
+			} else {
+				collectCompactionValues(stats)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 func collectCompactionValues(stats string) {
 	// Create a new tabwriter
 	var sb strings.Builder

--- a/muxdb/muxdb.go
+++ b/muxdb/muxdb.go
@@ -73,7 +73,7 @@ func collectCompactionMetrics(ctx context.Context, ldb *leveldb.DB) {
 		// We avoid calling the db if metrics are disabled
 		return
 	}
-	
+
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 

--- a/muxdb/muxdb.go
+++ b/muxdb/muxdb.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
-	"time"
 
 	"github.com/syndtr/goleveldb/leveldb"
 	dberrors "github.com/syndtr/goleveldb/leveldb/errors"
@@ -64,27 +63,6 @@ type MuxDB struct {
 	trieBackend *backend
 	cancelFunc  context.CancelFunc
 	wg          sync.WaitGroup
-}
-
-// collectCompactionMetrics collects compaction metrics periodically.
-func collectCompactionMetrics(ctx context.Context, ldb *leveldb.DB) {
-	ticker := time.NewTicker(10 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			// stats is a table in a single string, so we need to parse it
-			stats, err := ldb.GetProperty("leveldb.stats")
-			if err != nil {
-				logger.Error("Failed to get LevelDB stats: %v", err)
-			} else {
-				collectCompactionValues(stats)
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
 }
 
 // Open opens or creates DB at the given path.


### PR DESCRIPTION
# Description

This PR makes sure that we just call the db to get stats if the metrics are enabled (so different to noop).