### PR TITLE
fix: use best block ID for txs if provided is higher number

### DIFF
--- a/api/transactions/transactions.go
+++ b/api/transactions/transactions.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vechain/thor/v2/api/utils"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/thor"
+	"github.com/vechain/thor/v2/tx"
 	"github.com/vechain/thor/v2/txpool"
 )
 
@@ -209,6 +210,10 @@ func (t *Transactions) parseHead(head string) (thor.Bytes32, error) {
 	h, err := thor.ParseBytes32(head)
 	if err != nil {
 		return thor.Bytes32{}, err
+	}
+	// if the provided head is newer than the best block, return the best block ID.
+	if tx.NewBlockRefFromID(h).Number() > t.repo.BestBlockSummary().Header.Number() {
+		return t.repo.BestBlockSummary().Header.ID(), nil
 	}
 	return h, nil
 }


### PR DESCRIPTION
# Description

This PR seeks to reduce the `leveldb not found` error when clients are requesting a tx receipt with a given block ID that is higher than the best. (this happens a lot with ALB + connex)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
