### PR TITLE
set base fee if GALACTICA forks from 0

### DIFF
--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -740,7 +740,7 @@ func TestConsent(t *testing.T) {
 					Expiration(100).
 					Clause(tx.NewClause(&thor.Address{}).WithValue(big.NewInt(0)).WithData(nil)).
 					Nonce(0).
-					ChainTag(161)
+					ChainTag(tc.tag)
 
 				tx := txSign(txBuilder)
 

--- a/genesis/builder.go
+++ b/genesis/builder.go
@@ -7,6 +7,7 @@ package genesis
 
 import (
 	"math"
+	"math/big"
 
 	"github.com/pkg/errors"
 	"github.com/vechain/thor/v2/block"
@@ -123,11 +124,16 @@ func (b *Builder) Build(stater *state.Stater) (blk *block.Block, events tx.Event
 	parentID := thor.Bytes32{0xff, 0xff, 0xff, 0xff} //so, genesis number is 0
 	copy(parentID[4:], b.extraData[:])
 
-	return new(block.Builder).
+	blkBuilder := new(block.Builder).
 		ParentID(parentID).
 		Timestamp(b.timestamp).
 		GasLimit(b.gasLimit).
 		StateRoot(stateRoot).
-		ReceiptsRoot(tx.Transactions(nil).RootHash()).
-		Build(), events, transfers, nil
+		ReceiptsRoot(tx.Transactions(nil).RootHash())
+
+	if b.forkConfig.GALACTICA == 0 {
+		blkBuilder.BaseFee(new(big.Int).SetUint64(thor.InitialBaseFee))
+	}
+
+	return blkBuilder.Build(), events, transfers, nil
 }


### PR DESCRIPTION
# Description

Avoids panic if a custom net set GALACTICA to 0.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
