### PR TITLE
Rename baseGas to baseFeePerGas as per VIP

### DIFF
--- a/api/blocks/blocks_test.go
+++ b/api/blocks/blocks_test.go
@@ -291,7 +291,7 @@ func checkCollapsedBlock(t *testing.T, expBl *block.Block, actBl *blocks.JSONCol
 	for i, tx := range expBl.Transactions() {
 		assert.Equal(t, tx.ID(), actBl.Transactions[i], "txid should be equal")
 	}
-	assert.Equal(t, (*hexMath.HexOrDecimal256)(header.BaseFee()), actBl.BaseFee, "BaseFee should be equal")
+	assert.Equal(t, (*hexMath.HexOrDecimal256)(header.BaseFee()), actBl.BaseFeePerGas, "BaseFee should be equal")
 }
 
 func checkExpandedBlock(t *testing.T, expBl *block.Block, actBl *blocks.JSONExpandedBlock) {
@@ -310,5 +310,5 @@ func checkExpandedBlock(t *testing.T, expBl *block.Block, actBl *blocks.JSONExpa
 	for i, tx := range expBl.Transactions() {
 		assert.Equal(t, tx.ID(), actBl.Transactions[i].ID, "txid should be equal")
 	}
-	assert.Equal(t, (*hexMath.HexOrDecimal256)(header.BaseFee()), actBl.BaseFee, "BaseFee should be equal")
+	assert.Equal(t, (*hexMath.HexOrDecimal256)(header.BaseFee()), actBl.BaseFeePerGas, "BaseFee should be equal")
 }

--- a/api/blocks/blocks_test.go
+++ b/api/blocks/blocks_test.go
@@ -309,6 +309,8 @@ func checkExpandedBlock(t *testing.T, expBl *block.Block, actBl *blocks.JSONExpa
 	assert.Equal(t, header.ReceiptsRoot(), actBl.ReceiptsRoot, "ReceiptsRoot should be equal")
 	for i, tx := range expBl.Transactions() {
 		assert.Equal(t, tx.ID(), actBl.Transactions[i].ID, "txid should be equal")
+		assert.Equal(t, hexMath.HexOrDecimal64(tx.Type()), actBl.Transactions[i].Type, "tx type should be equal")
+		assert.Equal(t, tx.ChainTag(), actBl.Transactions[i].ChainTag, "ChainTag should be equal")
 	}
 	assert.Equal(t, (*hexMath.HexOrDecimal256)(header.BaseFee()), actBl.BaseFeePerGas, "BaseFee should be equal")
 }

--- a/api/blocks/types.go
+++ b/api/blocks/types.go
@@ -14,24 +14,24 @@ import (
 )
 
 type JSONBlockSummary struct {
-	Number       uint32                `json:"number"`
-	ID           thor.Bytes32          `json:"id"`
-	Size         uint32                `json:"size"`
-	ParentID     thor.Bytes32          `json:"parentID"`
-	Timestamp    uint64                `json:"timestamp"`
-	GasLimit     uint64                `json:"gasLimit"`
-	Beneficiary  thor.Address          `json:"beneficiary"`
-	GasUsed      uint64                `json:"gasUsed"`
-	TotalScore   uint64                `json:"totalScore"`
-	TxsRoot      thor.Bytes32          `json:"txsRoot"`
-	TxsFeatures  uint32                `json:"txsFeatures"`
-	StateRoot    thor.Bytes32          `json:"stateRoot"`
-	ReceiptsRoot thor.Bytes32          `json:"receiptsRoot"`
-	COM          bool                  `json:"com"`
-	Signer       thor.Address          `json:"signer"`
-	IsTrunk      bool                  `json:"isTrunk"`
-	IsFinalized  bool                  `json:"isFinalized"`
-	BaseFee      *math.HexOrDecimal256 `json:"baseFee,omitempty"`
+	Number        uint32                `json:"number"`
+	ID            thor.Bytes32          `json:"id"`
+	Size          uint32                `json:"size"`
+	ParentID      thor.Bytes32          `json:"parentID"`
+	Timestamp     uint64                `json:"timestamp"`
+	GasLimit      uint64                `json:"gasLimit"`
+	Beneficiary   thor.Address          `json:"beneficiary"`
+	GasUsed       uint64                `json:"gasUsed"`
+	TotalScore    uint64                `json:"totalScore"`
+	TxsRoot       thor.Bytes32          `json:"txsRoot"`
+	TxsFeatures   uint32                `json:"txsFeatures"`
+	StateRoot     thor.Bytes32          `json:"stateRoot"`
+	ReceiptsRoot  thor.Bytes32          `json:"receiptsRoot"`
+	COM           bool                  `json:"com"`
+	Signer        thor.Address          `json:"signer"`
+	IsTrunk       bool                  `json:"isTrunk"`
+	IsFinalized   bool                  `json:"isFinalized"`
+	BaseFeePerGas *math.HexOrDecimal256 `json:"baseFeePerGas,omitempty"`
 }
 
 type JSONRawBlockSummary struct {
@@ -103,24 +103,24 @@ func buildJSONBlockSummary(summary *chain.BlockSummary, isTrunk bool, isFinalize
 	signer, _ := header.Signer()
 
 	return &JSONBlockSummary{
-		Number:       header.Number(),
-		ID:           header.ID(),
-		ParentID:     header.ParentID(),
-		Timestamp:    header.Timestamp(),
-		TotalScore:   header.TotalScore(),
-		GasLimit:     header.GasLimit(),
-		GasUsed:      header.GasUsed(),
-		Beneficiary:  header.Beneficiary(),
-		Signer:       signer,
-		Size:         uint32(summary.Size),
-		StateRoot:    header.StateRoot(),
-		ReceiptsRoot: header.ReceiptsRoot(),
-		TxsRoot:      header.TxsRoot(),
-		TxsFeatures:  uint32(header.TxsFeatures()),
-		COM:          header.COM(),
-		IsTrunk:      isTrunk,
-		IsFinalized:  isFinalized,
-		BaseFee:      (*math.HexOrDecimal256)(summary.Header.BaseFee()),
+		Number:        header.Number(),
+		ID:            header.ID(),
+		ParentID:      header.ParentID(),
+		Timestamp:     header.Timestamp(),
+		TotalScore:    header.TotalScore(),
+		GasLimit:      header.GasLimit(),
+		GasUsed:       header.GasUsed(),
+		Beneficiary:   header.Beneficiary(),
+		Signer:        signer,
+		Size:          uint32(summary.Size),
+		StateRoot:     header.StateRoot(),
+		ReceiptsRoot:  header.ReceiptsRoot(),
+		TxsRoot:       header.TxsRoot(),
+		TxsFeatures:   uint32(header.TxsFeatures()),
+		COM:           header.COM(),
+		IsTrunk:       isTrunk,
+		IsFinalized:   isFinalized,
+		BaseFeePerGas: (*math.HexOrDecimal256)(summary.Header.BaseFee()),
 	}
 }
 

--- a/api/blocks/types.go
+++ b/api/blocks/types.go
@@ -68,21 +68,21 @@ type JSONOutput struct {
 }
 
 type JSONEmbeddedTx struct {
-	ID                   thor.Bytes32        `json:"id"`
-	Type                 uint8               `json:"type"`
-	ChainTag             byte                `json:"chainTag"`
-	BlockRef             string              `json:"blockRef"`
-	Expiration           uint32              `json:"expiration"`
-	Clauses              []*JSONClause       `json:"clauses"`
-	GasPriceCoef         uint8               `json:"gasPriceCoef"`
-	MaxFeePerGas         *hexutil.Big        `json:"maxFeePerGas,omitempty"`
-	MaxPriorityFeePerGas *hexutil.Big        `json:"maxPriorityFeePerGas,omitempty"`
-	Gas                  uint64              `json:"gas"`
-	Origin               thor.Address        `json:"origin"`
-	Delegator            *thor.Address       `json:"delegator"`
-	Nonce                math.HexOrDecimal64 `json:"nonce"`
-	DependsOn            *thor.Bytes32       `json:"dependsOn"`
-	Size                 uint32              `json:"size"`
+	ID                   thor.Bytes32          `json:"id"`
+	Type                 math.HexOrDecimal64   `json:"type"`
+	ChainTag             byte                  `json:"chainTag"`
+	BlockRef             string                `json:"blockRef"`
+	Expiration           uint32                `json:"expiration"`
+	Clauses              []*JSONClause         `json:"clauses"`
+	GasPriceCoef         uint8                 `json:"gasPriceCoef"`
+	MaxFeePerGas         *math.HexOrDecimal256 `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas *math.HexOrDecimal256 `json:"maxPriorityFeePerGas,omitempty"`
+	Gas                  uint64                `json:"gas"`
+	Origin               thor.Address          `json:"origin"`
+	Delegator            *thor.Address         `json:"delegator"`
+	Nonce                math.HexOrDecimal64   `json:"nonce"`
+	DependsOn            *thor.Bytes32         `json:"dependsOn"`
+	Size                 uint32                `json:"size"`
 
 	// receipt part
 	GasUsed  uint64                `json:"gasUsed"`
@@ -177,7 +177,7 @@ func buildJSONEmbeddedTxs(txs tx.Transactions, receipts tx.Receipts) []*JSONEmbe
 
 		embedTx := &JSONEmbeddedTx{
 			ID:         trx.ID(),
-			Type:       trx.Type(),
+			Type:       math.HexOrDecimal64(trx.Type()),
 			ChainTag:   trx.ChainTag(),
 			BlockRef:   hexutil.Encode(blockRef[:]),
 			Expiration: trx.Expiration(),
@@ -199,8 +199,8 @@ func buildJSONEmbeddedTxs(txs tx.Transactions, receipts tx.Receipts) []*JSONEmbe
 		if trx.Type() == tx.TypeLegacy {
 			embedTx.GasPriceCoef = trx.GasPriceCoef()
 		} else {
-			embedTx.MaxFeePerGas = (*hexutil.Big)(trx.MaxFeePerGas())
-			embedTx.MaxPriorityFeePerGas = (*hexutil.Big)(trx.MaxPriorityFeePerGas())
+			embedTx.MaxFeePerGas = (*math.HexOrDecimal256)(trx.MaxFeePerGas())
+			embedTx.MaxPriorityFeePerGas = (*math.HexOrDecimal256)(trx.MaxPriorityFeePerGas())
 		}
 		jTxs = append(jTxs, embedTx)
 	}

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -1270,7 +1270,7 @@ components:
               format: hex
               description: |
                 The VeChain block identifier of the oldest block in the response.
-            baseFees:
+            baseFeePerGas:
               type: array
               description: |
                 An array of base fees per block as hexadecimal strings. They will be 0x0 for blocks previous to the Galactic fork.
@@ -1738,6 +1738,12 @@ components:
       title: Receipt
       type: object
       properties:
+        type:
+          type: string
+          format: hex
+          description: The transaction type of this receipt
+          example: '0x51'
+          nullable: true
         gasUsed:
           type: integer
           format: uint64

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -982,7 +982,7 @@ components:
         gasLimit: 11253579
         beneficiary: '0xb4094c25f86d628fdd571afc4077f0d0196afb48'
         gasUsed: 21000
-        baseFee: '0x9184e72a000'
+        baseFeePerGas: '0x9184e72a000'
         totalScore: 1029988
         txsRoot: '0x89dfd9fcd10c9e53d68592cf8b540b280b72d381b868523223992f3e09a806bb'
         txsFeatures: 0
@@ -1489,7 +1489,7 @@ components:
           description: The actual amount of gas used within the block
           example: 21000
           nullable: false
-        baseFee:
+        baseFeePerGas:
           type: string
           format: hex
           description: The minimum amount of fee required to include a transaction in the current block

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -112,7 +112,7 @@ func (f *Fees) handleGetFeesHistory(w http.ResponseWriter, req *http.Request) er
 
 	return utils.WriteJSON(w, &FeesHistory{
 		OldestBlock:   oldestBlockRevision,
-		BaseFees:      baseFees,
+		BaseFeePerGas: baseFees,
 		GasUsedRatios: gasUsedRatios,
 	})
 }

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -113,7 +113,7 @@ func (f *Fees) handleGetFeesHistory(w http.ResponseWriter, req *http.Request) er
 	return utils.WriteJSON(w, &FeesHistory{
 		OldestBlock:   oldestBlockRevision,
 		BaseFeePerGas: baseFees,
-		GasUsedRatios: gasUsedRatios,
+		GasUsedRatio:  gasUsedRatios,
 	})
 }
 

--- a/api/fees/fees_test.go
+++ b/api/fees/fees_test.go
@@ -139,7 +139,7 @@ func getFeeHistoryWithSummaries(t *testing.T, tclient *thorclient.Client, bestch
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
 		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
-		GasUsedRatios: []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
+		GasUsedRatio:  []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
 	}
 	assert.Equal(t, expectedFeesHistory, feesHistory)
 }
@@ -161,7 +161,7 @@ func getFeeHistoryOnlySummaries(t *testing.T, tclient *thorclient.Client, bestch
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 		},
-		GasUsedRatios: []float64{
+		GasUsedRatio: []float64{
 			expectedGasPriceUsedRatio,
 			expectedGasPriceUsedRatio,
 		},
@@ -184,7 +184,7 @@ func getFeeHistoryBestBlock(t *testing.T, tclient *thorclient.Client, bestchain 
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
 		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
-		GasUsedRatios: []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
+		GasUsedRatio:  []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
 	}
 
 	assert.Equal(t, expectedFeesHistory, feesHistory)
@@ -234,7 +234,7 @@ func getFeeHistoryCacheLimit(t *testing.T, tclient *thorclient.Client, bestchain
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
 		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee))},
-		GasUsedRatios: []float64{expectedGasPriceUsedRatio},
+		GasUsedRatio:  []float64{expectedGasPriceUsedRatio},
 	}
 
 	require.Equal(t, expectedFeesHistory, feesHistory)
@@ -272,7 +272,7 @@ func getFeeHistoryMoreBlocksRequestedThanAvailable(t *testing.T, tclient *thorcl
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee))},
-		GasUsedRatios: []float64{
+		GasUsedRatio: []float64{
 			0,
 			expectedGasPriceUsedRatio,
 			expectedGasPriceUsedRatio,
@@ -289,7 +289,7 @@ func getFeeHistoryMoreBlocksRequestedThanAvailable(t *testing.T, tclient *thorcl
 	assert.Equal(t, expectedFeesHistory.OldestBlock, feesHistory.OldestBlock)
 	assert.Equal(t, expectedFeesHistory.BaseFeePerGas[0].String(), feesHistory.BaseFeePerGas[0].String())
 	assert.Equal(t, expectedFeesHistory.BaseFeePerGas[1:], feesHistory.BaseFeePerGas[1:])
-	assert.Equal(t, expectedFeesHistory.GasUsedRatios, feesHistory.GasUsedRatios)
+	assert.Equal(t, expectedFeesHistory.GasUsedRatio, feesHistory.GasUsedRatio)
 }
 
 func getFeeHistoryBlock0(t *testing.T, tclient *thorclient.Client, bestchain *chain.Chain) {
@@ -306,12 +306,12 @@ func getFeeHistoryBlock0(t *testing.T, tclient *thorclient.Client, bestchain *ch
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
 		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(0))},
-		GasUsedRatios: []float64{0},
+		GasUsedRatio:  []float64{0},
 	}
 
 	assert.Equal(t, expectedFeesHistory.OldestBlock, feesHistory.OldestBlock)
 	assert.Equal(t, expectedFeesHistory.BaseFeePerGas[0].String(), feesHistory.BaseFeePerGas[0].String())
-	assert.Equal(t, expectedFeesHistory.GasUsedRatios, feesHistory.GasUsedRatios)
+	assert.Equal(t, expectedFeesHistory.GasUsedRatio, feesHistory.GasUsedRatio)
 }
 
 func getFeeHistoryMoreThanBacktraceLimit(t *testing.T, tclient *thorclient.Client, bestchain *chain.Chain) {
@@ -331,7 +331,7 @@ func getFeeHistoryMoreThanBacktraceLimit(t *testing.T, tclient *thorclient.Clien
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee))},
-		GasUsedRatios: []float64{
+		GasUsedRatio: []float64{
 			expectedGasPriceUsedRatio,
 			expectedGasPriceUsedRatio,
 			expectedGasPriceUsedRatio},
@@ -362,7 +362,7 @@ func getFeeHistoryNextBlock(t *testing.T, tclient *thorclient.Client, bestchain 
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
 		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
-		GasUsedRatios: []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
+		GasUsedRatio:  []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
 	}
 
 	assert.Equal(t, expectedFeesHistory, feesHistory)
@@ -382,7 +382,7 @@ func getFeeHistoryOnlyNextBlock(t *testing.T, tclient *thorclient.Client, bestch
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
 		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee))},
-		GasUsedRatios: []float64{expectedGasPriceUsedRatio},
+		GasUsedRatio:  []float64{expectedGasPriceUsedRatio},
 	}
 
 	assert.Equal(t, expectedFeesHistory, feesHistory)

--- a/api/fees/fees_test.go
+++ b/api/fees/fees_test.go
@@ -138,7 +138,7 @@ func getFeeHistoryWithSummaries(t *testing.T, tclient *thorclient.Client, bestch
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
-		BaseFees:      []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
+		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
 		GasUsedRatios: []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
 	}
 	assert.Equal(t, expectedFeesHistory, feesHistory)
@@ -157,7 +157,7 @@ func getFeeHistoryOnlySummaries(t *testing.T, tclient *thorclient.Client, bestch
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock: expectedOldestBlock,
-		BaseFees: []*hexutil.Big{
+		BaseFeePerGas: []*hexutil.Big{
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 		},
@@ -183,7 +183,7 @@ func getFeeHistoryBestBlock(t *testing.T, tclient *thorclient.Client, bestchain 
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
-		BaseFees:      []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
+		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
 		GasUsedRatios: []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
 	}
 
@@ -233,7 +233,7 @@ func getFeeHistoryCacheLimit(t *testing.T, tclient *thorclient.Client, bestchain
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
-		BaseFees:      []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee))},
+		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee))},
 		GasUsedRatios: []float64{expectedGasPriceUsedRatio},
 	}
 
@@ -261,7 +261,7 @@ func getFeeHistoryMoreBlocksRequestedThanAvailable(t *testing.T, tclient *thorcl
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock: expectedOldestBlock,
-		BaseFees: []*hexutil.Big{
+		BaseFeePerGas: []*hexutil.Big{
 			(*hexutil.Big)(big.NewInt(0)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
@@ -287,8 +287,8 @@ func getFeeHistoryMoreBlocksRequestedThanAvailable(t *testing.T, tclient *thorcl
 	}
 
 	assert.Equal(t, expectedFeesHistory.OldestBlock, feesHistory.OldestBlock)
-	assert.Equal(t, expectedFeesHistory.BaseFees[0].String(), feesHistory.BaseFees[0].String())
-	assert.Equal(t, expectedFeesHistory.BaseFees[1:], feesHistory.BaseFees[1:])
+	assert.Equal(t, expectedFeesHistory.BaseFeePerGas[0].String(), feesHistory.BaseFeePerGas[0].String())
+	assert.Equal(t, expectedFeesHistory.BaseFeePerGas[1:], feesHistory.BaseFeePerGas[1:])
 	assert.Equal(t, expectedFeesHistory.GasUsedRatios, feesHistory.GasUsedRatios)
 }
 
@@ -305,12 +305,12 @@ func getFeeHistoryBlock0(t *testing.T, tclient *thorclient.Client, bestchain *ch
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
-		BaseFees:      []*hexutil.Big{(*hexutil.Big)(big.NewInt(0))},
+		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(0))},
 		GasUsedRatios: []float64{0},
 	}
 
 	assert.Equal(t, expectedFeesHistory.OldestBlock, feesHistory.OldestBlock)
-	assert.Equal(t, expectedFeesHistory.BaseFees[0].String(), feesHistory.BaseFees[0].String())
+	assert.Equal(t, expectedFeesHistory.BaseFeePerGas[0].String(), feesHistory.BaseFeePerGas[0].String())
 	assert.Equal(t, expectedFeesHistory.GasUsedRatios, feesHistory.GasUsedRatios)
 }
 
@@ -327,7 +327,7 @@ func getFeeHistoryMoreThanBacktraceLimit(t *testing.T, tclient *thorclient.Clien
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock: expectedOldestBlock,
-		BaseFees: []*hexutil.Big{
+		BaseFeePerGas: []*hexutil.Big{
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee)),
 			(*hexutil.Big)(big.NewInt(expectedBaseFee))},
@@ -361,7 +361,7 @@ func getFeeHistoryNextBlock(t *testing.T, tclient *thorclient.Client, bestchain 
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
-		BaseFees:      []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
+		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee)), (*hexutil.Big)(big.NewInt(expectedBaseFee))},
 		GasUsedRatios: []float64{expectedGasPriceUsedRatio, expectedGasPriceUsedRatio, expectedGasPriceUsedRatio},
 	}
 
@@ -381,7 +381,7 @@ func getFeeHistoryOnlyNextBlock(t *testing.T, tclient *thorclient.Client, bestch
 	require.NoError(t, err)
 	expectedFeesHistory := fees.FeesHistory{
 		OldestBlock:   expectedOldestBlock,
-		BaseFees:      []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee))},
+		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(expectedBaseFee))},
 		GasUsedRatios: []float64{expectedGasPriceUsedRatio},
 	}
 

--- a/api/fees/types.go
+++ b/api/fees/types.go
@@ -12,7 +12,7 @@ import (
 
 type FeesHistory struct {
 	OldestBlock   thor.Bytes32   `json:"oldestBlock"`
-	BaseFeePerGas []*hexutil.Big `json:"baseFees"`
+	BaseFeePerGas []*hexutil.Big `json:"baseFeePerGas"`
 	GasUsedRatios []float64      `json:"gasUsedRatios"`
 }
 

--- a/api/fees/types.go
+++ b/api/fees/types.go
@@ -13,7 +13,7 @@ import (
 type FeesHistory struct {
 	OldestBlock   thor.Bytes32   `json:"oldestBlock"`
 	BaseFeePerGas []*hexutil.Big `json:"baseFeePerGas"`
-	GasUsedRatios []float64      `json:"gasUsedRatios"`
+	GasUsedRatio  []float64      `json:"gasUsedRatio"`
 }
 
 type FeesPriority struct {

--- a/api/fees/types.go
+++ b/api/fees/types.go
@@ -12,7 +12,7 @@ import (
 
 type FeesHistory struct {
 	OldestBlock   thor.Bytes32   `json:"oldestBlock"`
-	BaseFees      []*hexutil.Big `json:"baseFees"`
+	BaseFeePerGas []*hexutil.Big `json:"baseFees"`
 	GasUsedRatios []float64      `json:"gasUsedRatios"`
 }
 

--- a/api/transactions/transactions_converter.go
+++ b/api/transactions/transactions_converter.go
@@ -15,7 +15,7 @@ import (
 
 type Transaction struct {
 	ID                   thor.Bytes32          `json:"id"`
-	Type                 uint8                 `json:"type"`
+	Type                 math.HexOrDecimal64   `json:"type"`
 	ChainTag             byte                  `json:"chainTag"`
 	BlockRef             string                `json:"blockRef"`
 	Expiration           uint32                `json:"expiration"`
@@ -45,7 +45,7 @@ func convertTransaction(trx *tx.Transaction, header *block.Header) *Transaction 
 	br := trx.BlockRef()
 	t := &Transaction{
 		ChainTag:   trx.ChainTag(),
-		Type:       trx.Type(),
+		Type:       math.HexOrDecimal64(trx.Type()),
 		ID:         trx.ID(),
 		Origin:     origin,
 		BlockRef:   hexutil.Encode(br[:]),

--- a/api/transactions/transactions_coverter_test.go
+++ b/api/transactions/transactions_coverter_test.go
@@ -37,7 +37,7 @@ func TestConvertLegacyTransaction_Success(t *testing.T) {
 
 	result := convertTransaction(transaction, header)
 	// Common fields
-	assert.Equal(t, transaction.Type(), result.Type)
+	assert.Equal(t, math.HexOrDecimal64(transaction.Type()), result.Type)
 	assert.Equal(t, hexutil.Encode(br[:]), result.BlockRef)
 	assert.Equal(t, transaction.ChainTag(), result.ChainTag)
 	assert.Equal(t, transaction.Expiration(), result.Expiration)
@@ -78,7 +78,7 @@ func TestConvertDynTransaction_Success(t *testing.T) {
 
 	result := convertTransaction(transaction, header)
 	// Common fields
-	assert.Equal(t, transaction.Type(), result.Type)
+	assert.Equal(t, math.HexOrDecimal64(transaction.Type()), result.Type)
 	assert.Equal(t, hexutil.Encode(br[:]), result.BlockRef)
 	assert.Equal(t, transaction.ChainTag(), result.ChainTag)
 	assert.Equal(t, transaction.Expiration(), result.Expiration)

--- a/api/transactions/transactions_test.go
+++ b/api/transactions/transactions_test.go
@@ -128,14 +128,14 @@ func getTxReceipt(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, receipt.GasUsed, legacyTx.Gas(), "receipt gas used not equal to transaction gas")
-	assert.Equal(t, receipt.Type, legacyTx.Type())
+	assert.Equal(t, receipt.Type, math.HexOrDecimal64(legacyTx.Type()))
 
 	r = httpGetAndCheckResponseStatus(t, "/transactions/"+dynFeeTx.ID().String()+"/receipt", 200)
 	if err := json.Unmarshal(r, &receipt); err != nil {
 		t.Fatal(err)
 	}
 	assert.Equal(t, receipt.GasUsed, legacyTx.Gas(), "receipt gas used not equal to transaction gas")
-	assert.Equal(t, receipt.Type, dynFeeTx.Type())
+	assert.Equal(t, receipt.Type, math.HexOrDecimal64(dynFeeTx.Type()))
 }
 
 func sendLegacyTx(t *testing.T) {

--- a/api/transactions/types.go
+++ b/api/transactions/types.go
@@ -82,7 +82,7 @@ type ReceiptMeta struct {
 
 // Receipt for json marshal
 type Receipt struct {
-	Type     uint8                 `json:"type,omitempty"`
+	Type     math.HexOrDecimal64   `json:"type,omitempty"`
 	GasUsed  uint64                `json:"gasUsed"`
 	GasPayer thor.Address          `json:"gasPayer"`
 	Paid     *math.HexOrDecimal256 `json:"paid"`
@@ -122,7 +122,7 @@ func convertReceipt(txReceipt *tx.Receipt, header *block.Header, tx *tx.Transact
 		return nil, err
 	}
 	receipt := &Receipt{
-		Type:     txReceipt.Type,
+		Type:     math.HexOrDecimal64(txReceipt.Type),
 		GasUsed:  txReceipt.GasUsed,
 		GasPayer: txReceipt.GasPayer,
 		Paid:     &paid,

--- a/api/transactions/types_test.go
+++ b/api/transactions/types_test.go
@@ -77,7 +77,7 @@ func TestConvertReceipt(t *testing.T) {
 		convRec, err := convertReceipt(receipt, header, tr)
 
 		assert.NoError(t, err)
-		assert.Equal(t, receipt.Type, convRec.Type)
+		assert.Equal(t, math.HexOrDecimal64(receipt.Type), convRec.Type)
 		assert.Equal(t, 1, len(convRec.Outputs))
 		assert.Equal(t, 1, len(convRec.Outputs[0].Events))
 		assert.Equal(t, 1, len(convRec.Outputs[0].Transfers))

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -437,7 +437,7 @@ func testFeesEndpoint(t *testing.T, testchain *testchain.Chain, ts *httptest.Ser
 		require.NoError(t, err)
 		expectedFeesHistory := &fees.FeesHistory{
 			OldestBlock: expectedOldestBlock,
-			BaseFees: []*hexutil.Big{
+			BaseFeePerGas: []*hexutil.Big{
 				(*hexutil.Big)(big.NewInt(thor.InitialBaseFee)),
 			},
 			GasUsedRatios: []float64{

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -440,7 +440,7 @@ func testFeesEndpoint(t *testing.T, testchain *testchain.Chain, ts *httptest.Ser
 			BaseFeePerGas: []*hexutil.Big{
 				(*hexutil.Big)(big.NewInt(thor.InitialBaseFee)),
 			},
-			GasUsedRatios: []float64{
+			GasUsedRatio: []float64{
 				0.0058,
 			},
 		}

--- a/thorclient/httpclient/client_test.go
+++ b/thorclient/httpclient/client_test.go
@@ -337,7 +337,7 @@ func TestClient_GetFeesHistory(t *testing.T) {
 	expectedFeesHistory := &fees.FeesHistory{
 		OldestBlock:   thor.Bytes32{0x01},
 		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(0x01))},
-		GasUsedRatios: []float64{0.0021},
+		GasUsedRatio:  []float64{0.0021},
 	}
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/thorclient/httpclient/client_test.go
+++ b/thorclient/httpclient/client_test.go
@@ -336,7 +336,7 @@ func TestClient_GetFeesHistory(t *testing.T) {
 	newestBlock := "best"
 	expectedFeesHistory := &fees.FeesHistory{
 		OldestBlock:   thor.Bytes32{0x01},
-		BaseFees:      []*hexutil.Big{(*hexutil.Big)(big.NewInt(0x01))},
+		BaseFeePerGas: []*hexutil.Big{(*hexutil.Big)(big.NewInt(0x01))},
 		GasUsedRatios: []float64{0.0021},
 	}
 


### PR DESCRIPTION
# Description

This PR renames the base fee value to `baseFeePerGas` when exposed via api

[GHIssue](https://github.com/vechain/protocol-board-repo/issues/489)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
