### PR TITLE
feat: resolve url genesis

### DIFF
--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -13,7 +13,7 @@ import (
 var (
 	networkFlag = cli.StringFlag{
 		Name:  "network",
-		Usage: "the network to join (main|test) or path/ URL to a genesis file",
+		Usage: "the network to join (main|test) or path / URL to a genesis file",
 	}
 	configDirFlag = cli.StringFlag{
 		Name:   "config-dir",
@@ -202,6 +202,6 @@ var (
 	}
 	genesisFlag = cli.StringFlag{
 		Name:  "genesis",
-		Usage: "path to genesis file, if not set, the default devnet genesis will be used",
+		Usage: "path or URL to genesis file, if not set, the default devnet genesis will be used",
 	}
 )

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -13,7 +13,7 @@ import (
 var (
 	networkFlag = cli.StringFlag{
 		Name:  "network",
-		Usage: "the network to join (main|test) or path to genesis file",
+		Usage: "the network to join (main|test) or path/ URL to a genesis file",
 	}
 	configDirFlag = cli.StringFlag{
 		Name:   "config-dir",

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -13,7 +13,7 @@ import (
 var (
 	networkFlag = cli.StringFlag{
 		Name:  "network",
-		Usage: "the network to join (main|test) or path / URL to a genesis file",
+		Usage: "the network to join (main|test) or the path/URL to a genesis file",
 	}
 	configDirFlag = cli.StringFlag{
 		Name:   "config-dir",

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -253,7 +253,7 @@ func selectGenesis(ctx *cli.Context) (*genesis.Genesis, thor.ForkConfig, error) 
 func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
 	var (
 		reader io.ReadCloser
-		err error
+		err    error
 	)
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
 		res, err := http.Get(uri) // #nosec

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -252,7 +252,7 @@ func selectGenesis(ctx *cli.Context) (*genesis.Genesis, thor.ForkConfig, error) 
 
 func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
 	var reader io.Reader
-	
+
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
 		res, err := http.Get(uri) // #nosec
 		if err != nil {

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -251,11 +251,8 @@ func selectGenesis(ctx *cli.Context) (*genesis.Genesis, thor.ForkConfig, error) 
 }
 
 func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
-	var (
-		reader io.Reader
-		err    error
-	)
-
+	var reader io.Reader
+	
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
 		res, err := http.Get(uri) // #nosec
 		if err != nil {

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -251,23 +251,23 @@ func selectGenesis(ctx *cli.Context) (*genesis.Genesis, thor.ForkConfig, error) 
 }
 
 func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
-	var reader io.Reader
-
+	var (
+		reader io.ReadCloser
+		err error
+	)
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
 		res, err := http.Get(uri) // #nosec
 		if err != nil {
 			return nil, thor.ForkConfig{}, errors.Wrap(err, "http get genesis file")
 		}
-		defer res.Body.Close()
 		reader = res.Body
 	} else {
-		file, err := os.Open(uri)
+		reader, err = os.Open(uri)
 		if err != nil {
 			return nil, thor.ForkConfig{}, errors.Wrap(err, "open genesis file")
 		}
-		defer file.Close()
-		reader = file
 	}
+	defer reader.Close()
 
 	decoder := json.NewDecoder(reader)
 	decoder.DisallowUnknownFields()

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -257,7 +257,7 @@ func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
 	)
 
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
-		res, err := http.Get(uri)
+		res, err := http.Get(uri) // #nosec
 		if err != nil {
 			return nil, thor.ForkConfig{}, errors.Wrap(err, "http get genesis file")
 		}

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -266,6 +266,7 @@ func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
 			return nil, thor.ForkConfig{}, errors.Wrap(err, "open genesis file")
 		}
 		defer file.Close()
+		reader = file
 	}
 
 	decoder := json.NewDecoder(reader)


### PR DESCRIPTION
# Description

Resolve URLs when starting a node

1. Solo
```bash
go run ./cmd/thor solo --genesis https://raw.githubusercontent.com/vechain/thor-e2e-tests/refs/heads/main/network/config/genesis.json
```

2. Custom Network
```
go run ./cmd/thor --network https://raw.githubusercontent.com/vechain/thor-e2e-tests/refs/heads/main/network/config/genesis.json  
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
