### PR TITLE
fix(`fees/history`): `gasUsedRatio` in Swagger

### DIFF
--- a/api/doc/thor.yaml
+++ b/api/doc/thor.yaml
@@ -1290,7 +1290,7 @@ components:
               example:
                 - '0x0'
                 - '0x98'
-            gasUsedRatios:
+            gasUsedRatio:
               type: array
               description: |
                 An array of gas used ratios per block as float numbers.


### PR DESCRIPTION
# Description

Alignment with the actual field in the response
