### PR TITLE
chore(gha): only run codecov on vechain/thor

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,8 +51,9 @@ jobs:
         run: make test-coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
+        if: ${{ github.repository == 'vechain/thor' }}
         with:
           fail_ci_if_error: true
-          file: ./coverage.out
+          files: ./coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Description

Only run CodeCove on `vechain/thor` & update codecov action to v5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
