### PR TITLE
Add more baseFee and validation tests

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -460,6 +460,35 @@ func TestValidateBlockHeader(t *testing.T) {
 	}
 }
 
+func TestValidateBlockHeaderWithBadBaseFee(t *testing.T) {
+	forkConfig := testchain.DefaultForkConfig
+	forkConfig.GALACTICA = 1
+	forkConfig.VIP214 = 2
+
+	chain, err := testchain.NewWithFork(forkConfig)
+	assert.NoError(t, err)
+
+	con := New(chain.Repo(), chain.Stater(), forkConfig)
+
+	best, err := chain.BestBlock()
+	assert.NoError(t, err)
+
+	var sig [65]byte
+	rand.Read(sig[:])
+	newBlock := new(block.Builder).
+		ParentID(best.Header().ID()).
+		Timestamp(best.Header().Timestamp() + thor.BlockInterval).
+		TotalScore(best.Header().TotalScore() + 1).
+		BaseFee(big.NewInt(thor.InitialBaseFee * 123)).
+		TransactionFeatures(1).
+		GasLimit(thor.InitialGasLimit).
+		Build().
+		WithSignature(sig[:])
+
+	_, _, err = con.Process(con.repo.BestBlockSummary(), newBlock, newBlock.Header().Timestamp(), 0)
+	assert.Contains(t, err.Error(), "block header invalid: invalid baseFee: have 10000000000000, want 1230000000000000")
+}
+
 func TestVerifyBlock(t *testing.T) {
 	tc, err := newTestConsensus()
 	if err != nil {

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -486,23 +486,23 @@ func TestOrderTxsAfterGalacticaFork(t *testing.T) {
 	}
 
 	// Add a tx with the highest priority fee
-	firstTx := tx.NewTxBuilder(tx.TypeDynamicFee).
+	firstTx := tx.NewBuilder(tx.TypeDynamicFee).
 		ChainTag(repo.ChainTag()).
 		Expiration(100).
 		Gas(21000).
 		MaxFeePerGas(big.NewInt(thor.InitialBaseFee * 10)).
 		MaxPriorityFeePerGas(big.NewInt(thor.InitialBaseFee * 10)).
-		MustBuild()
+		Build()
 	firstTx = tx.MustSign(firstTx, devAccounts[0].PrivateKey)
 
 	// Add a tx with 0 priority fee
-	lastTx := tx.NewTxBuilder(tx.TypeDynamicFee).
+	lastTx := tx.NewBuilder(tx.TypeDynamicFee).
 		ChainTag(repo.ChainTag()).
 		Expiration(100).
 		Gas(21000).
 		MaxFeePerGas(big.NewInt(thor.InitialBaseFee * 10)).
 		MaxPriorityFeePerGas(common.Big0).
-		MustBuild()
+		Build()
 	lastTx = tx.MustSign(lastTx, devAccounts[0].PrivateKey)
 
 	assert.Nil(t, pool.Add(firstTx))

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
@@ -454,16 +455,16 @@ func TestOrderTxsAfterGalacticaFork(t *testing.T) {
 	repo, _ := chain.NewRepository(db, b0)
 	repo.AddBlock(b1, tx.Receipts{}, 0, true)
 
-	totalPoolTxs := 10_000
+	poolLimit := 10_000
 	pool := New(repo, state.NewStater(db), Options{
-		Limit:           totalPoolTxs,
-		LimitPerAccount: totalPoolTxs,
+		Limit:           poolLimit,
+		LimitPerAccount: poolLimit,
 		MaxLifetime:     time.Hour,
 	}, &thor.ForkConfig{GALACTICA: 1})
 	defer pool.Close()
 
 	txs := make(map[thor.Bytes32]*tx.Transaction)
-	for i := range totalPoolTxs {
+	for i := range poolLimit - 2 {
 		tx := tx.MustSign(generateRandomTx(t, i, repo.ChainTag()), devAccounts[i%len(devAccounts)].PrivateKey)
 		txs[tx.ID()] = tx
 		assert.Nil(t, pool.Add(tx))
@@ -473,7 +474,7 @@ func TestOrderTxsAfterGalacticaFork(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Zero(t, removed)
 	assert.Equal(t, len(txs), len(execTxs))
-	assert.Equal(t, totalPoolTxs, len(execTxs))
+	assert.Equal(t, poolLimit-2, len(execTxs))
 	baseGasPrice, err := builtin.Params.Native(st).Get(thor.KeyBaseGasPrice)
 	assert.Nil(t, err)
 	for i := 1; i < len(txs); i++ {
@@ -483,6 +484,36 @@ func TestOrderTxsAfterGalacticaFork(t *testing.T) {
 		currEffectiveFee := math.BigMin(new(big.Int).Sub(currGalacticaFee.MaxFee, b1.Header().BaseFee()), currGalacticaFee.MaxPriorityFee)
 		assert.True(t, prevEffectiveFee.Cmp(currEffectiveFee) >= 0)
 	}
+
+	// Add a tx with the highest priority fee
+	firstTx := tx.NewTxBuilder(tx.TypeDynamicFee).
+		ChainTag(repo.ChainTag()).
+		Expiration(100).
+		Gas(21000).
+		MaxFeePerGas(big.NewInt(thor.InitialBaseFee * 10)).
+		MaxPriorityFeePerGas(big.NewInt(thor.InitialBaseFee * 10)).
+		MustBuild()
+	firstTx = tx.MustSign(firstTx, devAccounts[0].PrivateKey)
+
+	// Add a tx with 0 priority fee
+	lastTx := tx.NewTxBuilder(tx.TypeDynamicFee).
+		ChainTag(repo.ChainTag()).
+		Expiration(100).
+		Gas(21000).
+		MaxFeePerGas(big.NewInt(thor.InitialBaseFee * 10)).
+		MaxPriorityFeePerGas(common.Big0).
+		MustBuild()
+	lastTx = tx.MustSign(lastTx, devAccounts[0].PrivateKey)
+
+	assert.Nil(t, pool.Add(firstTx))
+	assert.Nil(t, pool.Add(lastTx))
+
+	execTxs, removed, err = pool.wash(pool.repo.BestBlockSummary())
+	assert.Nil(t, err)
+	assert.Zero(t, removed)
+	assert.Equal(t, poolLimit, len(execTxs))
+	assert.Equal(t, execTxs[0].ID(), firstTx.ID())
+	assert.Equal(t, execTxs[len(execTxs)-1].ID(), lastTx.ID())
 }
 
 func TestOrderTxsAfterGalacticaForkSameValues(t *testing.T) {


### PR DESCRIPTION
# Description

This PR adds two more tests for galactica:
- validate a malicious proposed block with a fake baseFee;
- adding a tx with the highest priority fee makes it first in line;
- adding a tx with the lowest priority fee makes it the last one.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
