### PR TITLE
BaseFee, maxFeePerGas and maxPriorityFeePerGas as hex

### DIFF
--- a/api/blocks/blocks_test.go
+++ b/api/blocks/blocks_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"testing"
 
+	hexMath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -290,6 +291,7 @@ func checkCollapsedBlock(t *testing.T, expBl *block.Block, actBl *blocks.JSONCol
 	for i, tx := range expBl.Transactions() {
 		assert.Equal(t, tx.ID(), actBl.Transactions[i], "txid should be equal")
 	}
+	assert.Equal(t, (*hexMath.HexOrDecimal256)(header.BaseFee()), actBl.BaseFee, "BaseFee should be equal")
 }
 
 func checkExpandedBlock(t *testing.T, expBl *block.Block, actBl *blocks.JSONExpandedBlock) {
@@ -308,4 +310,5 @@ func checkExpandedBlock(t *testing.T, expBl *block.Block, actBl *blocks.JSONExpa
 	for i, tx := range expBl.Transactions() {
 		assert.Equal(t, tx.ID(), actBl.Transactions[i].ID, "txid should be equal")
 	}
+	assert.Equal(t, (*hexMath.HexOrDecimal256)(header.BaseFee()), actBl.BaseFee, "BaseFee should be equal")
 }

--- a/api/blocks/types.go
+++ b/api/blocks/types.go
@@ -16,24 +16,24 @@ import (
 )
 
 type JSONBlockSummary struct {
-	Number       uint32       `json:"number"`
-	ID           thor.Bytes32 `json:"id"`
-	Size         uint32       `json:"size"`
-	ParentID     thor.Bytes32 `json:"parentID"`
-	Timestamp    uint64       `json:"timestamp"`
-	GasLimit     uint64       `json:"gasLimit"`
-	Beneficiary  thor.Address `json:"beneficiary"`
-	GasUsed      uint64       `json:"gasUsed"`
-	TotalScore   uint64       `json:"totalScore"`
-	TxsRoot      thor.Bytes32 `json:"txsRoot"`
-	TxsFeatures  uint32       `json:"txsFeatures"`
-	StateRoot    thor.Bytes32 `json:"stateRoot"`
-	ReceiptsRoot thor.Bytes32 `json:"receiptsRoot"`
-	COM          bool         `json:"com"`
-	Signer       thor.Address `json:"signer"`
-	IsTrunk      bool         `json:"isTrunk"`
-	IsFinalized  bool         `json:"isFinalized"`
-	BaseFee      *big.Int     `json:"baseFee,omitempty"`
+	Number       uint32                `json:"number"`
+	ID           thor.Bytes32          `json:"id"`
+	Size         uint32                `json:"size"`
+	ParentID     thor.Bytes32          `json:"parentID"`
+	Timestamp    uint64                `json:"timestamp"`
+	GasLimit     uint64                `json:"gasLimit"`
+	Beneficiary  thor.Address          `json:"beneficiary"`
+	GasUsed      uint64                `json:"gasUsed"`
+	TotalScore   uint64                `json:"totalScore"`
+	TxsRoot      thor.Bytes32          `json:"txsRoot"`
+	TxsFeatures  uint32                `json:"txsFeatures"`
+	StateRoot    thor.Bytes32          `json:"stateRoot"`
+	ReceiptsRoot thor.Bytes32          `json:"receiptsRoot"`
+	COM          bool                  `json:"com"`
+	Signer       thor.Address          `json:"signer"`
+	IsTrunk      bool                  `json:"isTrunk"`
+	IsFinalized  bool                  `json:"isFinalized"`
+	BaseFee      *math.HexOrDecimal256 `json:"baseFee,omitempty"`
 }
 
 type JSONRawBlockSummary struct {
@@ -121,7 +121,7 @@ func buildJSONBlockSummary(summary *chain.BlockSummary, isTrunk bool, isFinalize
 		COM:          header.COM(),
 		IsTrunk:      isTrunk,
 		IsFinalized:  isFinalized,
-		BaseFee:      summary.Header.BaseFee(),
+		BaseFee:      (*math.HexOrDecimal256)(summary.Header.BaseFee()),
 	}
 }
 

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -923,10 +923,13 @@ components:
       example:
         id: '0x4de71f2d588aa8a1ea00fe8312d92966da424d9939a511fc0be81e65fad52af8'
         chainTag: 1
+        txType: '0x51'
         blockRef: '0x00000001511fc0be'
         expiration: 30
         clauses: [ ]
         gasPriceCoef: 128
+        maxFeePerGas: '0x5af3107a4000'
+        maxPriorityFeePerGas: '0x278d'
         gas: 21000
         origin: '0x7567d83b7b8d80addcb281a71d54fc7b3364ffed'
         delegator: null
@@ -964,6 +967,7 @@ components:
         gasLimit: 11253579
         beneficiary: '0xb4094c25f86d628fdd571afc4077f0d0196afb48'
         gasUsed: 21000
+        baseFee: '0x9184e72a000'
         totalScore: 1029988
         txsRoot: '0x89dfd9fcd10c9e53d68592cf8b540b280b72d381b868523223992f3e09a806bb'
         txsFeatures: 0
@@ -1458,6 +1462,12 @@ components:
           description: The actual amount of gas used within the block
           example: 21000
           nullable: false
+        baseFee:
+          type: string
+          format: hex
+          description: The minimum amount of fee required to include a transaction in the current block
+          example: '0x9184e72a000'
+          nullable: true
         totalScore:
           type: integer
           format: uint64
@@ -1540,6 +1550,12 @@ components:
           example: '0x284bba50ef777889ff1a367ed0b38d5e5626714477c40de38d71cedd6f9fa477'
           pattern: '^0x[0-9a-f]{64}$'
           nullable: false
+        txType:
+          type: string
+          format: hex
+          description: The transaction type in hex.
+          example: '0x51'
+          nullable: false
         origin:
           type: string
           description: The address of the origin account.
@@ -1589,6 +1605,18 @@ components:
           description: The coefficient used to calculate the final gas price of the transaction.
           example: 0
           nullable: false
+        maxFeePerGas:
+          type: string
+          format: hex
+          description: The maximum amount that can be spent to pay for base fee and priority fee expressed in hex.
+          example: '0x5af3107a4000'
+          nullable: true
+        maxPriorityFeePerGas:
+          type: string
+          format: hex
+          description: The maximum amount that can be tipped to the validator expressed in hex.
+          example: '0x278d'
+          nullable: true
         gas:
           type: integer
           format: uint64

--- a/api/transactions/transactions_converter.go
+++ b/api/transactions/transactions_converter.go
@@ -6,8 +6,6 @@
 package transactions
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/vechain/thor/v2/block"
@@ -16,22 +14,22 @@ import (
 )
 
 type Transaction struct {
-	ID                   thor.Bytes32        `json:"id"`
-	ChainTag             byte                `json:"chainTag"`
-	BlockRef             string              `json:"blockRef"`
-	Expiration           uint32              `json:"expiration"`
-	Clauses              Clauses             `json:"clauses"`
-	GasPriceCoef         uint8               `json:"gasPriceCoef"`
-	Gas                  uint64              `json:"gas"`
-	MaxFeePerGas         *big.Int            `json:"maxFeePerGas,omitempty"`
-	MaxPriorityFeePerGas *big.Int            `json:"maxPriorityFeePerGas,omitempty"`
-	TxType               math.HexOrDecimal64 `json:"txType"`
-	Origin               thor.Address        `json:"origin"`
-	Delegator            *thor.Address       `json:"delegator"`
-	Nonce                math.HexOrDecimal64 `json:"nonce"`
-	DependsOn            *thor.Bytes32       `json:"dependsOn"`
-	Size                 uint32              `json:"size"`
-	Meta                 *TxMeta             `json:"meta"`
+	ID                   thor.Bytes32          `json:"id"`
+	TxType               math.HexOrDecimal64   `json:"txType"`
+	ChainTag             byte                  `json:"chainTag"`
+	BlockRef             string                `json:"blockRef"`
+	Expiration           uint32                `json:"expiration"`
+	Clauses              Clauses               `json:"clauses"`
+	GasPriceCoef         uint8                 `json:"gasPriceCoef"`
+	Gas                  uint64                `json:"gas"`
+	MaxFeePerGas         *math.HexOrDecimal256 `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas *math.HexOrDecimal256 `json:"maxPriorityFeePerGas,omitempty"`
+	Origin               thor.Address          `json:"origin"`
+	Delegator            *thor.Address         `json:"delegator"`
+	Nonce                math.HexOrDecimal64   `json:"nonce"`
+	DependsOn            *thor.Bytes32         `json:"dependsOn"`
+	Size                 uint32                `json:"size"`
+	Meta                 *TxMeta               `json:"meta"`
 }
 
 // convertTransaction convert a raw transaction into a json format transaction
@@ -64,8 +62,8 @@ func convertTransaction(trx *tx.Transaction, header *block.Header) *Transaction 
 	case tx.TypeLegacy:
 		t.GasPriceCoef = trx.GasPriceCoef()
 	default:
-		t.MaxFeePerGas = trx.MaxFeePerGas()
-		t.MaxPriorityFeePerGas = trx.MaxPriorityFeePerGas()
+		t.MaxFeePerGas = (*math.HexOrDecimal256)(trx.MaxFeePerGas())
+		t.MaxPriorityFeePerGas = (*math.HexOrDecimal256)(trx.MaxPriorityFeePerGas())
 	}
 
 	if header != nil {

--- a/api/transactions/transactions_coverter_test.go
+++ b/api/transactions/transactions_coverter_test.go
@@ -37,6 +37,7 @@ func TestConvertLegacyTransaction_Success(t *testing.T) {
 
 	result := convertTransaction(transaction, header)
 	// Common fields
+	assert.Equal(t, (math.HexOrDecimal64)(transaction.Type()), result.TxType)
 	assert.Equal(t, hexutil.Encode(br[:]), result.BlockRef)
 	assert.Equal(t, transaction.ChainTag(), result.ChainTag)
 	assert.Equal(t, transaction.Expiration(), result.Expiration)
@@ -77,6 +78,7 @@ func TestConvertDynTransaction_Success(t *testing.T) {
 
 	result := convertTransaction(transaction, header)
 	// Common fields
+	assert.Equal(t, (math.HexOrDecimal64)(transaction.Type()), result.TxType)
 	assert.Equal(t, hexutil.Encode(br[:]), result.BlockRef)
 	assert.Equal(t, transaction.ChainTag(), result.ChainTag)
 	assert.Equal(t, transaction.Expiration(), result.Expiration)
@@ -88,8 +90,8 @@ func TestConvertDynTransaction_Success(t *testing.T) {
 	assert.Equal(t, addr, *result.Clauses[1].To)
 	assert.Equal(t, convertClause(cla2), result.Clauses[1])
 	// DynFee fields
-	assert.Equal(t, maxFeePerGas, result.MaxFeePerGas)
-	assert.Equal(t, maxPriorityFeePerGas, result.MaxPriorityFeePerGas)
+	assert.Equal(t, (*math.HexOrDecimal256)(maxFeePerGas), result.MaxFeePerGas)
+	assert.Equal(t, (*math.HexOrDecimal256)(maxPriorityFeePerGas), result.MaxPriorityFeePerGas)
 	// Non dynFee fields
 	assert.Empty(t, result.GasPriceCoef)
 }

--- a/api/transactions/transactions_test.go
+++ b/api/transactions/transactions_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -413,8 +414,8 @@ func checkMatchingTx(t *testing.T, expectedTx *tx.Transaction, actualTx *transac
 		assert.Empty(t, actualTx.MaxPriorityFeePerGas)
 	case tx.TypeDynamicFee:
 		assert.Empty(t, actualTx.GasPriceCoef)
-		assert.Equal(t, expectedTx.MaxFeePerGas(), actualTx.MaxFeePerGas)
-		assert.Equal(t, expectedTx.MaxPriorityFeePerGas(), actualTx.MaxPriorityFeePerGas)
+		assert.Equal(t, (*math.HexOrDecimal256)(expectedTx.MaxFeePerGas()), actualTx.MaxFeePerGas)
+		assert.Equal(t, (*math.HexOrDecimal256)(expectedTx.MaxPriorityFeePerGas()), actualTx.MaxPriorityFeePerGas)
 	}
 }
 


### PR DESCRIPTION
# Description

This PR returns the `baseFee`, `maxFeePerGas`, `maxPriorityFeePerGas` as hex values in `/transactions` and `/blocks` api endpoints response.

[GHIssue](https://github.com/vechain/protocol-board-repo/issues/440)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
