### PR TITLE
Reduce the number of state calls when processing blocks

### DIFF
--- a/consensus/fork/galactica.go
+++ b/consensus/fork/galactica.go
@@ -168,7 +168,7 @@ func CalculateReward(gasUsed uint64, rewardGasPrice, rewardRatio *big.Int, isGal
 	return reward
 }
 
-func validateGalacticaTxFee(tr *tx.Transaction, legacyTxBaseGasPrice, blockBaseFeeGasPrice *big.Int) error {
+func ValidateGalacticaTxFee(tr *tx.Transaction, legacyTxBaseGasPrice, blockBaseFeeGasPrice *big.Int) error {
 	// proved work is not accounted for verifying if gas is enough to cover block base fee
 	feeItems := GalacticaTxGasPriceAdapter(tr, tr.GasPrice(legacyTxBaseGasPrice))
 
@@ -179,11 +179,11 @@ func validateGalacticaTxFee(tr *tx.Transaction, legacyTxBaseGasPrice, blockBaseF
 	return nil
 }
 
-func ValidateGalacticaTxFee(tr *tx.Transaction, state *state.State, blockBaseFeeGasPrice *big.Int) error {
+func ValidateGalacticaTxFeeWithState(tr *tx.Transaction, state *state.State, blockBaseFeeGasPrice *big.Int) error {
 	legacyTxBaseGasPrice, err := builtin.Params.Native(state).Get(thor.KeyLegacyTxBaseGasPrice)
 	if err != nil {
 		return err
 	}
 
-	return validateGalacticaTxFee(tr, legacyTxBaseGasPrice, blockBaseFeeGasPrice)
+	return ValidateGalacticaTxFee(tr, legacyTxBaseGasPrice, blockBaseFeeGasPrice)
 }

--- a/consensus/fork/galactica_test.go
+++ b/consensus/fork/galactica_test.go
@@ -456,7 +456,7 @@ func TestValidateGalacticaTxFee(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateGalacticaTxFee(tt.tx, tt.legacyTxBaseGasPrice, tt.blkBaseFeeGasPrice)
+			err := ValidateGalacticaTxFee(tt.tx, tt.legacyTxBaseGasPrice, tt.blkBaseFeeGasPrice)
 			assert.True(t, errors.Is(err, tt.wantErr))
 		})
 	}

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -322,7 +322,7 @@ func (c *Consensus) verifyBlock(blk *block.Block, state *state.State, blockConfl
 
 		// check if tx has enough fee to cover for base fee, if set
 		if header.BaseFee() != nil {
-			if err := fork.ValidateGalacticaTxFee(tx, state, header.BaseFee()); err != nil {
+			if err := fork.ValidateGalacticaTxFeeWithState(tx, state, header.BaseFee()); err != nil {
 				return nil, nil, err
 			}
 		}

--- a/packer/flow.go
+++ b/packer/flow.go
@@ -154,7 +154,10 @@ func (f *Flow) Adopt(t *tx.Transaction) error {
 			return fork.ErrBaseFeeNotSet
 		}
 
-		if err := fork.ValidateGalacticaTxFee(t, f.runtime.State(), f.runtime.Context().BaseFee); err != nil {
+		// A transaction that changes the `legacyTxBaseGasPrice` will still obey the current block base fee
+		// Because the state of the block is not changed at this point
+		// re-fetching the `KeyLegacyTxBaseGasPrice` not produce different results
+		if err := fork.ValidateGalacticaTxFee(t, f.legacyTxBaseGasPrice, f.runtime.Context().BaseFee); err != nil {
 			return fmt.Errorf("%w: %w", errTxNotAdoptableNow, err)
 		}
 

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -127,7 +127,10 @@ func (p *Packer) Schedule(parent *chain.BlockSummary, nowTimestamp uint64) (flow
 		}
 	}
 
-	var baseFee *big.Int
+	var legacyTxBaseGasPrice, baseFee *big.Int
+	if legacyTxBaseGasPrice, err = builtin.Params.Native(state).Get(thor.KeyLegacyTxBaseGasPrice); err != nil {
+		return nil, err
+	}
 
 	if parent.Header.Number()+1 >= p.forkConfig.GALACTICA {
 		baseFee = fork.CalcBaseFee(&p.forkConfig, parent.Header)
@@ -147,7 +150,7 @@ func (p *Packer) Schedule(parent *chain.BlockSummary, nowTimestamp uint64) (flow
 		},
 		p.forkConfig)
 
-	return newFlow(p, parent.Header, rt, features), nil
+	return newFlow(p, parent.Header, rt, features, legacyTxBaseGasPrice), nil
 }
 
 // Mock create a packing flow upon given parent, but with a designated timestamp.
@@ -166,7 +169,11 @@ func (p *Packer) Mock(parent *chain.BlockSummary, targetTime uint64, gasLimit ui
 		gl = p.gasLimit(parent.Header.GasLimit())
 	}
 
-	var baseFee *big.Int
+	var err error
+	var legacyTxBaseGasPrice, baseFee *big.Int
+	if legacyTxBaseGasPrice, err = builtin.Params.Native(state).Get(thor.KeyLegacyTxBaseGasPrice); err != nil {
+		return nil, err
+	}
 	if parent.Header.Number()+1 >= p.forkConfig.GALACTICA {
 		baseFee = fork.CalcBaseFee(&p.forkConfig, parent.Header)
 	}
@@ -185,7 +192,7 @@ func (p *Packer) Mock(parent *chain.BlockSummary, targetTime uint64, gasLimit ui
 		},
 		p.forkConfig)
 
-	return newFlow(p, parent.Header, rt, features), nil
+	return newFlow(p, parent.Header, rt, features, legacyTxBaseGasPrice), nil
 }
 
 func (p *Packer) gasLimit(parentGasLimit uint64) uint64 {

--- a/txpool/validation.go
+++ b/txpool/validation.go
@@ -57,7 +57,7 @@ func ValidateTransaction(tr *tx.Transaction, repo *chain.Repository, head *chain
 
 func ValidateTransactionWithState(tr *tx.Transaction, header *block.Header, forkConfig *thor.ForkConfig, state *state.State) error {
 	if header.Number() >= forkConfig.GALACTICA {
-		if err := fork.ValidateGalacticaTxFee(tr, state, header.BaseFee()); err != nil {
+		if err := fork.ValidateGalacticaTxFeeWithState(tr, state, header.BaseFee()); err != nil {
 			return txRejectedError{err.Error()}
 		}
 	}


### PR DESCRIPTION
# Description

This is a PR comes from https://github.com/vechain/thor/pull/1054
It reduces the number of state calls done to retrieve the `thor.KeyLegacyTxBaseGasPrice`. 
Instead of once per tx, it's now done once per flow/block.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
