### PR TITLE
fix(`fees/history`): updated swagger docs so `newestBlock` can be `next`

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -2450,7 +2450,7 @@ components:
       name: newestBlock
       in: query
       required: true
-      description: Specify either `best`, `justified`, `finalized`, a block number or block ID. If omitted, the `best` block is assumed.
+      description: Specify either `best`, `justified`, `finalized`, `next` or a block number or block ID. If omitted, the `best` block is assumed.
       schema:
         type: string
     

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -2449,7 +2449,6 @@ components:
     NewestBlockInQuery:
       name: newestBlock
       in: query
-      required: true
       description: Specify either `best`, `justified`, `finalized`, `next`, a block number or block ID. If omitted, the `best` block is assumed.
       schema:
         type: string

--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -2450,7 +2450,7 @@ components:
       name: newestBlock
       in: query
       required: true
-      description: Specify either `best`, `justified`, `finalized`, `next` or a block number or block ID. If omitted, the `best` block is assumed.
+      description: Specify either `best`, `justified`, `finalized`, `next`, a block number or block ID. If omitted, the `best` block is assumed.
       schema:
         type: string
     


### PR DESCRIPTION
# Description

Also removed `required` for `newestBlock` since it is `best` when not provided
