### PR TITLE
refactor: move log printing galactica activation

### DIFF
--- a/cmd/thor/node/packer_loop.go
+++ b/cmd/thor/node/packer_loop.go
@@ -200,6 +200,12 @@ func (n *Node) pack(flow *packer.Flow) (err error) {
 			"et", fmt.Sprintf("%v|%v", common.PrettyDuration(execElapsed), common.PrettyDuration(commitElapsed)),
 			"id", shortID(newBlock.Header().ID()),
 		)
+		// TODO: log to be removed when fork is stable
+		if newBlock.Header().Number()+1 == n.forkConfig.GALACTICA {
+			logger.Info("Last block before Galactica fork activates!")
+		} else if newBlock.Header().Number() == n.forkConfig.GALACTICA {
+			logger.Info("Galactica fork activated!")
+		}
 
 		if v, updated := n.bandwidth.Update(newBlock.Header(), time.Duration(realElapsed)); updated {
 			logger.Trace("bandwidth updated", "gps", v)

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/consensus/fork"
-	"github.com/vechain/thor/v2/log"
 	"github.com/vechain/thor/v2/poa"
 	"github.com/vechain/thor/v2/runtime"
 	"github.com/vechain/thor/v2/state"
@@ -20,8 +19,6 @@ import (
 	"github.com/vechain/thor/v2/tx"
 	"github.com/vechain/thor/v2/xenv"
 )
-
-var logger = log.WithContext("pkg", "packer")
 
 // Packer to pack txs and build new blocks.
 type Packer struct {
@@ -130,12 +127,6 @@ func (p *Packer) Schedule(parent *chain.BlockSummary, nowTimestamp uint64) (flow
 	var baseFee *big.Int
 
 	if parent.Header.Number()+1 >= p.forkConfig.GALACTICA {
-		// TODO: log to be removed when fork is stable
-		if parent.Header.Number()-1 == p.forkConfig.GALACTICA {
-			logger.Info("Last block before Galactica fork activates")
-		} else if parent.Header.Number() == p.forkConfig.GALACTICA {
-			logger.Info("Galactica fork activated")
-		}
 		baseFee = fork.CalcBaseFee(&p.forkConfig, parent.Header)
 	}
 
@@ -174,12 +165,6 @@ func (p *Packer) Mock(parent *chain.BlockSummary, targetTime uint64, gasLimit ui
 
 	var baseFee *big.Int
 	if parent.Header.Number()+1 >= p.forkConfig.GALACTICA {
-		// TODO: log to be removed when fork is stable
-		if parent.Header.Number()-1 == p.forkConfig.GALACTICA {
-			logger.Info("Last block before Galactica fork activates")
-		} else if parent.Header.Number() == p.forkConfig.GALACTICA {
-			logger.Info("Galactica fork activated")
-		}
 		baseFee = fork.CalcBaseFee(&p.forkConfig, parent.Header)
 	}
 


### PR DESCRIPTION
# Description

Moved the log stating galactica activation after a block is packed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
