### PR TITLE
api: do not return gas price coef for dynamic fee transaction

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -1580,7 +1580,7 @@ components:
         type:
           type: integer
           format: uint8
-          description: The transaction type in hex.
+          description: The transaction type in number, currently 0(Legacy Transaction) and 81(DynamicFee Transaction) are supported.
           example: 81
           nullable: false
         origin:
@@ -1631,7 +1631,7 @@ components:
           format: uint8
           description: The coefficient used to calculate the final gas price of the transaction.
           example: 0
-          nullable: false
+          nullable: true
         maxFeePerGas:
           type: string
           format: hex

--- a/api/transactions/transactions_converter.go
+++ b/api/transactions/transactions_converter.go
@@ -20,7 +20,7 @@ type Transaction struct {
 	BlockRef             string                `json:"blockRef"`
 	Expiration           uint32                `json:"expiration"`
 	Clauses              Clauses               `json:"clauses"`
-	GasPriceCoef         uint8                 `json:"gasPriceCoef"`
+	GasPriceCoef         *uint8                `json:"gasPriceCoef,omitempty"`
 	Gas                  uint64                `json:"gas"`
 	MaxFeePerGas         *math.HexOrDecimal256 `json:"maxFeePerGas,omitempty"`
 	MaxPriorityFeePerGas *math.HexOrDecimal256 `json:"maxPriorityFeePerGas,omitempty"`
@@ -60,7 +60,8 @@ func convertTransaction(trx *tx.Transaction, header *block.Header) *Transaction 
 
 	switch trx.Type() {
 	case tx.TypeLegacy:
-		t.GasPriceCoef = trx.GasPriceCoef()
+		coef := trx.GasPriceCoef()
+		t.GasPriceCoef = &coef
 	default:
 		t.MaxFeePerGas = (*math.HexOrDecimal256)(trx.MaxFeePerGas())
 		t.MaxPriorityFeePerGas = (*math.HexOrDecimal256)(trx.MaxPriorityFeePerGas())

--- a/api/transactions/transactions_coverter_test.go
+++ b/api/transactions/transactions_coverter_test.go
@@ -49,7 +49,7 @@ func TestConvertLegacyTransaction_Success(t *testing.T) {
 	assert.Equal(t, addr, *result.Clauses[1].To)
 	assert.Equal(t, convertClause(cla2), result.Clauses[1])
 	// Legacy fields
-	assert.Equal(t, uint8(1), result.GasPriceCoef)
+	assert.Equal(t, uint8(1), *result.GasPriceCoef)
 	// Non legacy fields
 	assert.Empty(t, result.MaxFeePerGas)
 	assert.Empty(t, result.MaxPriorityFeePerGas)

--- a/api/transactions/transactions_test.go
+++ b/api/transactions/transactions_test.go
@@ -409,11 +409,11 @@ func checkMatchingTx(t *testing.T, expectedTx *tx.Transaction, actualTx *transac
 	}
 	switch expectedTx.Type() {
 	case tx.TypeLegacy:
-		assert.Equal(t, expectedTx.GasPriceCoef(), actualTx.GasPriceCoef)
+		assert.Equal(t, expectedTx.GasPriceCoef(), *actualTx.GasPriceCoef)
 		assert.Empty(t, actualTx.MaxFeePerGas)
 		assert.Empty(t, actualTx.MaxPriorityFeePerGas)
 	case tx.TypeDynamicFee:
-		assert.Empty(t, actualTx.GasPriceCoef)
+		assert.Nil(t, actualTx.GasPriceCoef)
 		assert.Equal(t, (*math.HexOrDecimal256)(expectedTx.MaxFeePerGas()), actualTx.MaxFeePerGas)
 		assert.Equal(t, (*math.HexOrDecimal256)(expectedTx.MaxPriorityFeePerGas()), actualTx.MaxPriorityFeePerGas)
 	}


### PR DESCRIPTION
# Description

Do not return gas price coef for dynamic fee transaction in API server.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
