### PR TITLE
add decode fuzz tests for block, tx and receipt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ THOR_VERSION = $(shell cat cmd/thor/VERSION)
 DISCO_VERSION = $(shell cat cmd/disco/VERSION)
 
 PACKAGES = `go list ./... | grep -v '/vendor/'`
+FUZZTIME=1m
 
 MAJOR = $(shell go version | cut -d' ' -f3 | cut -b 3- | cut -d. -f1)
 MINOR = $(shell go version | cut -d' ' -f3 | cut -b 3- | cut -d. -f2)
@@ -61,9 +62,12 @@ test:| go_version_check #@ Run the tests
 	@go test -cover $(PACKAGES)
 
 fuzz:| go_version_check #@ Run the fuzz tests
-	@go test -fuzz=FuzzTransactionMarshalling -fuzztime=1m $(CURDIR)/tx
-	@go test -fuzz=FuzzBlockEncoding -fuzztime=1m $(CURDIR)/block
-	@go test -fuzz=FuzzHeaderEncoding -fuzztime=1m $(CURDIR)/block
+	@go test -fuzz=FuzzTransactionMarshalling -fuzztime=$(FUZZTIME) $(CURDIR)/tx
+	@go test -fuzz=FuzzTransactionDecoding -fuzztime=$(FUZZTIME) $(CURDIR)/tx
+	@go test -fuzz=FuzzReceiptDecoding -fuzztime=$(FUZZTIME) $(CURDIR)/tx
+	@go test -fuzz=FuzzBlockEncoding -fuzztime=$(FUZZTIME) $(CURDIR)/block
+	@go test -fuzz=FuzzHeaderEncoding -fuzztime=$(FUZZTIME) $(CURDIR)/block
+	@go test -fuzz=FuzzBlockDecoding -fuzztime=$(FUZZTIME) $(CURDIR)/block
 
 test-coverage:| go_version_check #@ Run the tests with coverage
 	@go test -race -coverprofile=coverage.out -covermode=atomic $(PACKAGES)

