### PR TITLE
feat(legacy tx): error message when base fee is greater than baseGasPrice

### DIFF
--- a/consensus/fork/galactica.go
+++ b/consensus/fork/galactica.go
@@ -20,9 +20,9 @@ import (
 var (
 	// errBaseFeeTooHighForLegacyTx is returned if the base fee is too high for a legacy tx
 	errBaseFeeTooHighForLegacyTx = errors.New("base fee too high for legacy tx, use dynamic fee tx or retry later")
-	// errMaxFeePerGasTooLow is returned if the transaction max fee is less than
+	// errBaseFeeTooHighForDynamicFeeTx is returned if the transaction max fee is less than
 	// the base fee of the block.
-	errMaxFeePerGasTooLow = errors.New("max fee per gas is less than block base fee")
+	errBaseFeeTooHighForDynamicFeeTx = errors.New("max fee per gas is less than block base fee")
 	// ErrBaseFeeNotSet is returned if the base fee is not set after the Galactica fork
 	ErrBaseFeeNotSet = errors.New("base fee not set after galactica")
 )
@@ -170,7 +170,7 @@ func ValidateGalacticaTxFee(tr *tx.Transaction, baseFee, baseGasPrice *big.Int) 
 		if tr.Type() == tx.TypeLegacy {
 			return errBaseFeeTooHighForLegacyTx
 		}
-		return errMaxFeePerGasTooLow
+		return errBaseFeeTooHighForDynamicFeeTx
 	}
 	return nil
 }

--- a/consensus/fork/galactica.go
+++ b/consensus/fork/galactica.go
@@ -18,14 +18,13 @@ import (
 )
 
 var (
+	// errBaseFeeTooHighForLegacyTx is returned if the base fee is too high for a legacy tx
+	errBaseFeeTooHighForLegacyTx = errors.New("base fee too high for legacy tx, use dynamic fee tx or retry later")
+	// errMaxFeePerGasTooLow is returned if the transaction max fee is less than
+	// the base fee of the block.
+	errMaxFeePerGasTooLow = errors.New("max fee per gas is less than block base fee")
 	// ErrBaseFeeNotSet is returned if the base fee is not set after the Galactica fork
 	ErrBaseFeeNotSet = errors.New("base fee not set after galactica")
-	// ErrBaseFeeTooHighForLegacyTx is returned if the base fee is too high for a legacy tx
-	ErrBaseFeeTooHighForLegacyTx = errors.New("base fee too high for legacy tx, use dynamic fee tx or retry later")
-	// ErrMaxFeePerGasTooLow is returned if the transaction max fee is less than
-	// the base fee of the block.
-	ErrMaxFeePerGasTooLow = errors.New("max fee per gas is less than block base fee")
-
 )
 
 // VerifyGalacticaHeader verifies some header attributes which were changed in Galactica fork,
@@ -169,9 +168,9 @@ func ValidateGalacticaTxFee(tr *tx.Transaction, baseFee, baseGasPrice *big.Int) 
 	galacticaItems := GalacticaTxGasPriceAdapter(tr, baseGasPrice)
 	if galacticaItems.MaxFee.Cmp(baseFee) < 0 {
 		if tr.Type() == tx.TypeLegacy {
-			return ErrBaseFeeTooHighForLegacyTx
+			return errBaseFeeTooHighForLegacyTx
 		}
-		return ErrMaxFeePerGasTooLow
+		return errMaxFeePerGasTooLow
 	}
 	return nil
 }

--- a/consensus/fork/galactica_test.go
+++ b/consensus/fork/galactica_test.go
@@ -455,7 +455,7 @@ func TestValidateGalacticaTxFee(t *testing.T) {
 			tx:           tx.NewBuilder(tx.TypeLegacy).GasPriceCoef(255).Build(),
 			baseFee:      defaultBaseFee,
 			baseGasPrice: new(big.Int).Sub(defaultBaseFee, common.Big1),
-			wantErr:      errors.New("max fee per gas is less than block base fee"),
+			wantErr:      errors.New("base fee too high for legacy tx, use dynamic fee tx or retry later"),
 		},
 		{
 			name:         "dynamic fee transaction not with enough fee",

--- a/consensus/fork/galactica_test.go
+++ b/consensus/fork/galactica_test.go
@@ -7,7 +7,6 @@ package fork
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math/big"
 	"testing"
@@ -455,14 +454,14 @@ func TestValidateGalacticaTxFee(t *testing.T) {
 			tx:           tx.NewBuilder(tx.TypeLegacy).GasPriceCoef(255).Build(),
 			baseFee:      defaultBaseFee,
 			baseGasPrice: new(big.Int).Sub(defaultBaseFee, common.Big1),
-			wantErr:      errors.New("base fee too high for legacy tx, use dynamic fee tx or retry later"),
+			wantErr:      errBaseFeeTooHighForLegacyTx,
 		},
 		{
 			name:         "dynamic fee transaction not with enough fee",
 			tx:           tx.NewBuilder(tx.TypeDynamicFee).MaxFeePerGas(new(big.Int).Sub(defaultBaseFee, common.Big1)).Build(),
 			baseFee:      defaultBaseFee,
 			baseGasPrice: defaultBaseFee,
-			wantErr:      errors.New("max fee per gas is less than block base fee"),
+			wantErr:      errBaseFeeTooHighForDynamicFeeTx,
 		},
 	}
 

--- a/consensus/validator_test.go
+++ b/consensus/validator_test.go
@@ -6,6 +6,7 @@
 package consensus
 
 import (
+	"errors"
 	"math/big"
 	"testing"
 
@@ -14,7 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/chain"
-	"github.com/vechain/thor/v2/consensus/fork"
 	"github.com/vechain/thor/v2/genesis"
 	"github.com/vechain/thor/v2/muxdb"
 	"github.com/vechain/thor/v2/state"
@@ -119,7 +119,8 @@ func TestValidateBlock(t *testing.T) {
 				s, r, err := c.verifyBlock(blk, state, 0)
 				assert.Nil(t, s)
 				assert.Nil(t, r)
-				assert.Equal(t, fork.ErrMaxFeePerGasTooLow, err)
+				expectedErr := errors.New("max fee per gas is less than block base fee")
+				assert.Equal(t, expectedErr, err)
 			},
 		},
 		{
@@ -140,7 +141,8 @@ func TestValidateBlock(t *testing.T) {
 				s, r, err := c.verifyBlock(blk, state, 0)
 				assert.Nil(t, s)
 				assert.Nil(t, r)
-				assert.Equal(t, fork.ErrBaseFeeTooHighForLegacyTx, err)
+				expectedErr := errors.New("base fee too high for legacy tx, use dynamic fee tx or retry later")
+				assert.Equal(t, expectedErr, err)
 			},
 		},
 	}


### PR DESCRIPTION
# Description

Title is self-explanatory. Also reviewed the checks at `txpool/validation.go` but I think the errors are good there since both tx fee values are 0 in those cases for legacy tx.

Closes https://github.com/vechain/protocol-board-repo/issues/537
