### PR TITLE
fix: add an error log for WriteJSON

### DIFF
--- a/api/utils/http.go
+++ b/api/utils/http.go
@@ -102,7 +102,11 @@ func ParseJSON(r io.Reader, v interface{}) error {
 // WriteJSON response an object in JSON encoding.
 func WriteJSON(w http.ResponseWriter, obj interface{}) error {
 	w.Header().Set("Content-Type", JSONContentType)
-	return json.NewEncoder(w).Encode(obj)
+	err := json.NewEncoder(w).Encode(obj)
+	if err != nil {
+		logger.Error("failed to write JSON response", "err", err)
+	}
+	return nil
 }
 
 // HandleGone is a handler for deprecated endpoints that returns HTTP 410 Gone.


### PR DESCRIPTION
# Description

If WriteJSON fails, we should not return an error

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