--- a/block/block_fuzz_test.go
+++ b/block/block_fuzz_test.go
@@ -108,6 +108,10 @@ func FuzzHeaderEncoding(f *testing.F) {
 }
 
 func FuzzBlockDecoding(f *testing.F) {
+	blk := new(Builder).Build()
+	enc, _ := rlp.EncodeToBytes(&blk)
+	f.Add(enc)
+
 	f.Fuzz(func(t *testing.T, input []byte) {
 		var b Block
 		_ = rlp.DecodeBytes(input, &b)

--- a/block/block_fuzz_test.go
+++ b/block/block_fuzz_test.go
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package block
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/vechain/thor/v2/thor"
+	"github.com/vechain/thor/v2/tx"
+)
+
+func FuzzBlockEncoding(f *testing.F) {
+	f.Fuzz(func(t *testing.T, arrdBytes, beneficiary []byte, maxFee, gasUsed, gasLimit, totalScore uint64) {
+		newBlock := randomBlock(arrdBytes, beneficiary, maxFee, gasUsed, gasLimit, totalScore)
+		enc, err := rlp.EncodeToBytes(newBlock)
+		if err != nil {
+			t.Errorf("failed to encode block: %v", err)
+		}
+		var decodedBlock Block
+		if err := rlp.DecodeBytes(enc, &decodedBlock); err != nil {
+			t.Errorf("failed to decode block: %v", err)
+		}
+		if err := checkBlockEquality(newBlock, &decodedBlock); err != nil {
+			t.Errorf("Tx expected to be the same but: %v", err)
+		}
+	})
+}
+
+func randomBlock(addrBytes, byteArray []byte, maxFee, gasUsed, gasLimit, totalScore uint64) *Block {
+	addr := thor.BytesToAddress(addrBytes)
+	tx1 := tx.NewBuilder(tx.TypeLegacy).Clause(tx.NewClause(&addr)).Clause(tx.NewClause(&addr)).Build()
+	tx2 := tx.NewBuilder(tx.TypeDynamicFee).MaxFeePerGas(big.NewInt(int64(maxFee))).Clause(tx.NewClause(&addr)).Clause(tx.NewClause(&addr)).Build()
+
+	privKey := string("dce1443bd2ef0c2631adc1c67e5c93f13dc23a41c18b536effbbdcbcdb96fb65")
+
+	now := uint64(time.Now().UnixNano())
+
+	var (
+		root        thor.Bytes32 = thor.BytesToBytes32(byteArray)
+		beneficiary thor.Address = thor.BytesToAddress(byteArray)
+	)
+
+	b := new(Builder).
+		GasUsed(gasUsed).
+		Transaction(tx1).
+		Transaction(tx2).
+		GasLimit(gasLimit).
+		TotalScore(totalScore).
+		StateRoot(root).
+		ReceiptsRoot(root).
+		Timestamp(now).
+		BaseFee(big.NewInt(thor.InitialBaseFee)).
+		ParentID(root).
+		Beneficiary(beneficiary).
+		Build()
+
+	key, _ := crypto.HexToECDSA(privKey)
+	sig, _ := crypto.Sign(b.Header().SigningHash().Bytes(), key)
+
+	return b.WithSignature(sig)
+}
+
+func checkBlockEquality(newBlock, decodedBlock *Block) error {
+	if newBlock.Header().ID() != decodedBlock.Header().ID() {
+		return fmt.Errorf("ID expected %v but got %v", newBlock.Header().ID(), decodedBlock.Header().ID())
+	}
+	if newBlock.Header().TxsRoot() != decodedBlock.Header().TxsRoot() {
+		return fmt.Errorf("TxsRoot expected %v but got %v", newBlock.Header().TxsRoot(), decodedBlock.Header().TxsRoot())
+	}
+	if newBlock.Size() != decodedBlock.Size() {
+		return fmt.Errorf("Size expected %v but got %v", newBlock.Size(), decodedBlock.Size())
+	}
+	if newBlock.Header().String() != decodedBlock.Header().String() {
+		return fmt.Errorf("Header expected %v but got %v", newBlock.Header(), decodedBlock.Header())
+	}
+	for i, tx := range newBlock.Transactions() {
+		if tx.ID() != decodedBlock.Transactions()[i].ID() {
+			return fmt.Errorf("Tx expected %v but got %v", tx.String(), decodedBlock.Transactions()[i].String())
+		}
+	}
+
+	return nil
+}
+
+func FuzzHeaderEncoding(f *testing.F) {
+	f.Fuzz(func(t *testing.T, addrBytes, beneficiary []byte, maxFee, gasUsed, gasLimit, totalScore uint64) {
+		h0 := randomBlock(addrBytes, beneficiary, maxFee, gasUsed, gasLimit, totalScore).Header()
+		enc, err := rlp.EncodeToBytes(h0)
+		if err != nil {
+			t.Errorf("failed to encode header: %v", err)
+		}
+		var decodedHeader Header
+		if err := rlp.DecodeBytes(enc, &decodedHeader); err != nil {
+			t.Errorf("failed to decode header: %v", err)
+		}
+		if h0.String() != decodedHeader.String() {
+			t.Errorf("Header expected to be the same but: %v", err)
+		}
+	})
+}
+
+func FuzzBlockDecoding(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input []byte) {
+		var b Block
+		_ = rlp.DecodeBytes(input, &b)
+	})
+}

