### PR TITLE
feat: `fees/priority` endpoint

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -763,7 +763,7 @@ paths:
       description: |
         Retrieve historical fee data, including the gas used ratio per block.
         Will return only fees for accessible blocks.
-        Max accessible blocks = BestBlock - api-backtrace-limit-flag .
+        Max accessible blocks = BestBlock - api-backtrace-limit-flag.
         api-backtrace-limit defaults to 1000 blocks.
       parameters:
         - $ref: '#/components/parameters/BlockCountInQuery'
@@ -782,6 +782,21 @@ paths:
               schema:
                 type: string
                 example: 'Invalid revision'
+  
+  /fees/priority:
+    get:
+      tags:
+        - Fees
+      summary: Suggest a priority fee for a transaction to be included in a block
+      description: |
+        This endpoint allows you to estimate the priority fee for a transaction to be included in a block.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetFeesPriorityResponse'
 
 components:
   schemas:
@@ -1275,6 +1290,18 @@ components:
               example:
                 - 0.75
                 - 0.22
+
+    GetFeesPriorityResponse:
+      type: object
+      title: GetFeesPriorityResponse
+      allOf:
+        - properties:
+            maxPriorityFeePerGas:
+              type: string
+              format: hex
+              description: |
+                The suggested maximum priority fee per gas as an hexadecimal string.
+              example: '0x98'
 
     TxMeta:
       title: TxMeta

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -100,6 +100,7 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 
 			for _, tx := range transactions {
 				fee := tx.MaxPriorityFeePerGas()
+				// TODO: explore other cases where maxPriorityFeePerGas is smaller than baseFee
 				fee.Sub(fee, header.BaseFee())
 				heap.Push(priorityFees, fee)
 				if priorityFees.Len() > priorityNumberOfTxsPerBlock {

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -21,6 +21,10 @@ const (
 	priorityPercentile          = 60
 )
 
+var (
+	priorityMinPriorityFee = big.NewInt(2)
+)
+
 // minPriorityHeap is a min-heap of priority fee values.
 type minPriorityHeap []*big.Int
 
@@ -92,6 +96,9 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 
 	if priorityFees.Len() > 0 {
 		priorityFeeEntry := (*priorityFees)[(priorityFees.Len()-1)*priorityPercentile/100]
+		if priorityFeeEntry.Cmp(priorityMinPriorityFee) < 0 {
+			priorityFeeEntry = priorityMinPriorityFee
+		}
 		priorityFee := (*hexutil.Big)(priorityFeeEntry)
 		return oldestBlockID, baseFees, gasUsedRatios, priorityFee, nil
 	}

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -96,9 +96,8 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 		newestBlockID = fees.parentBlockID
 	}
 
-	priorityFeesValues := priorityFees.GetAllValues()
-	if len(priorityFeesValues) > 0 {
-		priorityFeeEntry := priorityFeesValues[(len(priorityFeesValues)-1)*priorityPercentile/100]
+	if priorityFees.Len() > 0 {
+		priorityFeeEntry := priorityFees.GetAllValues()[(priorityFees.Len()-1)*priorityPercentile/100]
 		priorityFee := (*hexutil.Big)(priorityFeeEntry)
 		return oldestBlockID, baseFees, gasUsedRatios, priorityFee, nil
 	}

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -79,7 +79,7 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 	var oldestBlockID thor.Bytes32
 	for i := blockCount; i > 0; i-- {
 		oldestBlockID = newestBlockID
-		fees, err := fd.pushFeesToCache(newestBlockID)
+		fees, err := fd.getOrLoadFees(newestBlockID)
 		if err != nil {
 			return thor.Bytes32{}, nil, nil, nil, err
 		}
@@ -93,7 +93,7 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 	return oldestBlockID, baseFees, gasUsedRatios, priorityFees, nil
 }
 
-func (fd *FeesData) pushFeesToCache(blockID thor.Bytes32) (*FeeCacheEntry, error) {
+func (fd *FeesData) getOrLoadFees(blockID thor.Bytes32) (*FeeCacheEntry, error) {
 	fees, _, found := fd.cache.Get(blockID)
 	if found {
 		return fees.(*FeeCacheEntry), nil

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -7,11 +7,9 @@ package fees
 
 import (
 	"math"
-	"math/big"
 	"net/http"
 	"strconv"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/vechain/thor/v2/api/utils"
@@ -101,8 +99,12 @@ func (f *Fees) handleGetFeesHistory(w http.ResponseWriter, req *http.Request) er
 }
 
 func (f *Fees) handleGetPriority(w http.ResponseWriter, req *http.Request) error {
+	priorityFee, err := f.data.getPriorityFee()
+	if err != nil {
+		return err
+	}
 	return utils.WriteJSON(w, &FeesPriority{
-		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(0)),
+		MaxPriorityFeePerGas: priorityFee,
 	})
 }
 

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -100,9 +100,12 @@ func (f *Fees) handleGetFeesHistory(w http.ResponseWriter, req *http.Request) er
 	})
 }
 
-func (f *Fees) handleGetPriority(w http.ResponseWriter, req *http.Request) error {
+func (f *Fees) handleGetPriority(w http.ResponseWriter, _ *http.Request) error {
 	bestBlockSummary := f.data.repo.BestBlockSummary()
-	_, _, _, priorityFee, err := f.data.resolveRange(bestBlockSummary, priorityNumberOfBlocks)
+	blockCount := uint32(math.Min(float64(priorityNumberOfBlocks), float64(f.backtraceLimit)))
+	blockCount = uint32(math.Min(float64(blockCount), float64(bestBlockSummary.Header.Number()+1)))
+
+	_, _, _, priorityFee, err := f.data.resolveRange(bestBlockSummary, blockCount)
 	if err != nil {
 		return err
 	}

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -7,9 +7,11 @@ package fees
 
 import (
 	"math"
+	"math/big"
 	"net/http"
 	"strconv"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/vechain/thor/v2/api/utils"
@@ -98,10 +100,20 @@ func (f *Fees) handleGetFeesHistory(w http.ResponseWriter, req *http.Request) er
 	})
 }
 
+func (f *Fees) handleGetPriority(w http.ResponseWriter, req *http.Request) error {
+	return utils.WriteJSON(w, &FeesPriority{
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(0)),
+	})
+}
+
 func (f *Fees) Mount(root *mux.Router, pathPrefix string) {
 	sub := root.PathPrefix(pathPrefix).Subrouter()
 	sub.Path("/history").
 		Methods(http.MethodGet).
 		Name("GET /fees/history").
 		HandlerFunc(utils.WrapHandlerFunc(f.handleGetFeesHistory))
+	sub.Path("/priority").
+		Methods(http.MethodGet).
+		Name("GET /fees/priority").
+		HandlerFunc(utils.WrapHandlerFunc(f.handleGetPriority))
 }

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -17,6 +17,8 @@ import (
 	"github.com/vechain/thor/v2/chain"
 )
 
