### PR TITLE
feat: Rewards in `fee/history`

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -768,7 +768,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/BlockCountInQuery'
         - $ref: '#/components/parameters/NewestBlockInQuery'
-        - $ref: '#/components/parameters/RewardsPercentilesInQuery'
+        - $ref: '#/components/parameters/RewardPercentilesInQuery'
       responses:
         '200':
           description: OK
@@ -1298,7 +1298,7 @@ components:
             reward:
               type: array
               description: |
-                An array of arrays of rewards by the percentiles provided in the request via rewardsPercentiles.
+                An array of arrays of rewards by the percentiles provided in the request via rewardPercentiles.
                 Each inner array contains the reward values for each percentile requested.
               nullable: true
               items:
@@ -2454,8 +2454,8 @@ components:
       schema:
         type: string
     
-    RewardsPercentilesInQuery:
-      name: rewardsPercentiles
+    RewardPercentilesInQuery:
+      name: rewardPercentiles
       in: query
       required: false
       description: |

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -768,6 +768,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/BlockCountInQuery'
         - $ref: '#/components/parameters/NewestBlockInQuery'
+        - $ref: '#/components/parameters/RewardsPercentilesInQuery'
       responses:
         '200':
           description: OK
@@ -1294,6 +1295,29 @@ components:
               example:
                 - 0.75
                 - 0.22
+            reward:
+              type: array
+              description: |
+                An array of arrays of rewards by the percentiles provided in the request via rewardsPercentiles.
+                Each inner array contains the reward values for each percentile requested.
+              nullable: true
+              items:
+                type: array
+                description: Array of reward values for each percentile requested
+                items:
+                  type: string
+                  format: hex
+                  description: Reward value in hex format
+              example:
+                - - '0x0'    # 25th percentile
+                  - '0xa'    # 50th percentile
+                  - '0xc'    # 75th percentile
+                - - '0x0'    # 25th percentile
+                  - '0xa'    # 50th percentile
+                  - '0xc'    # 75th percentile
+                - - '0x0'    # 25th percentile
+                  - '0xa'    # 50th percentile
+                  - '0xc'    # 75th percentile
 
     GetFeesPriorityResponse:
       type: object
@@ -2425,9 +2449,26 @@ components:
     NewestBlockInQuery:
       name: newestBlock
       in: query
+      required: true
       description: Specify either `best`, `justified`, `finalized`, a block number or block ID. If omitted, the `best` block is assumed.
       schema:
         type: string
+    
+    RewardsPercentilesInQuery:
+      name: rewardsPercentiles
+      in: query
+      required: false
+      description: |
+        The percentiles of the rewards to be returned.
+      schema:
+        type: array
+        items:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 100
+        description: Array of percentiles between 0 and 100
+      example: [25, 50, 75]
 
     CallCodeRevisionInQuery:
       name: revision
@@ -2652,11 +2693,11 @@ components:
     BlockCountInQuery:
       name: blockCount
       in: query
+      required: true
       schema:
         type: integer
         format: uint32
         minimum: 1
-        maximum: 1024
       description: |
         The number of blocks to be returned.
       example: 10

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -2459,7 +2459,7 @@ components:
       in: query
       required: false
       description: |
-        The percentiles of the rewards to be returned. Each percentile value must be between 0 and 100.
+        The percentiles of the rewards to be returned. Each percentile value must be between 0 and 100 and in ascending order.
         Values should be comma-separated.
         For example: ?rewardPercentiles=25,50,75
       schema:

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -2459,16 +2459,14 @@ components:
       in: query
       required: false
       description: |
-        The percentiles of the rewards to be returned.
+        The percentiles of the rewards to be returned. Each percentile value must be between 0 and 100.
+        Values should be comma-separated.
+        For example: ?rewardPercentiles=25,50,75
       schema:
-        type: array
-        items:
-          type: number
-          format: float
-          minimum: 0
-          maximum: 100
-        description: Array of percentiles between 0 and 100
-      example: [25, 50, 75]
+        type: string
+        pattern: '^(\d+(\.\d+)?,)*\d+(\.\d+)?$'
+        description: Comma-separated list of percentiles between 0 and 100
+      example: "25,50,75"
 
     CallCodeRevisionInQuery:
       name: revision

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -20,11 +20,10 @@ import (
 	"github.com/vechain/thor/v2/thor"
 )
 
