### PR TITLE
fix(fees/history): missing error messages

### DIFF
--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -40,7 +40,7 @@ func (f *Fees) validateGetFeesHistoryParams(req *http.Request) (uint32, *chain.B
 	}
 
 	if blockCount == 0 {
-		return 0, nil, utils.BadRequest(errors.WithMessage(err, "invalid blockCount, it should not be 0"))
+		return 0, nil, utils.BadRequest(errors.New("invalid blockCount, it should not be 0"))
 	}
 
 	// Validate newestBlock
@@ -69,7 +69,7 @@ func (f *Fees) validateGetFeesHistoryParams(req *http.Request) (uint32, *chain.B
 	}
 
 	if newestBlockSummary.Header.Number() < minAllowedBlock {
-		return 0, nil, utils.BadRequest(errors.WithMessage(err, "invalid newestBlock, it is below the minimum allowed block"))
+		return 0, nil, utils.BadRequest(errors.New("invalid newestBlock, it is below the minimum allowed block"))
 	}
 
 	// Adjust blockCount if the oldest block is below the allowed range

--- a/api/fees/fees_test.go
+++ b/api/fees/fees_test.go
@@ -71,6 +71,7 @@ func TestFeesFixedSizeSameAsBacktrace(t *testing.T) {
 		"getFeeHistoryBestBlock":                        getFeeHistoryBestBlock,
 		"getFeeHistoryMoreBlocksRequestedThanAvailable": getFeeHistoryMoreBlocksRequestedThanAvailable,
 		"getFeeHistoryBlock0":                           getFeeHistoryBlock0,
+		"getFeeHistoryBlockCount0":                      getFeeHistoryBlockCount0,
 	} {
 		t.Run(name, func(t *testing.T) {
 			tt(t, tclient, bestchain)
@@ -201,6 +202,7 @@ func getFeeHistoryNewestBlockNotIncluded(t *testing.T, tclient *thorclient.Clien
 	require.NoError(t, err)
 	require.Equal(t, 400, statusCode)
 	require.NotNil(t, res)
+	assert.Equal(t, "newestBlock: not found\n", string(res))
 }
 
 func getFeeHistoryCacheLimit(t *testing.T, tclient *thorclient.Client, bestchain *chain.Chain) {
@@ -234,6 +236,7 @@ func getFeeHistoryBlockCountBiggerThanMax(t *testing.T, tclient *thorclient.Clie
 	require.NoError(t, err)
 	require.Equal(t, 400, statusCode)
 	require.NotNil(t, res)
+	assert.Equal(t, "invalid newestBlock, it is below the minimum allowed block\n", string(res))
 }
 
 func getFeeHistoryMoreBlocksRequestedThanAvailable(t *testing.T, tclient *thorclient.Client, bestchain *chain.Chain) {
@@ -326,4 +329,12 @@ func getFeeHistoryMoreThanBacktraceLimit(t *testing.T, tclient *thorclient.Clien
 	}
 
 	assert.Equal(t, expectedFeesHistory, feesHistory)
+}
+
+func getFeeHistoryBlockCount0(t *testing.T, tclient *thorclient.Client, bestchain *chain.Chain) {
+	res, statusCode, err := tclient.RawHTTPClient().RawHTTPGet("/fees/history?blockCount=0&newestBlock=best")
+	require.NoError(t, err)
+	require.Equal(t, 400, statusCode)
+	require.NotNil(t, res)
+	assert.Equal(t, "invalid blockCount, it should not be 0\n", string(res))
 }


### PR DESCRIPTION
# Description

Added a couple of error messages missing due to relying on `err` (there is no `err` in those cases).

Added a test too.
