### PR TITLE
Adding a 32 block cache for gas prices in the tx pool

### DIFF
--- a/txpool/gas_price_cache.go
+++ b/txpool/gas_price_cache.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
 package txpool
 
 import (

--- a/txpool/gas_price_cache.go
+++ b/txpool/gas_price_cache.go
@@ -1,0 +1,50 @@
+package txpool
+
+import (
+	"math/big"
+
+	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/cache"
+	"github.com/vechain/thor/v2/consensus/fork"
+	"github.com/vechain/thor/v2/thor"
+)
+
+type entry struct {
+	baseFee *big.Int
+}
+
+type gasPriceCache struct {
+	cache      *cache.PrioCache
+	forkConfig *thor.ForkConfig
+}
+
+func newGasPriceCache(forkConfig *thor.ForkConfig, limit int) *gasPriceCache {
+	return &gasPriceCache{
+		cache:      cache.NewPrioCache(limit),
+		forkConfig: forkConfig,
+	}
+}
+
+// getBlockBaseFee returns the base fee for the given block
+// avoids recomputing every time, and caches the result
+func (c *gasPriceCache) getBlockBaseFee(blkHeader *block.Header) *big.Int {
+	if blkHeader.Number()+1 < c.forkConfig.GALACTICA {
+		// Before GALACTICA, the base fee is not set, so it returns nil.
+		return nil
+	}
+
+	var ent *entry
+	if val, _, ok := c.cache.Get(blkHeader.ID()); ok {
+		ent = val.(*entry)
+		if ent.baseFee != nil {
+			return ent.baseFee
+		}
+	} else {
+		ent = &entry{}
+	}
+
+	ent.baseFee = fork.CalcBaseFee(c.forkConfig, blkHeader)
+
+	c.cache.Set(blkHeader.ID(), ent, float64(blkHeader.Number()))
+	return ent.baseFee
+}

--- a/txpool/gas_price_cache_test.go
+++ b/txpool/gas_price_cache_test.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2025 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
 package txpool
 
 import (
@@ -145,7 +149,7 @@ func TestGasPriceCacheConcurrentAccess(t *testing.T) {
 	done := make(chan bool)
 
 	// Launch multiple goroutines to test concurrent access
-	for i := 0; i < 10; i++ {
+	for i := range [10]struct{}{} {
 		go func(blockNum uint32) {
 			header := new(block.Builder).
 				ParentID(createParentID(blockNum - 1)). // Parent of current block
@@ -165,7 +169,7 @@ func TestGasPriceCacheConcurrentAccess(t *testing.T) {
 	}
 
 	// Wait for all goroutines to complete
-	for i := 0; i < 10; i++ {
+	for range [10]struct{}{} {
 		<-done
 	}
 }

--- a/txpool/gas_price_cache_test.go
+++ b/txpool/gas_price_cache_test.go
@@ -1,0 +1,171 @@
+package txpool
+
+import (
+	"encoding/binary"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/thor"
+)
+
+func createParentID(blockNum uint32) thor.Bytes32 {
+	var id thor.Bytes32
+	binary.BigEndian.PutUint32(id[:], blockNum)
+	return id
+}
+
+func TestGasPriceCache(t *testing.T) {
+	// Create test fork config
+	forkConfig := &thor.ForkConfig{
+		GALACTICA: 1000, // Set GALACTICA fork at block 1000
+	}
+
+	// Create test cache with small limit
+	cache := newGasPriceCache(forkConfig, 2)
+
+	// Test pre-GALACTICA block
+	preGalacticaHeader := new(block.Builder).
+		ParentID(createParentID(997)). // Parent of block 998
+		Timestamp(1000).
+		TotalScore(100).
+		GasLimit(10000000).
+		GasUsed(0).
+		Beneficiary(thor.Address{}).
+		StateRoot(thor.Bytes32{}).
+		ReceiptsRoot(thor.Bytes32{}).
+		Build().Header()
+
+	baseFee := cache.getBlockBaseFee(preGalacticaHeader)
+	assert.Nil(t, baseFee, "Base fee should be nil for pre-GALACTICA blocks")
+
+	// Test post-GALACTICA block
+	postGalacticaHeader := new(block.Builder).
+		ParentID(createParentID(999)). // Parent of block 1000
+		Timestamp(1000).
+		TotalScore(100).
+		GasLimit(10000000).
+		GasUsed(0).
+		Beneficiary(thor.Address{}).
+		StateRoot(thor.Bytes32{}).
+		ReceiptsRoot(thor.Bytes32{}).
+		BaseFee(big.NewInt(1000)).
+		Build().Header()
+
+	baseFee = cache.getBlockBaseFee(postGalacticaHeader)
+	assert.NotNil(t, baseFee, "Base fee should not be nil for post-GALACTICA blocks")
+
+	// Test cache hit
+	baseFee2 := cache.getBlockBaseFee(postGalacticaHeader)
+	assert.Equal(t, baseFee, baseFee2, "Cached base fee should match")
+
+	// Test cache recalculation
+	// Add more blocks to force eviction
+	header3 := new(block.Builder).
+		ParentID(createParentID(1000)). // Parent of block 1001
+		Timestamp(1000).
+		TotalScore(100).
+		GasLimit(10000000).
+		GasUsed(40_000_000).
+		Beneficiary(thor.Address{}).
+		StateRoot(thor.Bytes32{}).
+		ReceiptsRoot(thor.Bytes32{}).
+		BaseFee(big.NewInt(1001)).
+		Build().Header()
+
+	header4 := new(block.Builder).
+		ParentID(createParentID(1001)). // Parent of block 1002
+		Timestamp(1000).
+		TotalScore(100).
+		GasLimit(10000000).
+		GasUsed(40_000_000).
+		Beneficiary(thor.Address{}).
+		StateRoot(thor.Bytes32{}).
+		ReceiptsRoot(thor.Bytes32{}).
+		BaseFee(big.NewInt(1002)).
+		Build().Header()
+
+	cache.getBlockBaseFee(header3)
+	cache.getBlockBaseFee(header4)
+
+	// First block should be evicted and values recalculated
+	assert.False(t, cache.cache.Contains(postGalacticaHeader.ID()))
+}
+
+func TestGasPriceCacheWithMockFork(t *testing.T) {
+	// Create a mock fork config
+	forkConfig := &thor.ForkConfig{
+		GALACTICA: 1000,
+	}
+
+	// Create test cache
+	cache := newGasPriceCache(forkConfig, 10)
+
+	// Test multiple blocks with different numbers
+	testCases := []struct {
+		blockNumber uint32
+		shouldBeNil bool
+	}{
+		{997, true},   // Pre-GALACTICA
+		{1000, false}, // At GALACTICA
+		{1001, false}, // Post-GALACTICA
+		{2000, false}, // Far post-GALACTICA
+	}
+
+	for _, tc := range testCases {
+		header := new(block.Builder).
+			ParentID(createParentID(tc.blockNumber - 1)). // Parent of current block
+			Timestamp(1000).
+			TotalScore(100).
+			GasLimit(10000000).
+			GasUsed(0).
+			Beneficiary(thor.Address{}).
+			StateRoot(thor.Bytes32{}).
+			ReceiptsRoot(thor.Bytes32{}).
+			BaseFee(big.NewInt(1000)).
+			Build().Header()
+
+		baseFee := cache.getBlockBaseFee(header)
+		if tc.shouldBeNil {
+			assert.Nil(t, baseFee, "Base fee should be nil for block %d", tc.blockNumber)
+		} else {
+			assert.NotNil(t, baseFee, "Base fee should not be nil for block %d", tc.blockNumber)
+		}
+	}
+}
+
+func TestGasPriceCacheConcurrentAccess(t *testing.T) {
+	forkConfig := &thor.ForkConfig{
+		GALACTICA: 1000,
+	}
+	cache := newGasPriceCache(forkConfig, 100)
+
+	// Create a channel to signal when all goroutines are done
+	done := make(chan bool)
+
+	// Launch multiple goroutines to test concurrent access
+	for i := 0; i < 10; i++ {
+		go func(blockNum uint32) {
+			header := new(block.Builder).
+				ParentID(createParentID(blockNum - 1)). // Parent of current block
+				Timestamp(1000).
+				TotalScore(100).
+				GasLimit(10000000).
+				GasUsed(0).
+				Beneficiary(thor.Address{}).
+				StateRoot(thor.Bytes32{}).
+				ReceiptsRoot(thor.Bytes32{}).
+				BaseFee(big.NewInt(1000)).
+				Build().Header()
+
+			cache.getBlockBaseFee(header)
+			done <- true
+		}(uint32(1000 + i))
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}

--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/vechain/thor/v2/block"
-	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/consensus/fork"
 	"github.com/vechain/thor/v2/runtime"
@@ -134,7 +133,7 @@ func (o *txObject) Executable(
 	if err != nil {
 		return false, fmt.Errorf("failed to get proved work: %w", err)
 	}
-	legacyTxBaseGasPrice, err := builtin.Params.Native(state).Get(thor.KeyLegacyTxBaseGasPrice)
+	legacyTxBaseGasPrice, err := cache.getLegacyTxBaseGasPrice(state, headBlock)
 	if err != nil {
 		return false, err
 	}

--- a/txpool/tx_object_map_test.go
+++ b/txpool/tx_object_map_test.go
@@ -167,17 +167,18 @@ func TestPendingCost(t *testing.T) {
 	chain := repo.NewBestChain()
 	best := repo.BestBlockSummary()
 	state := stater.NewState(best.Root())
+	cache := newGasPriceCache(&thor.NoFork, 10)
 
 	var err error
-	txObj1.executable, err = txObj1.Executable(chain, state, best.Header, &thor.NoFork)
+	txObj1.executable, err = txObj1.Executable(chain, state, best.Header, cache)
 	assert.Nil(t, err)
 	assert.True(t, txObj1.executable)
 
-	txObj2.executable, err = txObj2.Executable(chain, state, best.Header, &thor.NoFork)
+	txObj2.executable, err = txObj2.Executable(chain, state, best.Header, cache)
 	assert.Nil(t, err)
 	assert.True(t, txObj2.executable)
 
-	txObj3.executable, err = txObj3.Executable(chain, state, best.Header, &thor.NoFork)
+	txObj3.executable, err = txObj3.Executable(chain, state, best.Header, cache)
 	assert.Nil(t, err)
 	assert.True(t, txObj3.executable)
 

--- a/txpool/tx_object_test.go
+++ b/txpool/tx_object_test.go
@@ -76,6 +76,7 @@ func SetupTest() (genesis.DevAccount, *chain.Repository, *block.Block, *state.St
 
 func TestExecutableWithError(t *testing.T) {
 	acc, repo, b1, st := SetupTest()
+	cache := newGasPriceCache(&thor.NoFork, 10)
 
 	tests := []struct {
 		tx          *tx.Transaction
@@ -93,7 +94,7 @@ func TestExecutableWithError(t *testing.T) {
 		// pass custom headID
 		chain := repo.NewChain(thor.Bytes32{0})
 
-		exe, err := txObj.Executable(chain, st, b1.Header(), &thor.NoFork)
+		exe, err := txObj.Executable(chain, st, b1.Header(), cache)
 		if tt.expectedErr != "" {
 			assert.Equal(t, tt.expectedErr, err.Error())
 		} else {
@@ -152,6 +153,7 @@ func TestExecutable(t *testing.T) {
 	b1 := new(block.Builder).ParentID(b0.Header().ID()).GasLimit(10000000).TotalScore(100).Build()
 	repo.AddBlock(b1, nil, 0, false)
 	st := state.New(db, trie.Root{Hash: repo.GenesisBlock().Header().StateRoot()})
+	cache := newGasPriceCache(&thor.NoFork, 10)
 
 	tests := []struct {
 		tx          *tx.Transaction
@@ -176,7 +178,7 @@ func TestExecutable(t *testing.T) {
 		txObj, err := resolveTx(tt.tx, false)
 		assert.Nil(t, err)
 
-		exe, err := txObj.Executable(repo.NewChain(b1.Header().ID()), st, b1.Header(), &thor.NoFork)
+		exe, err := txObj.Executable(repo.NewChain(b1.Header().ID()), st, b1.Header(), cache)
 		if tt.expectedErr != "" {
 			assert.Equal(t, tt.expectedErr, err.Error())
 		} else {

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -433,19 +433,6 @@ func (p *TxPool) wash(headSummary *chain.BlockSummary) (executables tx.Transacti
 		}
 
 		if executable {
-			//provedWork, err := txObj.ProvedWork(headSummary.Header.Number(), chain.GetBlockID)
-			//if err != nil {
-			//	toRemove = append(toRemove, txObj)
-			//	logger.Trace("tx washed out", "id", txObj.ID(), "err", err)
-			//	continue
-			//}
-			//isGalactica := headSummary.Header.Number() >= p.forkConfig.GALACTICA
-			//var baseFee *big.Int
-			//if isGalactica {
-			//	baseFee = fork.CalcBaseFee(p.forkConfig, headSummary.Header)
-			//}
-			//txObj.priorityGasPrice = fork.GalacticaPriorityGasPrice(txObj.Transaction, legacyTxBaseGasPrice, provedWork, baseFee)
-
 			if txObj.localSubmitted {
 				localExecutableObjs = append(localExecutableObjs, txObj)
 			} else {


### PR DESCRIPTION
# Description

This PR comes from https://github.com/vechain/thor/pull/1054 
It adds a 32 block cache ( can perhaps be reduced ) to avoid the base fee re-calculation everytime a transaction is added cycled for in the tx pool.

Fixes # (issue)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added tests to the cache.

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
