### PR TITLE
enhance tests for signing hashes, implemented a guard

### DIFF
--- a/block/extension.go
+++ b/block/extension.go
@@ -65,56 +65,58 @@ func (ex *extension) DecodeRLP(s *rlp.Stream) error {
 
 	if len(raws) == 0 || len(raws) > 3 {
 		return errors.New("rlp: unexpected extension")
-	} else {
-		var alpha []byte
-		if err := rlp.DecodeBytes(raws[0], &alpha); err != nil {
-			return err
-		}
+	}
 
-		// only alpha, make sure it's trimmed
-		if len(raws) == 1 {
-			if len(alpha) == 0 {
-				return errors.New("rlp: extension must be trimmed")
-			}
+	// alpha is always decoded
+	var alpha []byte
+	if err := rlp.DecodeBytes(raws[0], &alpha); err != nil {
+		return err
+	}
 
-			*ex = extension{
-				Alpha: alpha,
-				COM:   false,
-			}
-			return nil
-		}
-
-		// more than one filed, must have com
-		var com bool
-		if err := rlp.DecodeBytes(raws[1], &com); err != nil {
-			return err
-		}
-
-		// alpha and com, make sure it's trimmed
-		if len(raws) == 2 {
-			// COM must be trimmed if not set
-			if !com {
-				return errors.New("rlp: extension must be trimmed")
-			}
-
-			*ex = extension{
-				Alpha: alpha,
-				COM:   com,
-			}
-			return nil
-		}
-
-		var baseFee big.Int
-		if err := rlp.DecodeBytes(raws[2], &baseFee); err != nil {
-			return err
+	// only alpha, make sure it's trimmed
+	if len(raws) == 1 {
+		if len(alpha) == 0 {
+			return errors.New("rlp: extension must be trimmed")
 		}
 
 		*ex = extension{
-			Alpha:   alpha,
-			COM:     com,
-			BaseFee: &baseFee,
+			Alpha: alpha,
+			COM:   false,
 		}
-
 		return nil
 	}
+
+	// more than one filed, must have com
+	var com bool
+	if err := rlp.DecodeBytes(raws[1], &com); err != nil {
+		return err
+	}
+
+	// alpha and com, make sure it's trimmed
+	if len(raws) == 2 {
+		// COM must be trimmed if not set
+		if !com {
+			return errors.New("rlp: extension must be trimmed")
+		}
+
+		*ex = extension{
+			Alpha: alpha,
+			COM:   com,
+		}
+		return nil
+	}
+
+	// For three fields, decode BaseFee
+	var baseFee big.Int
+	if err := rlp.DecodeBytes(raws[2], &baseFee); err != nil {
+		return err
+	}
+
+	*ex = extension{
+		Alpha:   alpha,
+		COM:     com,
+		BaseFee: &baseFee,
+	}
+
+	return nil
 }

--- a/block/extension.go
+++ b/block/extension.go
@@ -83,12 +83,14 @@ func (ex *extension) DecodeRLP(s *rlp.Stream) error {
 			}
 			return nil
 		}
+
+		// more than one filed, must have com
 		var com bool
 		if err := rlp.DecodeBytes(raws[1], &com); err != nil {
 			return err
 		}
 