-type FeeCacheEntry struct {
-	parentBlockID thor.Bytes32
-	baseFee       *hexutil.Big
-	gasUsedRatio  float64
-	cachedRewards *rewards
+type FeesData struct {
+	repo   *chain.Repository
+	cache  *cache.PrioCache
+	stater *state.Stater
 }
 
 type rewardItem struct {
@@ -37,10 +36,11 @@ type rewards struct {
 	totalGasUsed uint64
 }
 
-type FeesData struct {
-	repo   *chain.Repository
-	cache  *cache.PrioCache
-	stater *state.Stater
+type FeeCacheEntry struct {
+	parentBlockID thor.Bytes32
+	baseFee       *hexutil.Big
+	gasUsedRatio  float64
+	cachedRewards *rewards
 }
 
 func newFeesData(repo *chain.Repository, stater *state.Stater, fixedCacheSize int) *FeesData {

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -74,11 +74,7 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 				gasUsedRatios[i-1] = float64(header.GasUsed()) / float64(header.GasLimit())
 				if rewardPercentiles != nil {
 					//TODO: Use something different here
-					blockRewards, err := fd.calculateRewards(nil, rewardPercentiles, baseGasPrice)
-					if err != nil {
-						return thor.Bytes32{}, nil, nil, nil, err
-					}
-					rewards[i-1] = blockRewards
+					rewards[i-1] = make([]*hexutil.Big, 0)
 				}
 				newestBlockID = header.ParentID()
 				continue

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -108,11 +108,7 @@ func (fd *FeesData) calculateRewards(block *block.Block, rewardPercentiles *[]fl
 	// If there is no transactions, return zero rewards
 	transactions := block.Transactions()
 	if len(transactions) == 0 {
-		rewards := make([]*hexutil.Big, len(*rewardPercentiles))
-		for i := range rewards {
-			rewards[i] = (*hexutil.Big)(big.NewInt(0))
-		}
-		return rewards, nil
+		return make([]*hexutil.Big, len(*rewardPercentiles)), nil
 	}
 
 	header := block.Header()
@@ -176,12 +172,6 @@ func (fd *FeesData) getOrLoadFees(blockID thor.Bytes32, rewardPercentiles *[]flo
 		rewards, err = fd.calculateRewards(block, rewardPercentiles, baseGasPrice)
 		if err != nil {
 			return nil, err
-		}
-		// Ensure rewards are not nil
-		for i := range rewards {
-			if rewards[i] == nil {
-				rewards[i] = (*hexutil.Big)(big.NewInt(0))
-			}
 		}
 	}
 

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -95,7 +95,7 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 		baseFees[i-1] = fees.baseFee
 		gasUsedRatios[i-1] = fees.gasUsedRatio
 		if rewardPercentiles != nil {
-			copy(rewards[i-1], fees.rewards)
+			rewards[i-1] = fees.rewards
 		}
 
 		newestBlockID = fees.parentBlockID

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -105,8 +105,9 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 }
 
 func (fd *FeesData) calculateRewards(block *block.Block, rewardPercentiles *[]float64, baseGasPrice *big.Int) ([]*hexutil.Big, error) {
-	// If there is no block or no transactions, return zero rewards
-	if block == nil || len(block.Transactions()) == 0 {
+	// If there is no transactions, return zero rewards
+	transactions := block.Transactions()
+	if len(transactions) == 0 {
 		rewards := make([]*hexutil.Big, len(*rewardPercentiles))
 		for i := range rewards {
 			rewards[i] = (*hexutil.Big)(big.NewInt(0))
@@ -121,7 +122,6 @@ func (fd *FeesData) calculateRewards(block *block.Block, rewardPercentiles *[]fl
 	}
 
 	// Calculate rewards
-	transactions := block.Transactions()
 	items := make([]rewardItem, len(transactions))
 	isGalactica := header.Number() >= thor.GetForkConfig(fd.repo.NewBestChain().GenesisID()).GALACTICA
 

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -99,10 +99,14 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 }
 
 func (fd *FeesData) calculateRewards(block *block.Block, rewardPercentiles *[]float64, baseGasPrice *big.Int) ([]*hexutil.Big, error) {
-	// If there is no transactions, return zero rewards
+	// If there are no transactions, return rewards with zero values
 	transactions := block.Transactions()
+	rewards := make([]*hexutil.Big, len(*rewardPercentiles))
 	if len(transactions) == 0 {
-		return make([]*hexutil.Big, len(*rewardPercentiles)), nil
+		for i := range rewards {
+			rewards[i] = (*hexutil.Big)(big.NewInt(0))
+		}
+		return rewards, nil
 	}
 
 	header := block.Header()
@@ -132,7 +136,6 @@ func (fd *FeesData) calculateRewards(block *block.Block, rewardPercentiles *[]fl
 	})
 
 	// Calculate rewards for each percentile
-	rewards := make([]*hexutil.Big, len(*rewardPercentiles))
 	totalGasUsed := header.GasUsed()
 
 	currentTransactionIndex := 0

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -59,12 +59,6 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 	var rewards [][]*hexutil.Big
 	if rewardPercentiles != nil {
 		rewards = make([][]*hexutil.Big, blockCount)
-		for i := range rewards {
-			rewards[i] = make([]*hexutil.Big, len(*rewardPercentiles))
-			for j := range rewards[i] {
-				rewards[i][j] = (*hexutil.Big)(big.NewInt(0))
-			}
-		}
 	}
 
 	var oldestBlockID thor.Bytes32

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -146,7 +146,6 @@ func (fd *FeesData) getOrLoadFees(blockID thor.Bytes32, rewardPercentiles *[]flo
 }
 
 func (fd *FeesData) getRewardsForCache(block *block.Block, baseGasPrice *big.Int) (*rewards, error) {
-	// If there are no transactions, return rewards with zero values
 	transactions := block.Transactions()
 
 	header := block.Header()
@@ -183,6 +182,7 @@ func (fd *FeesData) getRewardsForCache(block *block.Block, baseGasPrice *big.Int
 
 func (fd *FeesData) calculateRewards(cachedRewards *rewards, rewardPercentiles *[]float64) []*hexutil.Big {
 	rewards := make([]*hexutil.Big, len(*rewardPercentiles))
+	// If there are no reward items, return rewards with value 0
 	if cachedRewards == nil || len(cachedRewards.items) == 0 {
 		for i := range rewards {
 			rewards[i] = (*hexutil.Big)(big.NewInt(0))

--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -84,7 +84,7 @@ func (fd *FeesData) resolveRange(newestBlockSummary *chain.BlockSummary, blockCo
 					if err != nil {
 						return thor.Bytes32{}, nil, nil, nil, err
 					}
-					copy(rewards[i-1], blockRewards)
+					rewards[i-1] = blockRewards
 				}
 				newestBlockID = header.ParentID()
 				continue

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -52,7 +52,7 @@ func New(repo *chain.Repository, bft bft.Committer, stater *state.Stater, config
 	}
 }
 
-func (f *Fees) validateGetFeesHistoryParams(req *http.Request) (uint32, *chain.BlockSummary, *[]float64, error) {
+func (f *Fees) validateGetFeesHistoryParams(req *http.Request) (uint32, *chain.BlockSummary, []float64, error) {
 	blockCount, err := f.validateBlockCount(req)
 	if err != nil {
 		return 0, nil, nil, err
@@ -113,7 +113,7 @@ func (f *Fees) validateNewestBlock(req *http.Request, blockCount *uint64) (*chai
 	return newestBlockSummary, nil
 }
 
-func (f *Fees) validateRewardPercentiles(req *http.Request) (*[]float64, error) {
+func (f *Fees) validateRewardPercentiles(req *http.Request) ([]float64, error) {
 	rewardPercentilesParam := req.URL.Query().Get("rewardPercentiles")
 	if rewardPercentilesParam == "" {
 		return nil, nil
@@ -140,7 +140,7 @@ func (f *Fees) validateRewardPercentiles(req *http.Request) (*[]float64, error) 
 		rewardPercentiles = append(rewardPercentiles, val)
 	}
 
-	return &rewardPercentiles, nil
+	return rewardPercentiles, nil
 }
 
 func (f *Fees) handleGetFeesHistory(w http.ResponseWriter, req *http.Request) error {

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -6,6 +6,7 @@
 package fees
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 	"net/http"
@@ -23,6 +24,8 @@ import (
 	"github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/thor"
 )
+
+const maxRewardPercentiles = 100
 
 type Config struct {
 	APIBacktraceLimit          int
@@ -121,6 +124,10 @@ func (f *Fees) validateRewardPercentiles(req *http.Request) (*[]float64, error) 
 
 	percentileStrs := strings.Split(rewardPercentilesParam, ",")
 	rewardPercentiles := make([]float64, 0, len(percentileStrs))
+
+	if len(percentileStrs) > maxRewardPercentiles {
+		return nil, utils.BadRequest(errors.New(fmt.Sprintf("there can be at most %d rewardPercentiles", maxRewardPercentiles)))
+	}
 
 	for _, str := range percentileStrs {
 		val, err := strconv.ParseFloat(str, 64)

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -126,13 +126,16 @@ func (f *Fees) validateRewardPercentiles(req *http.Request) (*[]float64, error) 
 		return nil, utils.BadRequest(errors.New(fmt.Sprintf("there can be at most %d rewardPercentiles", maxRewardPercentiles)))
 	}
 
-	for _, str := range percentileStrs {
+	for i, str := range percentileStrs {
 		val, err := strconv.ParseFloat(str, 64)
 		if err != nil {
 			return nil, utils.BadRequest(errors.WithMessage(err, "invalid rewardPercentiles value"))
 		}
 		if val < 0 || val > 100 {
 			return nil, utils.BadRequest(errors.New("rewardPercentiles values must be between 0 and 100"))
+		}
+		if i > 0 && val < rewardPercentiles[i-1] {
+			return nil, utils.BadRequest(errors.New(fmt.Sprintf("reward percentiles must be in ascending order, but %f is less than %f", val, rewardPercentiles[i-1])))
 		}
 		rewardPercentiles = append(rewardPercentiles, val)
 	}

--- a/api/fees/fees_test.go
+++ b/api/fees/fees_test.go
@@ -120,11 +120,11 @@ func initFeesServer(t *testing.T, backtraceLimit int, fixedCacheSize int, number
 	// Create blocks with transactions
 	for i := range numberOfBlocks - 1 {
 		// Create one transaction per block with different priority fees
-		priorityFee := int64(100 + i*50) // Each block has a different priority fee
+		priorityFee := new(big.Int).Add(big.NewInt(100), new(big.Int).Mul(big.NewInt(int64(i)), big.NewInt(50)))
 		trx := tx.NewBuilder(tx.TypeDynamicFee).
 			ChainTag(thorChain.Repo().ChainTag()).
 			MaxFeePerGas(big.NewInt(250_000_000_000_000)).
-			MaxPriorityFeePerGas(big.NewInt(priorityFee)).
+			MaxPriorityFeePerGas(priorityFee).
 			Expiration(720).
 			Gas(21000).
 			Nonce(uint64(i)).

--- a/api/fees/fees_test.go
+++ b/api/fees/fees_test.go
@@ -120,22 +120,20 @@ func initFeesServer(t *testing.T, backtraceLimit int, fixedCacheSize int, number
 	// Create blocks with transactions
 	for i := range numberOfBlocks - 1 {
 		// Create one transaction per block with different priority fees
-		priorityFee1 := big.NewInt(10)
 		trx1 := tx.NewBuilder(tx.TypeDynamicFee).
 			ChainTag(thorChain.Repo().ChainTag()).
 			MaxFeePerGas(big.NewInt(250_000_000_000_000)).
-			MaxPriorityFeePerGas(priorityFee1).
+			MaxPriorityFeePerGas(big.NewInt(10)).
 			Expiration(720).
 			Gas(21000).
 			Nonce(uint64(i)).
 			Clause(cla).
 			BlockRef(tx.NewBlockRef(uint32(i))).
 			Build()
-		priorityFee2 := big.NewInt(12)
 		trx2 := tx.NewBuilder(tx.TypeDynamicFee).
 			ChainTag(thorChain.Repo().ChainTag()).
 			MaxFeePerGas(big.NewInt(250_000_000_000_000)).
-			MaxPriorityFeePerGas(priorityFee2).
+			MaxPriorityFeePerGas(big.NewInt(12)).
 			Expiration(720).
 			Gas(21000).
 			Nonce(uint64(i)).
@@ -144,6 +142,10 @@ func initFeesServer(t *testing.T, backtraceLimit int, fixedCacheSize int, number
 			Build()
 		require.NoError(t, thorChain.MintBlock(genesis.DevAccounts()[0], tx.MustSign(trx1, genesis.DevAccounts()[0].PrivateKey), tx.MustSign(trx2, genesis.DevAccounts()[0].PrivateKey)))
 	}
+
+	allBlocks, err := thorChain.GetAllBlocks()
+	require.NoError(t, err)
+	require.Len(t, allBlocks, numberOfBlocks)
 
 	return httptest.NewServer(router), thorChain.Repo().NewBestChain()
 }

--- a/api/fees/fees_test.go
+++ b/api/fees/fees_test.go
@@ -440,23 +440,12 @@ func getRewardsValidPercentiles(t *testing.T, tclient *thorclient.Client, bestch
 	require.Len(t, feesHistory.Reward, 3, "should have rewards for 3 blocks")
 
 	// Expected reward values based on MaxPriorityFeePerGas values
-	expectedRewards := [][]*hexutil.Big{
-		{
-			(*hexutil.Big)(big.NewInt(10)), // 25th percentile
-			(*hexutil.Big)(big.NewInt(10)), // 50th percentile
-			(*hexutil.Big)(big.NewInt(12)), // 75th percentile
-		},
-		{
-			(*hexutil.Big)(big.NewInt(10)), // 25th percentile
-			(*hexutil.Big)(big.NewInt(10)), // 50th percentile
-			(*hexutil.Big)(big.NewInt(12)), // 75th percentile
-		},
-		{
-			(*hexutil.Big)(big.NewInt(10)), // 25th percentile
-			(*hexutil.Big)(big.NewInt(10)), // 50th percentile
-			(*hexutil.Big)(big.NewInt(12)), // 75th percentile
-		},
+	expectedTxRewardsByPercentile := []*hexutil.Big{
+		(*hexutil.Big)(big.NewInt(10)), // 25th percentile
+		(*hexutil.Big)(big.NewInt(10)), // 50th percentile
+		(*hexutil.Big)(big.NewInt(12)), // 75th percentile
 	}
+	expectedRewards := [][]*hexutil.Big{expectedTxRewardsByPercentile, expectedTxRewardsByPercentile, expectedTxRewardsByPercentile}
 
 	for i, blockRewards := range feesHistory.Reward {
 		require.NotNil(t, blockRewards, "block %d rewards should not be nil", i)

--- a/api/fees/fees_test.go
+++ b/api/fees/fees_test.go
@@ -90,9 +90,10 @@ func TestRewardPercentiles(t *testing.T) {
 
 	tclient := thorclient.New(ts.URL)
 	for name, tt := range map[string]func(*testing.T, *thorclient.Client, *chain.Chain){
-		"getRewardsValidPercentiles":      getRewardsValidPercentiles,
-		"getRewardsInvalidPercentiles":    getRewardsInvalidPercentiles,
-		"getRewardsOutOfRangePercentiles": getRewardsOutOfRangePercentiles,
+		"getRewardsValidPercentiles":        getRewardsValidPercentiles,
+		"getRewardsInvalidPercentiles":      getRewardsInvalidPercentiles,
+		"getRewardsOutOfRangePercentiles":   getRewardsOutOfRangePercentiles,
+		"getRewardsNonAscendingPercentiles": getRewardsNonAscendingPercentiles,
 	} {
 		t.Run(name, func(t *testing.T) {
 			tt(t, tclient, bestchain)
@@ -497,4 +498,12 @@ func getRewardsOutOfRangePercentiles(t *testing.T, tclient *thorclient.Client, b
 		require.NoError(t, err)
 		require.Equal(t, 400, statusCode, "should fail with percentiles out of range: %s", percentiles)
 	}
+}
+
+func getRewardsNonAscendingPercentiles(t *testing.T, tclient *thorclient.Client, bestchain *chain.Chain) {
+	res, statusCode, err := tclient.RawHTTPClient().RawHTTPGet("/fees/history?blockCount=3&newestBlock=4&rewardPercentiles=20,10,30")
+	require.NoError(t, err)
+	require.Equal(t, 400, statusCode)
+	require.NotNil(t, res)
+	assert.Equal(t, "reward percentiles must be in ascending order, but 10.000000 is less than 20.000000\n", string(res))
 }

--- a/api/fees/types.go
+++ b/api/fees/types.go
@@ -14,7 +14,7 @@ type FeesHistory struct {
 	OldestBlock   thor.Bytes32     `json:"oldestBlock"`
 	BaseFees      []*hexutil.Big   `json:"baseFees"`
 	GasUsedRatios []float64        `json:"gasUsedRatios"`
-	Reward        [][]*hexutil.Big `json:"reward"`
+	Reward        [][]*hexutil.Big `json:"reward,omitempty"`
 }
 
 type FeesPriority struct {

--- a/api/fees/types.go
+++ b/api/fees/types.go
@@ -11,9 +11,10 @@ import (
 )
 
 type FeesHistory struct {
-	OldestBlock   thor.Bytes32   `json:"oldestBlock"`
-	BaseFees      []*hexutil.Big `json:"baseFees"`
-	GasUsedRatios []float64      `json:"gasUsedRatios"`
+	OldestBlock   thor.Bytes32     `json:"oldestBlock"`
+	BaseFees      []*hexutil.Big   `json:"baseFees"`
+	GasUsedRatios []float64        `json:"gasUsedRatios"`
+	Reward        [][]*hexutil.Big `json:"reward"`
 }
 
 type FeesPriority struct {

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -439,7 +439,8 @@ func testFeesEndpoint(t *testing.T, testchain *testchain.Chain, ts *httptest.Ser
 	t.Run("GetFeesHistory", func(t *testing.T) {
 		blockCount := uint32(1)
 		newestBlock := "best"
-		feesHistory, err := c.FeesHistory(blockCount, newestBlock)
+		//TODO: Add test for rewardsPercentiles
+		feesHistory, err := c.FeesHistory(blockCount, newestBlock, nil)
 		require.NoError(t, err)
 		require.NotNil(t, feesHistory)
 

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -439,7 +439,7 @@ func testFeesEndpoint(t *testing.T, testchain *testchain.Chain, ts *httptest.Ser
 	t.Run("GetFeesHistory", func(t *testing.T) {
 		blockCount := uint32(1)
 		newestBlock := "best"
-		//TODO: Add test for rewardsPercentiles
+		//TODO: Add test for rewardPercentiles
 		feesHistory, err := c.FeesHistory(blockCount, newestBlock, nil)
 		require.NoError(t, err)
 		require.NotNil(t, feesHistory)

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -439,7 +439,6 @@ func testFeesEndpoint(t *testing.T, testchain *testchain.Chain, ts *httptest.Ser
 	t.Run("GetFeesHistory", func(t *testing.T) {
 		blockCount := uint32(1)
 		newestBlock := "best"
-		//TODO: Add test for rewardPercentiles
 		feesHistory, err := c.FeesHistory(blockCount, newestBlock, nil)
 		require.NoError(t, err)
 		require.NotNil(t, feesHistory)

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -457,6 +457,44 @@ func testFeesEndpoint(t *testing.T, testchain *testchain.Chain, ts *httptest.Ser
 		}
 
 		require.Equal(t, expectedFeesHistory, feesHistory)
+
+		rewardPercentiles := []float64{10, 90}
+		feesHistory, err = c.FeesHistory(blockCount, newestBlock, &rewardPercentiles)
+		require.NoError(t, err)
+		require.NotNil(t, feesHistory)
+
+		expectedOldestBlock, err = testchain.Repo().NewBestChain().GetBlockID(2)
+		require.NoError(t, err)
+		expectedFeesHistory = &fees.FeesHistory{
+			OldestBlock: expectedOldestBlock,
+			BaseFeePerGas: []*hexutil.Big{
+				(*hexutil.Big)(big.NewInt(thor.InitialBaseFee)),
+			},
+			GasUsedRatio: []float64{
+				0.0037,
+			},
+			Reward: [][]*hexutil.Big{
+				{
+					(*hexutil.Big)(big.NewInt(0)),
+					(*hexutil.Big)(big.NewInt(0)),
+				},
+			},
+		}
+
+		require.Equal(t, expectedFeesHistory.OldestBlock, feesHistory.OldestBlock)
+		require.Equal(t, expectedFeesHistory.BaseFeePerGas, feesHistory.BaseFeePerGas)
+		require.Equal(t, expectedFeesHistory.GasUsedRatio, feesHistory.GasUsedRatio)
+
+		// Compare rewards as strings
+		require.Len(t, feesHistory.Reward, len(expectedFeesHistory.Reward), "should have same number of reward blocks")
+		for i, blockRewards := range feesHistory.Reward {
+			require.Len(t, blockRewards, len(expectedFeesHistory.Reward[i]), "block %d should have same number of rewards", i)
+			for j, reward := range blockRewards {
+				require.NotNil(t, reward, "reward %d in block %d should not be nil", j, i)
+				require.NotNil(t, expectedFeesHistory.Reward[i][j], "expected reward %d in block %d should not be nil", j, i)
+				require.Equal(t, expectedFeesHistory.Reward[i][j].String(), reward.String(), "reward %d in block %d should match", j, i)
+			}
+		}
 	})
 
 	// 2. Test GET /fees/priority

--- a/thorclient/httpclient/client.go
+++ b/thorclient/httpclient/client.go
@@ -297,7 +297,11 @@ func (c *Client) GetFeesHistory(blockCount uint32, newestBlock string, rewardPer
 	var url strings.Builder
 	url.WriteString(c.url + "/fees/history?blockCount=" + fmt.Sprint(blockCount) + "&newestBlock=" + newestBlock)
 	if rewardPercentiles != nil && len(*rewardPercentiles) > 0 {
-		url.WriteString("&rewardPercentiles=" + strings.Trim(fmt.Sprint(*rewardPercentiles), "[]"))
+		strValues := make([]string, len(*rewardPercentiles))
+		for i, v := range *rewardPercentiles {
+			strValues[i] = fmt.Sprint(v)
+		}
+		url.WriteString("&rewardPercentiles=" + strings.Join(strValues, ","))
 	}
 	body, err := c.httpGET(url.String())
 	if err != nil {

--- a/thorclient/httpclient/client.go
+++ b/thorclient/httpclient/client.go
@@ -13,6 +13,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/vechain/thor/v2/api/accounts"
 	"github.com/vechain/thor/v2/api/blocks"
@@ -292,8 +293,13 @@ func (c *Client) GetPeers() ([]*node.PeerStats, error) {
 }
 
 // GetFeesHistory retrieves the fees history based on the block count and newest block.
-func (c *Client) GetFeesHistory(blockCount uint32, newestBlock string) (*fees.FeesHistory, error) {
-	body, err := c.httpGET(c.url + "/fees/history?blockCount=" + fmt.Sprint(blockCount) + "&newestBlock=" + newestBlock)
+func (c *Client) GetFeesHistory(blockCount uint32, newestBlock string, rewardsPercentiles *[]float64) (*fees.FeesHistory, error) {
+	var url strings.Builder
+	url.WriteString(c.url + "/fees/history?blockCount=" + fmt.Sprint(blockCount) + "&newestBlock=" + newestBlock)
+	if rewardsPercentiles != nil && len(*rewardsPercentiles) > 0 {
+		url.WriteString("&rewardsPercentiles=" + strings.Trim(fmt.Sprint(*rewardsPercentiles), "[]"))
+	}
+	body, err := c.httpGET(url.String())
 	if err != nil {
 		return nil, fmt.Errorf("unable to get the fees history - %w", err)
 	}

--- a/thorclient/httpclient/client.go
+++ b/thorclient/httpclient/client.go
@@ -293,11 +293,11 @@ func (c *Client) GetPeers() ([]*node.PeerStats, error) {
 }
 
 // GetFeesHistory retrieves the fees history based on the block count and newest block.
-func (c *Client) GetFeesHistory(blockCount uint32, newestBlock string, rewardsPercentiles *[]float64) (*fees.FeesHistory, error) {
+func (c *Client) GetFeesHistory(blockCount uint32, newestBlock string, rewardPercentiles *[]float64) (*fees.FeesHistory, error) {
 	var url strings.Builder
 	url.WriteString(c.url + "/fees/history?blockCount=" + fmt.Sprint(blockCount) + "&newestBlock=" + newestBlock)
-	if rewardsPercentiles != nil && len(*rewardsPercentiles) > 0 {
-		url.WriteString("&rewardsPercentiles=" + strings.Trim(fmt.Sprint(*rewardsPercentiles), "[]"))
+	if rewardPercentiles != nil && len(*rewardPercentiles) > 0 {
+		url.WriteString("&rewardPercentiles=" + strings.Trim(fmt.Sprint(*rewardPercentiles), "[]"))
 	}
 	body, err := c.httpGET(url.String())
 	if err != nil {

--- a/thorclient/httpclient/client_test.go
+++ b/thorclient/httpclient/client_test.go
@@ -349,7 +349,8 @@ func TestClient_GetFeesHistory(t *testing.T) {
 	defer ts.Close()
 
 	client := New(ts.URL)
-	feesHistory, err := client.GetFeesHistory(blockCount, newestBlock)
+	//TODO: Add test for rewardsPercentiles
+	feesHistory, err := client.GetFeesHistory(blockCount, newestBlock, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, expectedFeesHistory, feesHistory)

--- a/thorclient/httpclient/client_test.go
+++ b/thorclient/httpclient/client_test.go
@@ -349,7 +349,7 @@ func TestClient_GetFeesHistory(t *testing.T) {
 	defer ts.Close()
 
 	client := New(ts.URL)
-	//TODO: Add test for rewardsPercentiles
+	//TODO: Add test for rewardPercentiles
 	feesHistory, err := client.GetFeesHistory(blockCount, newestBlock, nil)
 
 	assert.NoError(t, err)

--- a/thorclient/thorclient.go
+++ b/thorclient/thorclient.go
@@ -222,8 +222,8 @@ func (c *Client) ChainTag() (byte, error) {
 }
 
 // FeesHistory retrieves the fee history for the range newest block - block count.
-func (c *Client) FeesHistory(blockCount uint32, newestBlock string) (feesHistory *fees.FeesHistory, err error) {
-	return c.httpConn.GetFeesHistory(blockCount, newestBlock)
+func (c *Client) FeesHistory(blockCount uint32, newestBlock string, rewardsPercentiles *[]float64) (feesHistory *fees.FeesHistory, err error) {
+	return c.httpConn.GetFeesHistory(blockCount, newestBlock, rewardsPercentiles)
 }
 
 // FeesPriority retrieves the suggested maxPriorityFeePerGas for a transaction to be included in the next blocks.

--- a/thorclient/thorclient.go
+++ b/thorclient/thorclient.go
@@ -222,8 +222,8 @@ func (c *Client) ChainTag() (byte, error) {
 }
 
 // FeesHistory retrieves the fee history for the range newest block - block count.
-func (c *Client) FeesHistory(blockCount uint32, newestBlock string, rewardsPercentiles *[]float64) (feesHistory *fees.FeesHistory, err error) {
-	return c.httpConn.GetFeesHistory(blockCount, newestBlock, rewardsPercentiles)
+func (c *Client) FeesHistory(blockCount uint32, newestBlock string, rewardPercentiles *[]float64) (feesHistory *fees.FeesHistory, err error) {
+	return c.httpConn.GetFeesHistory(blockCount, newestBlock, rewardPercentiles)
 }
 
 // FeesPriority retrieves the suggested maxPriorityFeePerGas for a transaction to be included in the next blocks.

--- a/tx/transaction.go
+++ b/tx/transaction.go
@@ -20,8 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/vechain/thor/v2/block"
-	"github.com/vechain/thor/v2/consensus/fork"
 	"github.com/vechain/thor/v2/thor"
 )
 
@@ -627,35 +625,4 @@ func dataGas(data []byte) (uint64, error) {
 		return 0, errIntrinsicGasOverflow
 	}
 	return gas, nil
-}
-
-// EffectivePriorityFee calculates the effective priority fee for the transaction.
-// It requires:
-// - blockNumber: the current block number
-// - getBlockID: function to get block ID by number
-// - baseGasPrice: base gas price for legacy transactions
-// - isGalactica: whether Galactica fork is active
-func (t *Transaction) EffectivePriorityFee(
-    blockNumber uint32,
-    getBlockID func(uint32) (thor.Bytes32, error),
-    baseGasPrice *big.Int,
-	baseFee *big.Int,
-    isGalactica bool,
-) (*big.Int, error) {
-    provedWork, err := t.ProvedWork(blockNumber, getBlockID)
-    if err != nil {
-        return nil, err
-    }
-
-    effectivePriorityFee := fork.GalacticaPriorityPrice(
-        t,
-        baseGasPrice,
-        provedWork,
-        &fork.GalacticaItems{
-            IsActive: isGalactica,
-            BaseFee:  baseFee,
-        },
-    )
-    
-    return effectivePriorityFee, nil
 }

--- a/tx/transaction.go
+++ b/tx/transaction.go
@@ -20,6 +20,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/consensus/fork"
 	"github.com/vechain/thor/v2/thor"
 )
 
@@ -625,4 +627,35 @@ func dataGas(data []byte) (uint64, error) {
 		return 0, errIntrinsicGasOverflow
 	}
 	return gas, nil
+}
+
+// EffectivePriorityFee calculates the effective priority fee for the transaction.
+// It requires:
+// - blockNumber: the current block number
+// - getBlockID: function to get block ID by number
+// - baseGasPrice: base gas price for legacy transactions
+// - isGalactica: whether Galactica fork is active
+func (t *Transaction) EffectivePriorityFee(
+    blockNumber uint32,
+    getBlockID func(uint32) (thor.Bytes32, error),
+    baseGasPrice *big.Int,
+	baseFee *big.Int,
+    isGalactica bool,
+) (*big.Int, error) {
+    provedWork, err := t.ProvedWork(blockNumber, getBlockID)
+    if err != nil {
+        return nil, err
+    }
+
+    effectivePriorityFee := fork.GalacticaPriorityPrice(
+        t,
+        baseGasPrice,
+        provedWork,
+        &fork.GalacticaItems{
+            IsActive: isGalactica,
+            BaseFee:  baseFee,
+        },
+    )
+    
+    return effectivePriorityFee, nil
 }


### PR DESCRIPTION
# Description

This PR adds support to:

- `rewardsPercentile` (request): List of percentiles (for instance, `20,50,90`) to organise the rewards to request.
- `reward` (response): Array of arrays with the rewards by percentile (in the example above, it will be an array of 3-element arrays)

It is based on this.

Some things to consider:

1. We are limiting to 100 percentiles at most, same as go-ethereum (so `rewardPercentiles` could have 100 elements)
2. We split cache handling from reward calculation. This is due to a request from the user with different sizes for `rewardPercentiles` (I can request `20,30` for block 30 and `50` later on for the same block, if using the cache directly for this we will be storing the first call so 2 values for this block).

Closes https://github.com/vechain/protocol-board-repo/issues/508