### PR TITLE
fix: `next` block adjustments (transactions, gas used, receipts root)

### DIFF
--- a/api/utils/revisions.go
+++ b/api/utils/revisions.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/thor"
+	"github.com/vechain/thor/v2/tx"
 )
 
 const (
@@ -121,10 +122,9 @@ func GetSummaryAndState(rev *Revision, repo *chain.Repository, bft bft.Committer
 			Timestamp(best.Header.Timestamp() + thor.BlockInterval).
 			TotalScore(best.Header.TotalScore()).
 			GasLimit(best.Header.GasLimit()).
-			GasUsed(0).
 			Beneficiary(best.Header.Beneficiary()).
 			StateRoot(best.Header.StateRoot()).
-			ReceiptsRoot(thor.Bytes32{}).
+			ReceiptsRoot(tx.Receipts{}.RootHash()).
 			TransactionFeatures(best.Header.TxsFeatures()).
 			Alpha(best.Header.Alpha())
 

--- a/api/utils/revisions.go
+++ b/api/utils/revisions.go
@@ -121,10 +121,10 @@ func GetSummaryAndState(rev *Revision, repo *chain.Repository, bft bft.Committer
 			Timestamp(best.Header.Timestamp() + thor.BlockInterval).
 			TotalScore(best.Header.TotalScore()).
 			GasLimit(best.Header.GasLimit()).
-			GasUsed(best.Header.GasUsed()).
+			GasUsed(0).
 			Beneficiary(best.Header.Beneficiary()).
 			StateRoot(best.Header.StateRoot()).
-			ReceiptsRoot(best.Header.ReceiptsRoot()).
+			ReceiptsRoot(thor.Bytes32{}).
 			TransactionFeatures(best.Header.TxsFeatures()).
 			Alpha(best.Header.Alpha())
 

--- a/api/utils/revisions.go
+++ b/api/utils/revisions.go
@@ -141,7 +141,7 @@ func GetSummaryAndState(rev *Revision, repo *chain.Repository, bft bft.Committer
 		// rebuild the block summary with the next header (mocked) AND the best block status
 		return &chain.BlockSummary{
 			Header:    mocked.Header(),
-			Txs:       best.Txs,
+			Txs:       make([]thor.Bytes32, 0),
 			Size:      uint64(mocked.Size()),
 			Conflicts: best.Conflicts,
 		}, st, nil

--- a/api/utils/revisions_test.go
+++ b/api/utils/revisions_test.go
@@ -167,6 +167,7 @@ func TestGetSummaryAndState(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, summary.Header.Number(), b.Header().Number()+1)
 	assert.Equal(t, summary.Header.Timestamp(), b.Header().Timestamp()+thor.BlockInterval)
+	assert.Equal(t, len(summary.Txs), 0)
 
 	signer, err := summary.Header.Signer()
 	assert.NotNil(t, err)

--- a/api/utils/revisions_test.go
+++ b/api/utils/revisions_test.go
@@ -167,6 +167,8 @@ func TestGetSummaryAndState(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, summary.Header.Number(), b.Header().Number()+1)
 	assert.Equal(t, summary.Header.Timestamp(), b.Header().Timestamp()+thor.BlockInterval)
+	assert.Equal(t, summary.Header.GasUsed(), uint64(0))
+	assert.Equal(t, summary.Header.ReceiptsRoot(), thor.Bytes32{})
 	assert.Equal(t, len(summary.Txs), 0)
 
 	signer, err := summary.Header.Signer()

--- a/api/utils/revisions_test.go
+++ b/api/utils/revisions_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vechain/thor/v2/test/testchain"
 	"github.com/vechain/thor/v2/thor"
+	"github.com/vechain/thor/v2/tx"
 )
 
 func TestParseRevision(t *testing.T) {
@@ -168,7 +169,7 @@ func TestGetSummaryAndState(t *testing.T) {
 	assert.Equal(t, summary.Header.Number(), b.Header().Number()+1)
 	assert.Equal(t, summary.Header.Timestamp(), b.Header().Timestamp()+thor.BlockInterval)
 	assert.Equal(t, summary.Header.GasUsed(), uint64(0))
-	assert.Equal(t, summary.Header.ReceiptsRoot(), thor.Bytes32{})
+	assert.Equal(t, summary.Header.ReceiptsRoot(), tx.Receipts{}.RootHash())
 	assert.Equal(t, len(summary.Txs), 0)
 
 	signer, err := summary.Header.Signer()


### PR DESCRIPTION
# Description

The `next` block should not have the `best` transactions since they are not part of it.