-		// alpha and com, make sure baseFee is trimmed
+		// alpha and com, make sure it's trimmed
 		if len(raws) == 2 {
 			// COM must be trimmed if not set
 			if !com {
@@ -102,19 +104,15 @@ func (ex *extension) DecodeRLP(s *rlp.Stream) error {
 			return nil
 		}
 
-		var baseFee *big.Int
+		var baseFee big.Int
 		if err := rlp.DecodeBytes(raws[2], &baseFee); err != nil {
 			return err
 		}
 
-		// baseFee must be trimmed if not set
-		if baseFee == nil {
-			return errors.New("rlp: extension must be trimmed")
-		}
 		*ex = extension{
 			Alpha:   alpha,
 			COM:     com,
-			BaseFee: baseFee,
+			BaseFee: &baseFee,
 		}
 
 		return nil

--- a/block/header.go
+++ b/block/header.go
@@ -148,24 +148,28 @@ func (h *Header) SigningHash() (hash thor.Bytes32) {
 	defer func() { h.cache.signingHash.Store(hash) }()
 
 	return thor.Blake2bFn(func(w io.Writer) {
-		hashBody := []any{
-			&h.body.ParentID,
-			h.body.Timestamp,
-			h.body.GasLimit,
-			&h.body.Beneficiary,
-
-			h.body.GasUsed,
-			h.body.TotalScore,
-
-			&h.body.TxsRootFeatures,
-			&h.body.StateRoot,
-			&h.body.ReceiptsRoot,
-		}
-		if h.body.Extension.BaseFee != nil {
-			hashBody = append(hashBody, &h.body.Extension.BaseFee)
-		}
-		rlp.Encode(w, hashBody)
+		rlp.Encode(w, h.signingFields())
 	})
+}
+
+func (h *Header) signingFields() []any {
+	fields := []any{
+		&h.body.ParentID,
+		h.body.Timestamp,
+		h.body.GasLimit,
+		&h.body.Beneficiary,
+
+		h.body.GasUsed,
+		h.body.TotalScore,
+
+		&h.body.TxsRootFeatures,
+		&h.body.StateRoot,
+		&h.body.ReceiptsRoot,
+	}
+	if h.body.Extension.BaseFee != nil {
+		fields = append(fields, &h.body.Extension)
+	}
+	return fields
 }
 
 // Signature returns signature.

--- a/block/header.go
+++ b/block/header.go
@@ -154,17 +154,17 @@ func (h *Header) SigningHash() (hash thor.Bytes32) {
 
 func (h *Header) signingFields() []any {
 	fields := []any{
-		&h.body.ParentID,
+		h.body.ParentID,
 		h.body.Timestamp,
 		h.body.GasLimit,
-		&h.body.Beneficiary,
+		h.body.Beneficiary,
 
 		h.body.GasUsed,
 		h.body.TotalScore,
 
 		&h.body.TxsRootFeatures,
-		&h.body.StateRoot,
-		&h.body.ReceiptsRoot,
+		h.body.StateRoot,
+		h.body.ReceiptsRoot,
 	}
 	if h.body.Extension.BaseFee != nil {
 		fields = append(fields, &h.body.Extension)

--- a/block/header_test.go
+++ b/block/header_test.go
@@ -447,14 +447,14 @@ func TestHeaderHash(t *testing.T) {
 		}
 		assert.Equal(t, expectedFieldsLen, len(h.signingFields()), "unexpected number of signing fields")
 
-		expected := signingHash(h)
+		expected := signingHash(h, t)
 		assert.Equal(t, expected, h.SigningHash())
 	}
 }
 
 // signingHash returns the signing hash the block header.
 // this is a reflect based implementation used for cross checking.
-func signingHash(h *Header) thor.Bytes32 {
+func signingHash(h *Header, t *testing.T) thor.Bytes32 {
 	types := reflect.TypeOf(h.body)
 	values := reflect.ValueOf(h.body)
 
@@ -478,6 +478,6 @@ func signingHash(h *Header) thor.Bytes32 {
 	}
 
 	return thor.Blake2bFn(func(w io.Writer) {
-		rlp.Encode(w, fields)
+		assert.Nil(t, rlp.Encode(w, fields))
 	})
 }

--- a/block/header_test.go
+++ b/block/header_test.go
@@ -265,7 +265,7 @@ func TestExtensionV2(t *testing.T) {
 				cnt, err := rlp.CountValues(content)
 				assert.Nil(t, err)
 
-				// Extension should represent
+				// Extension should be present
 				assert.Equal(t, 1, cnt)
 
 				var dst v2
@@ -292,7 +292,7 @@ func TestExtensionV2(t *testing.T) {
 				})
 				assert.Nil(t, err)
 
-				// Extension should represent in the Encoding
+				// Extension should be present in the Encoding
 				content, _, err := rlp.SplitList(bytes)
 				assert.Nil(t, err)
 				cnt, err := rlp.CountValues(content)
@@ -305,7 +305,7 @@ func TestExtensionV2(t *testing.T) {
 				cnt, err = rlp.CountValues(content)
 				assert.Nil(t, err)
 
-				// Only alpha represent
+				// Only alpha present
 				assert.Equal(t, 1, cnt)
 
 				var dst v2
@@ -334,7 +334,7 @@ func TestExtensionV2(t *testing.T) {
 				assert.Nil(t, err)
 				cnt, err := rlp.CountValues(content)
 				assert.Nil(t, err)
-				// All fields should be represented
+				// All fields should be present
 				assert.Equal(t, 3, cnt)
 
 				var dst v2
@@ -365,7 +365,7 @@ func TestExtensionV2(t *testing.T) {
 				assert.Nil(t, err)
 				cnt, err := rlp.CountValues(content)
 				assert.Nil(t, err)
-				// All fields should be represented
+				// All fields should be present
 				assert.Equal(t, 3, cnt)
 
 				var dst v2

--- a/test/datagen/numbers.go
+++ b/test/datagen/numbers.go
@@ -6,11 +6,17 @@
 package datagen
 
 import (
+	"crypto/rand"
+	"math/big"
 	mathrand "math/rand/v2"
 )
 
 func RandInt() int {
 	return mathrand.Int() //#nosec G404
+}
+
+func RandUint32() uint32 {
+	return mathrand.Uint32() //#nosec G404
 }
 
 func RandUint64() uint64 {
@@ -19,4 +25,12 @@ func RandUint64() uint64 {
 
 func RandIntN(n int) int {
 	return mathrand.N(n) //#nosec G404
+}
+
+func RandBigInt() *big.Int {
+	var data [32]byte
+
+	rand.Read(data[:])
+
+	return new(big.Int).SetBytes(data[:])
 }

--- a/tx/transaction_test.go
+++ b/tx/transaction_test.go
@@ -7,12 +7,15 @@ package tx
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"reflect"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
@@ -460,4 +463,113 @@ func checkTxsEquality(expectedTx, actualTx *Transaction) error {
 		return fmt.Errorf("SigningHash: expected %v, got %v", expectedTx.SigningHash(), actualTx.SigningHash())
 	}
 	return nil
+}
+
+func TestTransactionHash(t *testing.T) {
+	for range 100 {
+		num := datagen.RandUint64()
+		var builder *Builder
+		if num%2 == 0 {
+			builder = NewBuilder(TypeLegacy)
+		} else {
+			builder = NewBuilder(TypeDynamicFee)
+		}
+
+		var (
+			ref  BlockRef
+			feat Features
+		)
+		randBytes := datagen.RandBytes(9)
+		copy(ref[:], randBytes[1:9])
+		to := datagen.RandAddress()
+
+		builder.
+			ChainTag(randBytes[0]).
+			BlockRef(ref).
+			Expiration(uint32(num)).
+			Clause(NewClause(&to).WithValue(big.NewInt(int64(num))).WithData(datagen.RandBytes(32))).
+			GasPriceCoef(uint8(num)).
+			Gas(datagen.RandUint64()).
+			Nonce(num)
+
+		if num%3 == 0 {
+			feat.SetDelegated(true)
+		}
+		builder.Features(feat)
+
+		if num%5 == 0 {
+			dep := datagen.RandomHash()
+			builder.DependsOn(&dep)
+		}
+
+		trx := builder.Build()
+
+		var expected thor.Bytes32
+		if trx.Type() == TypeLegacy {
+			expected = rlpHash(signingFields(trx.body))
+
+			// test evaluate work
+			origin := thor.BytesToAddress(datagen.RandBytes(20))
+			nonce := datagen.RandUint64()
+
+			body, _ := trx.body.(*legacyTransaction)
+			expectedWork := evaluateWork(body, origin, nonce)
+			assert.Equal(t, expectedWork, trx.EvaluateWork(origin)(nonce))
+		} else {
+			expected = prefixedRlpHash(trx.Type(), signingFields(trx.body))
+		}
+		assert.Equal(t, len(trx.body.signingFields()), reflect.TypeOf(trx.body).Elem().NumField()-1, "unexpected number of signing fields")
+		assert.Equal(t, expected, trx.SigningHash())
+	}
+}
+
+// a reflect based implementation of hashWithoutNonce for cross implementation.
+func evaluateWork(body *legacyTransaction, origin thor.Address, nonce uint64) *big.Int {
+	types := reflect.TypeOf(body)
+	values := reflect.ValueOf(body)
+
+	fields := make([]any, 0)
+	// hash without nonce
+	for i := range types.Elem().NumField() {
+		// skip signature and nonce field
+		if types.Elem().Field(i).Name != "Signature" && types.Elem().Field(i).Name != "Nonce" {
+			// pass reserved field as a pointer
+			if types.Elem().Field(i).Name == "Reserved" {
+				reserved := values.Elem().Field(i).Interface().(reserved)
+				fields = append(fields, &reserved)
+			} else {
+				fields = append(fields, values.Elem().Field(i).Interface())
+			}
+		}
+	}
+	fields = append(fields, origin)
+	hashWithoutNonce := rlpHash(fields)
+
+	var nonceBytes [8]byte
+	binary.BigEndian.PutUint64(nonceBytes[:], nonce)
+	hash := thor.Blake2b(hashWithoutNonce[:], nonceBytes[:])
+	r := new(big.Int).SetBytes(hash[:])
+	return r.Div(math.MaxBig256, r)
+}
+
+// signingFields returns the fields that need to be signed.
+// this is a reflect based implementation used for cross checking.
+func signingFields(body txData) []any {
+	types := reflect.TypeOf(body)
+	values := reflect.ValueOf(body)
+
+	fields := make([]any, 0)
+	for i := range types.Elem().NumField() {
+		// skip signature field
+		if types.Elem().Field(i).Name != "Signature" {
+			// pass reserved field as a pointer
+			if types.Elem().Field(i).Name == "Reserved" {
+				reserved := values.Elem().Field(i).Interface().(reserved)
+				fields = append(fields, &reserved)
+			} else {
+				fields = append(fields, values.Elem().Field(i).Interface())
+			}
+		}
+	}
+	return fields
 }


### PR DESCRIPTION
# Description

Signing fields are defined to all fields, except the signature, we are writing these codes manually, to avoid any potential human error like [this](https://github.com/vechain/thor/pull/1020/commits/fa71fc0307f4121b37b6cc59283c50c25481372a), this PR introduced a reflect based singing hash test mechanism to run the signing in an automated way in the tests to have a guard for that kind of functions.

Links to vechain/protocol-board-repo#513

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
