### PR TITLE
Modify testchain to accept current time

### DIFF
--- a/api/transactions/transactions_test.go
+++ b/api/transactions/transactions_test.go
@@ -34,6 +34,7 @@ var (
 	mempoolTx   *tx.Transaction
 	tclient     *thorclient.Client
 	chainTag    byte
+	thorChain   *testchain.Chain
 )
 
 func TestTransaction(t *testing.T) {
@@ -43,8 +44,9 @@ func TestTransaction(t *testing.T) {
 	// Send tx
 	tclient = thorclient.New(ts.URL)
 	for name, tt := range map[string]func(*testing.T){
-		"sendTx":              sendTx,
-		"sendTxWithBadFormat": sendTxWithBadFormat,
+		"sendTx":                                   sendTx,
+		"sendImpossibleBlockRefExpiryTx":           sendImpossibleBlockRefExpiryTx,
+		"sendTxWithBadFormat":                      sendTxWithBadFormat,
 		"sendTxThatCannotBeAcceptedInLocalMempool": sendTxThatCannotBeAcceptedInLocalMempool,
 	} {
 		t.Run(name, tt)
@@ -131,6 +133,30 @@ func sendTx(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, trx.ID().String(), txObj["id"], "should be the same transaction id")
+}
+
+func sendImpossibleBlockRefExpiryTx(t *testing.T) {
+	var blockRef = tx.NewBlockRef(thorChain.Repo().BestBlockSummary().Header.Number())
+	var expiration = uint32(0)
+	var gas = uint64(21000)
+
+	trx := tx.MustSign(
+		new(tx.Builder).
+			BlockRef(blockRef).
+			ChainTag(chainTag).
+			Expiration(expiration).
+			Gas(gas).
+			Build(),
+		genesis.DevAccounts()[0].PrivateKey,
+	)
+
+	rlpTx, err := rlp.EncodeToBytes(trx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := httpPostAndCheckResponseStatus(t, "/transactions", transactions.RawTx{Raw: hexutil.Encode(rlpTx)}, 403)
+	assert.Equal(t, "tx rejected: expired\n", string(res), "should be expired")
 }
 
 func getTxWithBadID(t *testing.T) {
@@ -266,7 +292,8 @@ func httpPostAndCheckResponseStatus(t *testing.T, url string, obj any, responseS
 }
 
 func initTransactionServer(t *testing.T) {
-	thorChain, err := testchain.NewIntegrationTestChain()
+	var err error
+	thorChain, err = testchain.NewIntegrationTestChain()
 	require.NoError(t, err)
 
 	chainTag = thorChain.Repo().ChainTag()

--- a/api/utils/revisions_test.go
+++ b/api/utils/revisions_test.go
@@ -102,6 +102,7 @@ func TestGetSummary(t *testing.T) {
 	thorChain, err := testchain.NewIntegrationTestChain()
 	require.NoError(t, err)
 
+	customRevision := thorChain.Repo().BestBlockSummary().Header.ID()
 	// Test cases
 	testCases := []struct {
 		name     string
@@ -129,8 +130,8 @@ func TestGetSummary(t *testing.T) {
 			err:      nil,
 		},
 		{
-			name:     "0x00000000c05a20fbca2bf6ae3affba6af4a74b800b585bf7a4988aba7aea69f6",
-			revision: &Revision{thor.MustParseBytes32("0x00000000c05a20fbca2bf6ae3affba6af4a74b800b585bf7a4988aba7aea69f6")},
+			name:     "customRevision",
+			revision: &Revision{customRevision},
 			err:      nil,
 		},
 		{

--- a/genesis/devnet.go
+++ b/genesis/devnet.go
@@ -63,7 +63,10 @@ func NewDevnet() *Genesis {
 
 func NewDevnetWithConfig(config thor.ForkConfig) *Genesis {
 	launchTime := uint64(1526400000) // 'Wed May 16 2018 00:00:00 GMT+0800 (CST)'
+	return NewDevnetWithConfigAndLaunchtime(config, launchTime)
+}
 
+func NewDevnetWithConfigAndLaunchtime(config thor.ForkConfig, launchTime uint64) *Genesis {
 	executor := DevAccounts()[0].Address
 	soloBlockSigner := DevAccounts()[0]
 

--- a/test/testchain/chain.go
+++ b/test/testchain/chain.go
@@ -73,7 +73,7 @@ func NewIntegrationTestChain() (*Chain, error) {
 	stater := state.NewStater(db)
 
 	// Initialize the genesis and retrieve the genesis block
-	gene := genesis.NewDevnetWithConfig(forkConfig)
+	gene := genesis.NewDevnetWithConfigAndLaunchtime(forkConfig, uint64(time.Now().Unix()))
 	geneBlk, _, _, err := gene.Build(stater)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

Testchain now uses the devnet with the local timestamp.

This is particularly important to handle tx pool tests where the `isChainSynced` is used to determine the tx evaluation flow.
Previously the testchain was never sync'd, now it's always sync'd.

Fixes # [(issue)](https://github.com/vechain/otherviews-workboard/issues/157) and [issue](https://github.com/vechain/protocol-board-repo/issues/542)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
