### PR TITLE
chore: update go and lint versions

### DIFF
--- a/.github/workflows/go-mod-check.yaml
+++ b/.github/workflows/go-mod-check.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: false
 
       - name: go mod tidy

--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: false
       - name: Run Gosec
         id: gosec-run

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: false
 
       - name: Check `builtins` directory
@@ -27,7 +27,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.4.1
         with:
-          version: v1.60.3
+          version: v1.64.5
           # use the default if on main branch, otherwise use the pull request config
           args: --timeout=30m --config=.golangci.yml
           only-new-issues: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,13 @@ jobs:
       matrix:
         go-version: [1.23.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - go-version: 1.21.x
+            os: ubuntu-latest
+          - go-version: 1.22.x
+            os: ubuntu-latest
+          - go-version: 1.24.x
+            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,11 +11,8 @@ jobs:
   unit_tests:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - go-version: 1.23.x
-            os: ubuntu-latest
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -42,7 +39,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
 
       - name: Make all
         run: make all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build thor in a stock Go builder container
-FROM golang:1.22-alpine3.20 AS builder
+FROM golang:1.23-alpine3.21 AS builder
 
 RUN apk add --no-cache make gcc musl-dev linux-headers git
 WORKDIR  /go/thor
@@ -7,7 +7,7 @@ COPY . /go/thor
 RUN make all
 
 # Pull thor into a second stage deploy alpine container
-FROM alpine:3.20
+FROM alpine:3.21.3
 
 RUN apk add --no-cache ca-certificates
 RUN apk upgrade libssl3 libcrypto3

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ dep:| go_version_check
 
 go_version_check:
 	@if test $(MAJOR) -lt 1; then \
-		echo "Go 1.22 or higher required"; \
+		echo "Go 1.23 or higher required"; \
 		exit 1; \
 	else \
 		if test $(MAJOR) -eq 1 -a $(MINOR) -lt 22; then \
-			echo "Go 1.22 or higher required"; \
+			echo "Go 1.23 or higher required"; \
 			exit 1; \
 		fi \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vechain/thor/v2
 
-go 1.22
+go 1.23
 
 require (
 	github.com/beevik/ntp v0.2.0


### PR DESCRIPTION
# Description

Required: Install go v1.23 and golangci-lint@v1.64.5

To install latest linter:

```
go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