+const priorityNumberOfBlocks = 20
+
 type Fees struct {
 	data           *FeesData
 	bft            bft.Committer
@@ -86,7 +88,7 @@ func (f *Fees) handleGetFeesHistory(w http.ResponseWriter, req *http.Request) er
 		return err
 	}
 
-	oldestBlockRevision, baseFees, gasUsedRatios, err := f.data.resolveRange(newestBlockSummary, blockCount)
+	oldestBlockRevision, baseFees, gasUsedRatios, _, err := f.data.resolveRange(newestBlockSummary, blockCount)
 	if err != nil {
 		return err
 	}
@@ -99,7 +101,8 @@ func (f *Fees) handleGetFeesHistory(w http.ResponseWriter, req *http.Request) er
 }
 
 func (f *Fees) handleGetPriority(w http.ResponseWriter, req *http.Request) error {
-	priorityFee, err := f.data.getPriorityFee()
+	bestBlockSummary := f.data.repo.BestBlockSummary()
+	_, _, _, priorityFee, err := f.data.resolveRange(bestBlockSummary, priorityNumberOfBlocks)
 	if err != nil {
 		return err
 	}

--- a/api/fees/fees_test.go
+++ b/api/fees/fees_test.go
@@ -73,6 +73,7 @@ func TestFeesFixedSizeSameAsBacktrace(t *testing.T) {
 		"getFeeHistoryMoreBlocksRequestedThanAvailable": getFeeHistoryMoreBlocksRequestedThanAvailable,
 		"getFeeHistoryBlock0":                           getFeeHistoryBlock0,
 		"getFeeHistoryBlockCount0":                      getFeeHistoryBlockCount0,
+		"getFeePriority":                                getFeePriority,
 	} {
 		t.Run(name, func(t *testing.T) {
 			tt(t, tclient, bestchain)
@@ -338,4 +339,21 @@ func getFeeHistoryBlockCount0(t *testing.T, tclient *thorclient.Client, bestchai
 	require.Equal(t, 400, statusCode)
 	require.NotNil(t, res)
 	assert.Equal(t, "invalid blockCount, it should not be 0\n", string(res))
+}
+
+func getFeePriority(t *testing.T, tclient *thorclient.Client, bestchain *chain.Chain) {
+	res, statusCode, err := tclient.RawHTTPClient().RawHTTPGet("/fees/priority")
+	require.NoError(t, err)
+	require.Equal(t, 200, statusCode)
+	require.NotNil(t, res)
+	var feesPriority fees.FeesPriority
+	if err := json.Unmarshal(res, &feesPriority); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedFeesPriority := fees.FeesPriority{
+		MaxPriorityFeePerGas: (*hexutil.Big)(big.NewInt(100)),
+	}
+
+	assert.Equal(t, expectedFeesPriority, feesPriority)
 }

--- a/api/fees/types.go
+++ b/api/fees/types.go
@@ -15,3 +15,7 @@ type FeesHistory struct {
 	BaseFees      []*hexutil.Big `json:"baseFees"`
 	GasUsedRatios []float64      `json:"gasUsedRatios"`
 }
+
+type FeesPriority struct {
+	MaxPriorityFeePerGas *hexutil.Big `json:"maxPriorityFeePerGas"`
+}


### PR DESCRIPTION
# Description

This endpoint is a version of `eth_maxPriorityFeePerGas`. 

Interface-wise is the same, and the parameters are based on go-ethereum except for the max priority fee cap (500 gwei in Eth, we do not have a reference figure yet). The other difference is that all the params are internal and non-configurable (in geth they use also flags, we can do the same but I prefer to comment it over the PR).

Re-uses the cache logic of the other `fees` endpoint so the common cache is built by any of these endpoints.

Added a new integration test for this endpoint, further testing will be done as part of the follow-up ticket regarding parameters. Checked though that the priority fees array is built as expected.

Closes https://github.com/vechain/protocol-board-repo/issues/390
