### PR TITLE
Don't remove tx if non adoptable because baseFee too high

### DIFF
--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -320,6 +320,17 @@ func (c *Consensus) verifyBlock(blk *block.Block, state *state.State, blockConfl
 			return nil, nil, consensusError("tx already exists")
 		}
 
+		// check if tx has enough fee to cover for base fee, if set
+		if header.BaseFee() != nil {
+			baseGasPrice, err := builtin.Params.Native(state).Get(thor.KeyBaseGasPrice)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err := fork.ValidateGalacticaTxFee(tx, header.BaseFee(), baseGasPrice); err != nil {
+				return nil, nil, err
+			}
+		}
+
 		// check depended tx
 		if dep := tx.DependsOn(); dep != nil {
 			found, reverted, err := findDep(*dep)

--- a/packer/flow.go
+++ b/packer/flow.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
 	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/consensus/fork"
 	"github.com/vechain/thor/v2/runtime"
 	"github.com/vechain/thor/v2/state"
@@ -124,6 +125,13 @@ func (f *Flow) Adopt(t *tx.Transaction) error {
 	} else {
 		if f.runtime.Context().BaseFee == nil {
 			return fork.ErrBaseFeeNotSet
+		}
+		baseGasPrice, err := builtin.Params.Native(f.runtime.State()).Get(thor.KeyBaseGasPrice)
+		if err != nil {
+			return err
+		}
+		if err := fork.ValidateGalacticaTxFee(t, f.runtime.Context().BaseFee, baseGasPrice); err != nil {
+			return errTxNotAdoptableNow
 		}
 	}
 

--- a/packer/flow_test.go
+++ b/packer/flow_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/vechain/thor/v2/genesis"
 	"github.com/vechain/thor/v2/muxdb"
 	"github.com/vechain/thor/v2/packer"
-	"github.com/vechain/thor/v2/runtime"
 	"github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/test/testchain"
 	"github.com/vechain/thor/v2/thor"
@@ -228,7 +227,7 @@ func TestPackAfterGalacticaFork(t *testing.T) {
 	// Adopt a tx which has not enough max fee to cover for base fee
 	badTx := tx.NewTxBuilder(tx.TypeDynamicFee).ChainTag(repo.ChainTag()).Gas(21000).MaxFeePerGas(big.NewInt(thor.InitialBaseFee - 1)).MaxPriorityFeePerGas(common.Big1).Expiration(100).MustBuild()
 	badTx = tx.MustSign(badTx, genesis.DevAccounts()[0].PrivateKey)
-	expectedErrorMessage := fmt.Sprintf("bad tx: %s", runtime.ErrMaxFeePerGasTooLow.Error())
+	expectedErrorMessage := "tx not adoptable now"
 	if err := flow.Adopt(badTx); err.Error() != expectedErrorMessage {
 		t.Fatalf("Expected error message: '%s', but got: '%s'", expectedErrorMessage, err.Error())
 	}
@@ -323,7 +322,7 @@ func TestAdoptErrorAfterGalactica(t *testing.T) {
 	tr = tx.NewTxBuilder(tx.TypeDynamicFee).ChainTag(chain.Repo().ChainTag()).Nonce(2).MaxFeePerGas(notEnoughBaseFee).Gas(21000).Expiration(100).MustBuild()
 	tr = tx.MustSign(tr, genesis.DevAccounts()[0].PrivateKey)
 	err = chain.MintBlock(genesis.DevAccounts()[0], tr)
-	expectedErrMsg = "unable to adopt tx into block: bad tx: max fee per gas is less than block base fee"
+	expectedErrMsg = "unable to adopt tx into block: tx not adoptable now"
 	assert.Equal(t, expectedErrMsg, err.Error())
 
 	// Try to adopt a dyn fee with just the right amount of max fee per gas - SUCCESS

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -35,12 +35,6 @@ var (
 	EmptyRuntimeBytecode = []byte{0x60, 0x60, 0x60, 0x40, 0x52, 0x60, 0x02, 0x56}
 )
 
-var (
-	// ErrMaxFeePerGasTooLow is returned if the transaction fee cap is less than
-	// the base fee of the block.
-	ErrMaxFeePerGasTooLow = errors.New("max fee per gas is less than block base fee")
-)
-
 func init() {
 	var found bool
 	if energyTransferEvent, found = builtin.Energy.ABI.EventByName("Transfer"); !found {
@@ -420,13 +414,6 @@ func (rt *Runtime) PrepareTransaction(tx *tx.Transaction) (*TransactionExecutor,
 	baseGasPrice, gasPrice, payer, _, returnGas, err := resolvedTx.BuyGas(rt.state, rt.ctx.Time, &fork.GalacticaItems{IsActive: galactica, BaseFee: rt.ctx.BaseFee})
 	if err != nil {
 		return nil, err
-	}
-
-	if galactica {
-		feeItems := fork.GalacticaTxGasPriceAdapter(tx, gasPrice)
-		if feeItems.MaxFee.Cmp(rt.ctx.BaseFee) < 0 {
-			return nil, ErrMaxFeePerGasTooLow
-		}
 	}
 
 	txCtx, err := resolvedTx.ToContext(gasPrice, payer, rt.ctx.Number, rt.chain.GetBlockID)

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -242,7 +242,7 @@ func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmi
 		}
 
 		state := p.stater.NewState(headSummary.Root())
-		if err := ValidateTransactionWithState(newTx, headSummary, p.forkConfig, state); err != nil {
+		if err := ValidateTransactionWithState(newTx, headSummary.Header, p.forkConfig, state); err != nil {
 			return err
 		}
 		executable, err := txObj.Executable(p.repo.NewChain(headSummary.Header.ID()), state, headSummary.Header, p.forkConfig)


### PR DESCRIPTION
# Description

When adopting a tx previously accepted in the mempool when the `baseFee` is higher was causing the tx to be removed from the mempool. Now it's just ignored because it's not adoptable now

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