--- a/block/block_test.go
+++ b/block/block_test.go
@@ -6,7 +6,6 @@
 package block
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -97,77 +96,4 @@ func TestBlock(t *testing.T) {
 	assert.Nil(t, rlp.DecodeBytes(data, &bx))
 	assert.Equal(t, blk.Header().ID(), bx.Header().ID())
 	assert.Equal(t, blk.Header().TxsFeatures(), bx.Header().TxsFeatures())
-}
-
-func FuzzBlockEncoding(f *testing.F) {
-	f.Fuzz(func(t *testing.T, arrdBytes, beneficiary []byte, maxFee, gasUsed, gasLimit, totalScore uint64) {
-		newBlock := randomBlock(arrdBytes, beneficiary, maxFee, gasUsed, gasLimit, totalScore)
-		enc, err := rlp.EncodeToBytes(newBlock)
-		if err != nil {
-			t.Errorf("failed to encode block: %v", err)
-		}
-		var decodedBlock Block
-		if err := rlp.DecodeBytes(enc, &decodedBlock); err != nil {
-			t.Errorf("failed to decode block: %v", err)
-		}
-		if err := checkBlockEquality(newBlock, &decodedBlock); err != nil {
-			t.Errorf("Tx expected to be the same but: %v", err)
-		}
-	})
-}
-
-func randomBlock(addrBytes, byteArray []byte, maxFee, gasUsed, gasLimit, totalScore uint64) *Block {
-	addr := thor.BytesToAddress(addrBytes)
-	tx1 := tx.NewBuilder(tx.TypeLegacy).Clause(tx.NewClause(&addr)).Clause(tx.NewClause(&addr)).Build()
-	tx2 := tx.NewBuilder(tx.TypeDynamicFee).MaxFeePerGas(big.NewInt(int64(maxFee))).Clause(tx.NewClause(&addr)).Clause(tx.NewClause(&addr)).Build()
-
-	privKey := string("dce1443bd2ef0c2631adc1c67e5c93f13dc23a41c18b536effbbdcbcdb96fb65")
-
-	now := uint64(time.Now().UnixNano())
-
-	var (
-		root        thor.Bytes32 = thor.BytesToBytes32(byteArray)
-		beneficiary thor.Address = thor.BytesToAddress(byteArray)
-	)
-
-	b := new(Builder).
-		GasUsed(gasUsed).
-		Transaction(tx1).
-		Transaction(tx2).
-		GasLimit(gasLimit).
-		TotalScore(totalScore).
-		StateRoot(root).
-		ReceiptsRoot(root).
-		Timestamp(now).
-		BaseFee(big.NewInt(thor.InitialBaseFee)).
-		ParentID(root).
-		Beneficiary(beneficiary).
-		Build()
-
-	key, _ := crypto.HexToECDSA(privKey)
-	sig, _ := crypto.Sign(b.Header().SigningHash().Bytes(), key)
-
-	return b.WithSignature(sig)
-}
-
-func checkBlockEquality(newBlock, decodedBlock *Block) error {
-	if newBlock.Header().ID() != decodedBlock.Header().ID() {
-		return fmt.Errorf("ID expected %v but got %v", newBlock.Header().ID(), decodedBlock.Header().ID())
-	}
-	if newBlock.Header().TxsRoot() != decodedBlock.Header().TxsRoot() {
-		return fmt.Errorf("TxsRoot expected %v but got %v", newBlock.Header().TxsRoot(), decodedBlock.Header().TxsRoot())
-	}
-	if newBlock.Size() != decodedBlock.Size() {
-		return fmt.Errorf("Size expected %v but got %v", newBlock.Size(), decodedBlock.Size())
-	}
-	if newBlock.Header().String() != decodedBlock.Header().String() {
-		return fmt.Errorf("Header expected %v but got %v", newBlock.Header(), decodedBlock.Header())
-	}
-	for i, tx := range newBlock.Transactions() {
-		if tx.ID() != decodedBlock.Transactions()[i].ID() {
-			return fmt.Errorf("Tx expected %v but got %v", tx.String(), decodedBlock.Transactions()[i].String())
-		}
-	}
-
-	return nil
 }

--- a/block/header_test.go
+++ b/block/header_test.go
@@ -386,23 +386,6 @@ func TestExtensionV2(t *testing.T) {
 	}
 }
 
