### PR TITLE
Fix expired txs flaky test

### DIFF
--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -526,7 +526,7 @@ func TestExpiredTxs(t *testing.T) {
 	// add 1 non-executable
 	assert.NoError(t, pool.Add(newTx(pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, &thor.Bytes32{1}, tx.Features(0), devAccounts[2])))
 
-	executables, washed, err = pool.wash(pool.repo.BestBlockSummary())
+	executables, washed, err := pool.wash(pool.repo.BestBlockSummary())
 	assert.Nil(t, err)
 	assert.Equal(t, 90, len(executables))
 	assert.Equal(t, 0, washed)

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -496,18 +495,9 @@ func TestNonExecutables(t *testing.T) {
 		assert.NoError(t, pool.AddLocal(newTx(pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[i%len(devAccounts)])))
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	executables, _, _ := pool.wash(pool.repo.BestBlockSummary())
+	pool.executables.Store(executables)
 
-	go func() {
-		defer wg.Done()
-		pool.housekeeping()
-	}()
-
-	time.Sleep(2 * time.Second)
-	pool.cancel()
-
-	wg.Wait()
 	// add 1 non-executable
 	assert.NoError(t, pool.AddLocal(newTx(pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, &thor.Bytes32{1}, tx.Features(0), devAccounts[2])))
 }

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -526,7 +526,7 @@ func TestExpiredTxs(t *testing.T) {
 	// add 1 non-executable
 	assert.NoError(t, pool.Add(newTx(pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, &thor.Bytes32{1}, tx.Features(0), devAccounts[2])))
 
-	executables, washed, err = pool.wash(pool.repo.BestBlockSummary())
+	executables, _, _ = pool.wash(pool.repo.BestBlockSummary())
 	assert.Nil(t, err)
 	assert.Equal(t, 90, len(executables))
 	assert.Equal(t, 0, washed)

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -520,13 +520,13 @@ func TestExpiredTxs(t *testing.T) {
 		assert.NoError(t, pool.Add(newTx(pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[i%len(devAccounts)])))
 	}
 
-	executables, washed, err := pool.wash(pool.repo.BestBlockSummary())
+	executables, _, _ := pool.wash(pool.repo.BestBlockSummary())
 	pool.executables.Store(executables)
 
 	// add 1 non-executable
 	assert.NoError(t, pool.Add(newTx(pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, &thor.Bytes32{1}, tx.Features(0), devAccounts[2])))
 
-	executables, _, _ = pool.wash(pool.repo.BestBlockSummary())
+	executables, washed, err = pool.wash(pool.repo.BestBlockSummary())
 	assert.Nil(t, err)
 	assert.Equal(t, 90, len(executables))
 	assert.Equal(t, 0, washed)

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -520,22 +520,13 @@ func TestExpiredTxs(t *testing.T) {
 		assert.NoError(t, pool.Add(newTx(pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[i%len(devAccounts)])))
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	executables, washed, err := pool.wash(pool.repo.BestBlockSummary())
+	pool.executables.Store(executables)
 
-	go func() {
-		defer wg.Done()
-		pool.housekeeping()
-	}()
-
-	time.Sleep(1 * time.Second)
-	pool.cancel()
-
-	wg.Wait()
 	// add 1 non-executable
 	assert.NoError(t, pool.Add(newTx(pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, &thor.Bytes32{1}, tx.Features(0), devAccounts[2])))
 
-	executables, washed, err := pool.wash(pool.repo.BestBlockSummary())
+	executables, washed, err = pool.wash(pool.repo.BestBlockSummary())
 	assert.Nil(t, err)
 	assert.Equal(t, 90, len(executables))
 	assert.Equal(t, 0, washed)


### PR DESCRIPTION
# Description

Minor fix for flaky test, instead of waiting on housekeeping function, wash is invoked from the test and executable transactions are stored

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
