### PR TITLE
feat: use arm64 to publish docker images

### DIFF
--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -48,16 +48,16 @@ jobs:
           if [ "${{ inputs.publish_arm64 }}" == "true" ]; then
             echo "::set-output name=runs-on::[\"ubuntu-latest\",\"ubuntu-24.04-arm\"]"
           else
-            echo "::set-output name=runs-on::[\"ubuntu-latest\"]"4
+            echo "::set-output name=runs-on::[\"ubuntu-latest\"]"
           fi
 
   build-and-push-image:
     name: Build and Push Docker Image
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: ${{ matrix.os }}
     needs: matrix-options
     strategy:
       matrix:
-        runs-on: ${{ fromJSON(needs.matrix-options.outputs.runs-on) }}
+        os: ${{ fromJSON(needs.matrix-options.outputs.runs-on) }}
 
     permissions:
       contents: read

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -29,9 +29,25 @@ on:
         default: false
 
 jobs:
+  matrix-options:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Output matrix options
+        id: result
+        run: |
+          if [ "${{ inputs.publish_arm64 }}" == "true" ]; then
+            echo "::set-output name=runs-on::[\"ubuntu-latest\",\"ubuntu-24.04-arm\"]"
+          else
+            echo "::set-output name=runs-on::[\"ubuntu-latest\"]"4
+          fi
+
   build-and-push-image:
     name: Build and Push Docker Image
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runs-on }}
+    needs: matrix-options
+    strategy:
+      matrix:
+        runs-on: ${{ fromJSON(needs.matrix-options.outputs.runs-on) }}
 
     permissions:
       contents: read
@@ -76,11 +92,20 @@ jobs:
           # use the branch + sha if workflow_dispatch
           tags: ${{ inputs.tags || format('type=raw,value={0}-{1}', github.ref_name, github.sha) }}
 