-func FuzzHeaderEncoding(f *testing.F) {
-	f.Fuzz(func(t *testing.T, addrBytes, beneficiary []byte, maxFee, gasUsed, gasLimit, totalScore uint64) {
-		h0 := randomBlock(addrBytes, beneficiary, maxFee, gasUsed, gasLimit, totalScore).Header()
-		enc, err := rlp.EncodeToBytes(h0)
-		if err != nil {
-			t.Errorf("failed to encode header: %v", err)
-		}
-		var decodedHeader Header
-		if err := rlp.DecodeBytes(enc, &decodedHeader); err != nil {
-			t.Errorf("failed to decode header: %v", err)
-		}
-		if h0.String() != decodedHeader.String() {
-			t.Errorf("Header expected to be the same but: %v", err)
-		}
-	})
-}
-
 func TestHeaderHash(t *testing.T) {
 	for range 100 {
 		var builder = new(Builder)

--- a/tx/transaction_fuzz_test.go
+++ b/tx/transaction_fuzz_test.go
@@ -76,6 +76,18 @@ func checkTxsEquality(expectedTx, actualTx *Transaction) error {
 }
 
 func FuzzTransactionDecoding(f *testing.F) {
+	trx := NewBuilder(TypeLegacy).Build()
+	enc, _ := rlp.EncodeToBytes(trx)
+	f.Add(enc)
+	enc, _ = trx.MarshalBinary()
+	f.Add(enc)
+
+	trx = NewBuilder(TypeDynamicFee).Build()
+	enc, _ = rlp.EncodeToBytes(trx)
+	f.Add(enc)
+	enc, _ = trx.MarshalBinary()
+	f.Add(enc)
+
 	f.Fuzz(func(t *testing.T, input []byte) {
 		var (
 			trx1 Transaction
@@ -87,6 +99,18 @@ func FuzzTransactionDecoding(f *testing.F) {
 }
 
 func FuzzReceiptDecoding(f *testing.F) {
+	var r Receipt
+	enc, _ := rlp.EncodeToBytes(&r)
+	f.Add(enc)
+	enc, _ = r.MarshalBinary()
+	f.Add(enc)
+
+	r.Type = TypeDynamicFee
+	enc, _ = rlp.EncodeToBytes(&r)
+	f.Add(enc)
+	enc, _ = r.MarshalBinary()
+	f.Add(enc)
+
 	f.Fuzz(func(t *testing.T, input []byte) {
 		var (
 			r1 Receipt

--- a/tx/transaction_fuzz_test.go
+++ b/tx/transaction_fuzz_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package tx
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/vechain/thor/v2/test/datagen"
+)
+
+func FuzzTransactionMarshalling(f *testing.F) {
+	f.Fuzz(func(t *testing.T, b []byte, ui8 uint8, ui32 uint32, ui64 uint64) {
+		txType := TypeLegacy
+		if ui8%2 == 0 {
+			txType = TypeDynamicFee
+		}
+		newTx := randomTx(b, ui8, ui32, ui64, txType)
+		enc, err := newTx.MarshalBinary()
+		if err != nil {
+			t.Errorf("MarshalBinary: %v", err)
+		}
+		decTx := new(Transaction)
+		err = decTx.UnmarshalBinary(enc)
+		if err != nil {
+			t.Errorf("UnmarshalBinary: %v", err)
+		}
+		if err := checkTxsEquality(newTx, decTx); err != nil {
+			t.Errorf("Tx expected to be the same but: %v", err)
+		}
+	})
+}
+
+func randomTx(b []byte, ui8 uint8, ui32 uint32, ui64 uint64, txType Type) *Transaction {
+	to := datagen.RandAddress()
+	var b8 [8]byte
+	copy(b8[:], b)
+	i64 := int64(ui64)
+	tag := datagen.RandBytes(1)[0]
+	tr := NewBuilder(txType).ChainTag(tag).
+		BlockRef(b8).
+		Expiration(ui32).
+		Clause(NewClause(&to).WithValue(big.NewInt(i64)).WithData(b)).
+		Clause(NewClause(&to).WithValue(big.NewInt(i64)).WithData(b)).
+		GasPriceCoef(ui8).
+		MaxFeePerGas(big.NewInt(i64)).
+		MaxPriorityFeePerGas(big.NewInt(i64)).
+		Gas(ui64).
+		DependsOn(nil).
+		Nonce(ui64).Build()
+
+	priv, _ := crypto.HexToECDSA("99f0500549792796c14fed62011a51081dc5b5e68fe8bd8a13b86be829c4fd36")
+	sig, _ := crypto.Sign(tr.SigningHash().Bytes(), priv)
+
+	tr = tr.WithSignature(sig)
+	return tr
+}
+
+func checkTxsEquality(expectedTx, actualTx *Transaction) error {
+	if expectedTx.ID() != actualTx.ID() {
+		return fmt.Errorf("ID: expected %v, got %v", expectedTx.ID(), actualTx.ID())
+	}
+	if expectedTx.Hash() != actualTx.Hash() {
+		return fmt.Errorf("Hash: expected %v, got %v", expectedTx.Hash(), actualTx.Hash())
+	}
+	if expectedTx.SigningHash() != actualTx.SigningHash() {
+		return fmt.Errorf("SigningHash: expected %v, got %v", expectedTx.SigningHash(), actualTx.SigningHash())
+	}
+	return nil
+}
+
+func FuzzTransactionDecoding(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input []byte) {
+		var (
+			trx1 Transaction
+			trx2 Transaction
+		)
+		_ = rlp.DecodeBytes(input, &trx1)
+		_ = trx2.UnmarshalBinary(input)
+	})
+}
+
+func FuzzReceiptDecoding(f *testing.F) {
+	f.Fuzz(func(t *testing.T, input []byte) {
+		var (
+			r1 Receipt
+			r2 Receipt
+		)
+		_ = rlp.DecodeBytes(input, &r1)
+		_ = r2.UnmarshalBinary(input)
+	})
+}

--- a/tx/transaction_test.go
+++ b/tx/transaction_test.go
@@ -396,28 +396,6 @@ func BenchmarkTxMining(b *testing.B) {
 	}
 }
 
-func FuzzTransactionMarshalling(f *testing.F) {
-	f.Fuzz(func(t *testing.T, b []byte, ui8 uint8, ui32 uint32, ui64 uint64) {
-		txType := TypeLegacy
-		if ui8%2 == 0 {
-			txType = TypeDynamicFee
-		}
-		newTx := randomTx(b, ui8, ui32, ui64, txType)
-		enc, err := newTx.MarshalBinary()
-		if err != nil {
-			t.Errorf("MarshalBinary: %v", err)
-		}
-		decTx := new(Transaction)
-		err = decTx.UnmarshalBinary(enc)
-		if err != nil {
-			t.Errorf("UnmarshalBinary: %v", err)
-		}
-		if err := checkTxsEquality(newTx, decTx); err != nil {
-			t.Errorf("Tx expected to be the same but: %v", err)
-		}
-	})
-}
-
 func TestLegacyHashWithoutNonceFieldsIntegrity(t *testing.T) {
 	mockTx := GetMockTx(TypeLegacy)
 
@@ -443,44 +421,6 @@ func TestHashingFieldsIntegrity(t *testing.T) {
 	})
 
 	assert.Equal(t, fieldsHash.String(), "0x0b196cb741cc67de0bc389b9da472ebf9b6282ad226325a19fdb8c3d8941086e")
-}
-
-func randomTx(b []byte, ui8 uint8, ui32 uint32, ui64 uint64, txType Type) *Transaction {
-	to := datagen.RandAddress()
-	var b8 [8]byte
-	copy(b8[:], b)
-	i64 := int64(ui64)
-	tag := datagen.RandBytes(1)[0]
-	tr := NewBuilder(txType).ChainTag(tag).
-		BlockRef(b8).
-		Expiration(ui32).
-		Clause(NewClause(&to).WithValue(big.NewInt(i64)).WithData(b)).
-		Clause(NewClause(&to).WithValue(big.NewInt(i64)).WithData(b)).
-		GasPriceCoef(ui8).
-		MaxFeePerGas(big.NewInt(i64)).
-		MaxPriorityFeePerGas(big.NewInt(i64)).
-		Gas(ui64).
-		DependsOn(nil).
-		Nonce(ui64).Build()
-
-	priv, _ := crypto.HexToECDSA("99f0500549792796c14fed62011a51081dc5b5e68fe8bd8a13b86be829c4fd36")
-	sig, _ := crypto.Sign(tr.SigningHash().Bytes(), priv)
-
-	tr = tr.WithSignature(sig)
-	return tr
-}
-
-func checkTxsEquality(expectedTx, actualTx *Transaction) error {
-	if expectedTx.ID() != actualTx.ID() {
-		return fmt.Errorf("ID: expected %v, got %v", expectedTx.ID(), actualTx.ID())
-	}
-	if expectedTx.Hash() != actualTx.Hash() {
-		return fmt.Errorf("Hash: expected %v, got %v", expectedTx.Hash(), actualTx.Hash())
-	}
-	if expectedTx.SigningHash() != actualTx.SigningHash() {
-		return fmt.Errorf("SigningHash: expected %v, got %v", expectedTx.SigningHash(), actualTx.SigningHash())
-	}
-	return nil
 }
 
 func TestTransactionHash(t *testing.T) {


### PR DESCRIPTION
# Description

This PR adds some extra fuzz decode tests and improved fuzz command in Makefile which allows custom fuzz time via `make fuzz FUZZTIME=10m`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
