### PR TITLE
vm: keep shanghai as a version name

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -60,8 +60,8 @@ var baseChainConfig = vm.ChainConfig{
 		Ethash:              nil,
 		Clique:              nil,
 	},
-	IstanbulBlock:  nil,
-	GalacticaBlock: nil,
+	IstanbulBlock: nil,
+	ShanghaiBlock: nil,
 }
 
 // Output output of clause execution.
@@ -100,7 +100,7 @@ func New(
 	currentChainConfig := baseChainConfig
 	currentChainConfig.ConstantinopleBlock = big.NewInt(int64(forkConfig.ETH_CONST))
 	currentChainConfig.IstanbulBlock = big.NewInt(int64(forkConfig.ETH_IST))
-	currentChainConfig.GalacticaBlock = big.NewInt(int64(forkConfig.GALACTICA))
+	currentChainConfig.ShanghaiBlock = big.NewInt(int64(forkConfig.GALACTICA))
 	if chain != nil {
 		// use genesis id as chain id
 		currentChainConfig.ChainID = new(big.Int).SetBytes(chain.GenesisID().Bytes())
@@ -108,7 +108,7 @@ func New(
 
 	// alloc precompiled contracts
 	if forkConfig.GALACTICA == ctx.Number {
-		for addr := range vm.PrecompiledContractsGalactica {
+		for addr := range vm.PrecompiledContractsShanghai {
 			if err := state.SetCode(thor.Address(addr), EmptyRuntimeBytecode); err != nil {
 				panic(err)
 			}
@@ -410,7 +410,7 @@ func (rt *Runtime) PrepareTransaction(tx *tx.Transaction) (*TransactionExecutor,
 		return nil, err
 	}
 
-	galactica := rt.chainConfig.IsGalactica(big.NewInt(int64(rt.ctx.Number)))
+	galactica := rt.chainConfig.IsShanghai(big.NewInt(int64(rt.ctx.Number)))
 	baseGasPrice, gasPrice, payer, _, returnGas, err := resolvedTx.BuyGas(rt.state, rt.ctx.Time, &fork.GalacticaItems{IsActive: galactica, BaseFee: rt.ctx.BaseFee})
 	if err != nil {
 		return nil, err

--- a/vm/chain_config.go
+++ b/vm/chain_config.go
@@ -22,8 +22,8 @@ func isForked(s, head *big.Int) bool {
 // ChainConfig extends eth ChainConfig.
 type ChainConfig struct {
 	params.ChainConfig
-	IstanbulBlock  *big.Int `json:"istanbulBlock,omitempty"`  // Istanbul switch block (nil = no fork, 0 = already on istanbul)
-	GalacticaBlock *big.Int `json:"galacticaBlock,omitempty"` // Galactica switch block (nil = no fork, 0 = already on galactica)
+	IstanbulBlock *big.Int `json:"istanbulBlock,omitempty"` // Istanbul switch block (nil = no fork, 0 = already on istanbul)
+	ShanghaiBlock *big.Int `json:"shanghaiBlock,omitempty"` // Shanghai switch block (nil = no fork, 0 = already on shanghai)
 }
 
 // IsIstanbul returns whether num is either equal to the Istanbul fork block or greater.
@@ -31,9 +31,9 @@ func (c *ChainConfig) IsIstanbul(num *big.Int) bool {
 	return isForked(c.IstanbulBlock, num)
 }
 
-// IsGalactica returns whether num is either equal to the Istanbul fork block or greater.
-func (c *ChainConfig) IsGalactica(num *big.Int) bool {
-	return isForked(c.GalacticaBlock, num)
+// IsShanghai returns whether num is either equal to the Shanghai fork block or greater.
+func (c *ChainConfig) IsShanghai(num *big.Int) bool {
+	return isForked(c.ShanghaiBlock, num)
 }
 
 // Rules wraps ChainConfig and is merely syntatic sugar or can be used for functions
@@ -46,7 +46,7 @@ type Rules struct {
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158 bool
 	IsByzantium                               bool
 	IsIstanbul                                bool
-	IsGalactica                               bool
+	IsShanghai                                bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -63,6 +63,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsEIP158:    c.IsEIP158(num),
 		IsByzantium: c.IsByzantium(num),
 		IsIstanbul:  c.IsIstanbul((num)),
-		IsGalactica: c.IsGalactica((num)),
+		IsShanghai:  c.IsShanghai((num)),
 	}
 }

--- a/vm/contracts.go
+++ b/vm/contracts.go
@@ -77,11 +77,11 @@ var PrecompiledContractsIstanbul = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 }
 
-// PrecompiledContractsGalactica contains the default set of pre-compiled Ethereum
+// PrecompiledContractsShanghai contains the default set of pre-compiled Ethereum
 // contracts used in the Shanghai release.
 // NOTE: Shanghai release does not introduce any changes in precompiled contracts.
 // We are catching up from Istanbul, so Shanghai in thor includes eip1108 and eip2565.
-var PrecompiledContractsGalactica = map[common.Address]PrecompiledContract{
+var PrecompiledContractsShanghai = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}): &safeEcrecover{},
 	common.BytesToAddress([]byte{2}): &sha256hash{},
 	common.BytesToAddress([]byte{3}): &ripemd160hash{},
@@ -94,7 +94,7 @@ var PrecompiledContractsGalactica = map[common.Address]PrecompiledContract{
 }
 
 var (
-	PrecompiledAddressesGalactica []common.Address
+	PrecompiledAddressesShanghai  []common.Address
 	PrecompiledAddressesIstanbul  []common.Address
 	PrecompiledAddressesByzantium []common.Address
 	PrecompiledAddressesHomestead []common.Address
@@ -110,16 +110,16 @@ func init() {
 	for k := range PrecompiledContractsIstanbul {
 		PrecompiledAddressesIstanbul = append(PrecompiledAddressesIstanbul, k)
 	}
-	for k := range PrecompiledContractsGalactica {
-		PrecompiledAddressesGalactica = append(PrecompiledAddressesGalactica, k)
+	for k := range PrecompiledContractsShanghai {
+		PrecompiledAddressesShanghai = append(PrecompiledAddressesShanghai, k)
 	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules Rules) []common.Address {
 	switch {
-	case rules.IsGalactica:
-		return PrecompiledAddressesGalactica
+	case rules.IsShanghai:
+		return PrecompiledAddressesShanghai
 	case rules.IsIstanbul:
 		return PrecompiledAddressesIstanbul
 	case rules.IsByzantium:

--- a/vm/evm.go
+++ b/vm/evm.go
@@ -52,8 +52,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
-	case evm.chainRules.IsGalactica:
-		precompiles = PrecompiledContractsGalactica
+	case evm.chainRules.IsShanghai:
+		precompiles = PrecompiledContractsShanghai
 	case evm.chainRules.IsIstanbul:
 		precompiles = PrecompiledContractsIstanbul
 	case evm.chainRules.IsByzantium:
@@ -492,7 +492,7 @@ func (evm *EVM) create(caller ContractRef, code []byte, gas uint64, value *big.I
 	}
 
 	// Reject code starting with 0xEF if EIP-3541 is enabled.
-	if err == nil && len(ret) >= 1 && ret[0] == 0xEF && evm.chainRules.IsGalactica {
+	if err == nil && len(ret) >= 1 && ret[0] == 0xEF && evm.chainRules.IsShanghai {
 		err = ErrInvalidCode
 	}
 

--- a/vm/interpreter.go
+++ b/vm/interpreter.go
@@ -59,7 +59,7 @@ func NewInterpreter(evm *EVM, cfg Config) *Interpreter {
 	// we'll set the default jump table.
 	if cfg.JumpTable == nil {
 		switch {
-		case evm.ChainConfig().IsGalactica(evm.BlockNumber):
+		case evm.ChainConfig().IsShanghai(evm.BlockNumber):
 			cfg.JumpTable = shanghaiInstructionSet
 		case evm.ChainConfig().IsIstanbul(evm.BlockNumber):
 			cfg.JumpTable = istanbulInstructionSet


### PR DESCRIPTION
# Description

This PR reverts name changes in vm package to kept shanghai as it's a evm version.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