+      - name: Set Platform
+        id: platform
+        run: |
+          if [ "${{ matrix.runs-on }}" == "ubuntu-latest" ]; then
+            echo "::set-output name=platform::linux/amd64"
+          else
+            echo "::set-output name=platform::linux/arm64"
+          fi
+
       - name: Push to Registry(s)
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: ${{ steps.platform.outputs.platform }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           provenance: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - host-os: [linux, x64]
+          - host-os: ubuntu-22.04
             docker-arch: linux/amd64
           - host-os: ubuntu-24.04-arm
             docker-arch: linux/arm64

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish_arm64:
+        description: 'Publish the arm64 image'
+        required: true
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       trigger_internal_ci:
@@ -27,6 +32,11 @@ on:
         required: true
         type: boolean
         default: false
+      publish_arm64:
+        description: 'Whether to publish the arm64 image'
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   matrix-options:

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -48,9 +48,9 @@ jobs:
         id: result
         run: |
           if [ "${{ inputs.publish_arm64 }}" == "true" ]; then
-            echo "publish-os="[\"ubuntu-latest\",\"ubuntu-24.04-arm\"]" >> $GITHUB_OUTPUT
+            echo "publish-os=[\"ubuntu-latest\",\"ubuntu-24.04-arm\"]" >> $GITHUB_OUTPUT
           else
-            echo "publish-os="[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
+            echo "publish-os=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
           fi
 
   build-and-push-image:
@@ -59,7 +59,7 @@ jobs:
     needs: matrix-options
     strategy:
       matrix:
-        os: ${{fromJSON(needs.matrix-options.outputs.publish-os)}}
+        os: ${{ fromJSON(needs.matrix-options.outputs.publish-os) }}
 
     permissions:
       contents: read

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -20,11 +20,6 @@ on:
         required: false
         type: boolean
         default: false
-      publish_arm64:
-        description: 'Publish the arm64 image'
-        required: true
-        type: boolean
-        default: true
   workflow_dispatch:
     inputs:
       trigger_internal_ci:
@@ -32,34 +27,18 @@ on:
         required: true
         type: boolean
         default: false
-      publish_arm64:
-        description: 'Whether to publish the arm64 image'
-        required: true
-        type: boolean
-        default: true
 
 jobs:
-  matrix-options:
-    runs-on: ubuntu-latest
-    outputs:
-      publish-os: ${{ steps.result.outputs.publish-os }}
-    steps:
-      - name: Output matrix options
-        id: result
-        run: |
-          if [ "${{ inputs.publish_arm64 }}" == "true" ]; then
-            echo "publish-os=[\"ubuntu-latest\",\"ubuntu-24.04-arm\"]" >> $GITHUB_OUTPUT
-          else
-            echo "publish-os=[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
-          fi
+
 
   build-and-push-image:
     name: Build and Push Docker Image
     runs-on: ${{ matrix.os }}
-    needs: matrix-options
     strategy:
       matrix:
-        os: ${{ fromJSON(needs.matrix-options.outputs.publish-os) }}
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
 
     permissions:
       contents: read
@@ -107,7 +86,7 @@ jobs:
       - name: Set Platform
         id: platform
         run: |
-          if [ "${{ matrix.runs-on }}" == "ubuntu-latest" ]; then
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
             echo "::set-output name=platform::linux/amd64"
           else
             echo "::set-output name=platform::linux/arm64"

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -41,14 +41,16 @@ on:
 jobs:
   matrix-options:
     runs-on: ubuntu-latest
+    outputs:
+      publish-os: ${{ steps.result.outputs.publish-os }}
     steps:
       - name: Output matrix options
         id: result
         run: |
           if [ "${{ inputs.publish_arm64 }}" == "true" ]; then
-            echo "::set-output name=runs-on::[\"ubuntu-latest\",\"ubuntu-24.04-arm\"]"
+            echo "publish-os="[\"ubuntu-latest\",\"ubuntu-24.04-arm\"]" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=runs-on::[\"ubuntu-latest\"]"
+            echo "publish-os="[\"ubuntu-latest\"]" >> $GITHUB_OUTPUT
           fi
 
   build-and-push-image:
@@ -57,7 +59,7 @@ jobs:
     needs: matrix-options
     strategy:
       matrix:
-        os: ${{ fromJSON(needs.matrix-options.outputs.runs-on) }}
+        os: ${{fromJSON(needs.matrix-options.outputs.publish-os)}}
 
     permissions:
       contents: read

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -29,8 +29,6 @@ on:
         default: false
 
 jobs:
-
-
   build-and-push-image:
     name: Build and Push Docker Image
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -31,12 +31,14 @@ on:
 jobs:
   build-and-push-image:
     name: Build and Push Docker Image
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.host-os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
+        include:
+          - host-os: ubuntu-24.04-x86
+            docker-arch: linux/amd64
+          - host-os: ubuntu-24.04-arm
+            docker-arch: linux/arm64
 
     permissions:
       contents: read
@@ -47,14 +49,6 @@ jobs:
 
       - name: Checkout Repo
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -81,20 +75,11 @@ jobs:
           # use the branch + sha if workflow_dispatch
           tags: ${{ inputs.tags || format('type=raw,value={0}-{1}', github.ref_name, github.sha) }}
 
-      - name: Set Platform
-        id: platform
-        run: |
-          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            echo "::set-output name=platform::linux/amd64"
-          else
-            echo "::set-output name=platform::linux/arm64"
-          fi
-
       - name: Push to Registry(s)
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: ${{ steps.platform.outputs.platform }}
+          platforms: ${{ matrix.docker-arch }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           provenance: ${{ github.event_name != 'pull_request' }}
@@ -123,12 +108,3 @@ jobs:
           # See https://github.com/aquasecurity/trivy/discussions/7538
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
-      - name: Internal CI
-        uses: peter-evans/repository-dispatch@v3
-        if: ${{ inputs.trigger_internal_ci }}
-        continue-on-error: true
-        with:
-          token: ${{ secrets.INTERNAL_CI_TOKEN }}
-          repository: vechain/thor-internal-ci
-          event-type: internal-thor-ci
-          client-payload: '{"thor_image": "${{ fromJSON(steps.build-and-push-image.outputs.meta.json).tags[0] }}"}'

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - host-os: ubuntu-24.04-x86
+          - host-os: [linux, x64]
             docker-arch: linux/amd64
           - host-os: ubuntu-24.04-arm
             docker-arch: linux/arm64
@@ -49,6 +49,12 @@ jobs:
 
       - name: Checkout Repo
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -107,4 +113,3 @@ jobs:
         env:
           # See https://github.com/aquasecurity/trivy/discussions/7538
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
-

--- a/.github/workflows/publish-docker-images.yaml
+++ b/.github/workflows/publish-docker-images.yaml
@@ -85,7 +85,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: ${{ matrix.docker-arch }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name == 'pull_request' }}
           provenance: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -11,12 +11,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Build and export
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
# Description

WIP: Use arm64 for docker publish

Error: one pipeline overwrites the other

Seems the amd image gets published and then replaced by arm64 image once that workflow finishes. Need some kind of multi platfrom build like from the docs: https://docs.docker.com/build/ci/github-actions/multi-platform/

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
