### PR TITLE
Reduce allocations by using ForkConfig as a pointer

### DIFF
--- a/api/accounts/accounts.go
+++ b/api/accounts/accounts.go
@@ -30,7 +30,7 @@ type Accounts struct {
 	repo              *chain.Repository
 	stater            *state.Stater
 	callGasLimit      uint64
-	forkConfig        thor.ForkConfig
+	forkConfig        *thor.ForkConfig
 	bft               bft.Committer
 	enabledDeprecated bool
 }
@@ -39,7 +39,7 @@ func New(
 	repo *chain.Repository,
 	stater *state.Stater,
 	callGasLimit uint64,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 	bft bft.Committer,
 	enabledDeprecated bool,
 ) *Accounts {

--- a/api/accounts/accounts_test.go
+++ b/api/accounts/accounts_test.go
@@ -306,7 +306,7 @@ func initAccountServer(t *testing.T, enabledDeprecated bool) {
 	)
 
 	router := mux.NewRouter()
-	accounts.New(thorChain.Repo(), thorChain.Stater(), uint64(gasLimit), thor.NoFork, thorChain.Engine(), enabledDeprecated).
+	accounts.New(thorChain.Repo(), thorChain.Stater(), uint64(gasLimit), &thor.NoFork, thorChain.Engine(), enabledDeprecated).
 		Mount(router, "/accounts")
 
 	ts = httptest.NewServer(router)

--- a/api/api.go
+++ b/api/api.go
@@ -57,7 +57,7 @@ func New(
 	logDB *logdb.LogDB,
 	bft bft.Committer,
 	nw node.Network,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 	config Config,
 ) (http.HandlerFunc, func()) {
 	origins := strings.Split(strings.TrimSpace(config.AllowedOrigins), ",")

--- a/api/debug/debug.go
+++ b/api/debug/debug.go
@@ -40,7 +40,7 @@ const defaultMaxStorageResult = 1000
 type Debug struct {
 	repo              *chain.Repository
 	stater            *state.Stater
-	forkConfig        thor.ForkConfig
+	forkConfig        *thor.ForkConfig
 	callGasLimit      uint64
 	allowCustomTracer bool
 	bft               bft.Committer
@@ -51,7 +51,7 @@ type Debug struct {
 func New(
 	repo *chain.Repository,
 	stater *state.Stater,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 	callGaslimit uint64,
 	allowCustomTracer bool,
 	bft bft.Committer,

--- a/api/debug/debug_test.go
+++ b/api/debug/debug_test.go
@@ -567,10 +567,8 @@ func initDebugServer(t *testing.T) {
 	allBlocks, err := thorChain.GetAllBlocks()
 	require.NoError(t, err)
 	blk = allBlocks[1]
-
-	forkConfig := thor.GetForkConfig(blk.Header().ID())
 	router := mux.NewRouter()
-	debug = New(thorChain.Repo(), thorChain.Stater(), forkConfig, 21000, true, thorChain.Engine(), []string{"all"}, false)
+	debug = New(thorChain.Repo(), thorChain.Stater(), thorChain.GetForkConfig(), 21000, true, thorChain.Engine(), []string{"all"}, false)
 	debug.Mount(router, "/debug")
 	ts = httptest.NewServer(router)
 }

--- a/api/metrics_test.go
+++ b/api/metrics_test.go
@@ -48,7 +48,7 @@ func TestMetricsMiddleware(t *testing.T) {
 	assert.NotNil(t, err)
 
 	router := mux.NewRouter()
-	acc := accounts.New(thorChain.Repo(), thorChain.Stater(), math.MaxUint64, thor.NoFork, thorChain.Engine(), true)
+	acc := accounts.New(thorChain.Repo(), thorChain.Stater(), math.MaxUint64, &thor.NoFork, thorChain.Engine(), true)
 	acc.Mount(router, "/accounts")
 	router.PathPrefix("/metrics").Handler(metrics.HTTPHandler())
 	router.Use(metricsMiddleware)

--- a/api/subscriptions/pending_tx_test.go
+++ b/api/subscriptions/pending_tx_test.go
@@ -126,7 +126,7 @@ func TestPendingTx_DispatchLoop(t *testing.T) {
 }
 
 func addNewBlock(repo *chain.Repository, stater *state.Stater, b0 *block.Block, t *testing.T) {
-	packer := packer.New(repo, stater, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address, thor.NoFork)
+	packer := packer.New(repo, stater, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address, &thor.NoFork)
 	sum, _ := repo.GetBlockSummary(b0.Header().ID())
 	flow, err := packer.Schedule(sum, uint64(time.Now().Unix()))
 	if err != nil {

--- a/api/transactions/transactions_benchmark_test.go
+++ b/api/transactions/transactions_benchmark_test.go
@@ -322,7 +322,7 @@ func packTxsIntoBlock(thorChain *testchain.Chain, proposerAccount *genesis.DevAc
 }
 
 func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Chain, error) {
-	forkConfig := thor.NoFork
+	forkConfig := *thor.NoFork // value copy
 	forkConfig.VIP191 = 1
 	forkConfig.BLOCKLIST = 0
 	forkConfig.VIP214 = 2
@@ -393,7 +393,7 @@ func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Cha
 		stater,
 		geneBlk,
 		logDb,
-		thor.NoFork,
+		&forkConfig,
 	), nil
 }
 

--- a/api/transactions/transactions_benchmark_test.go
+++ b/api/transactions/transactions_benchmark_test.go
@@ -322,7 +322,7 @@ func packTxsIntoBlock(thorChain *testchain.Chain, proposerAccount *genesis.DevAc
 }
 
 func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Chain, error) {
-	forkConfig := *thor.NoFork // value copy
+	forkConfig := thor.NoFork
 	forkConfig.VIP191 = 1
 	forkConfig.BLOCKLIST = 0
 	forkConfig.VIP214 = 2

--- a/bft/engine.go
+++ b/bft/engine.go
@@ -41,7 +41,7 @@ type Engine struct {
 	repo       *chain.Repository
 	data       kv.Store
 	stater     *state.Stater
-	forkConfig thor.ForkConfig
+	forkConfig *thor.ForkConfig
 	master     thor.Address
 	casts      casts
 	finalized  atomic.Value
@@ -54,7 +54,7 @@ type Engine struct {
 }
 
 // NewEngine creates a new bft engine.
-func NewEngine(repo *chain.Repository, mainDB *muxdb.MuxDB, forkConfig thor.ForkConfig, master thor.Address) (*Engine, error) {
+func NewEngine(repo *chain.Repository, mainDB *muxdb.MuxDB, forkConfig *thor.ForkConfig, master thor.Address) (*Engine, error) {
 	engine := Engine{
 		repo:       repo,
 		data:       mainDB.NewStore(dataStoreName),

--- a/bft/engine_test.go
+++ b/bft/engine_test.go
@@ -31,7 +31,7 @@ const MaxBlockProposers = 11
 
 var (
 	devAccounts = genesis.DevAccounts()
-	defaultFC   = thor.NoFork
+	defaultFC   = &thor.NoFork
 )
 
 func init() {

--- a/bft/engine_test.go
+++ b/bft/engine_test.go
@@ -24,7 +24,7 @@ type TestBFT struct {
 	db     *muxdb.MuxDB
 	repo   *chain.Repository
 	stater *state.Stater
-	fc     thor.ForkConfig
+	fc     *thor.ForkConfig
 }
 
 const MaxBlockProposers = 11
@@ -38,7 +38,7 @@ func init() {
 	defaultFC.FINALITY = 0
 }
 
-func newTestBft(forkCfg thor.ForkConfig) (*TestBFT, error) {
+func newTestBft(forkCfg *thor.ForkConfig) (*TestBFT, error) {
 	db := muxdb.NewMem()
 
 	auth := make([]genesis.Authority, 0, len(devAccounts))
@@ -54,7 +54,7 @@ func newTestBft(forkCfg thor.ForkConfig) (*TestBFT, error) {
 		LaunchTime: 1526400000,
 		GasLimit:   thor.InitialGasLimit,
 		ExtraData:  "",
-		ForkConfig: &forkCfg,
+		ForkConfig: forkCfg,
 		Authority:  auth,
 		Params: genesis.Params{
 			MaxBlockProposers: &mbp,

--- a/builtin/executor_test.go
+++ b/builtin/executor_test.go
@@ -77,7 +77,7 @@ func initExectorTest() *ctest {
 	st := state.New(db, trie.Root{Hash: b0.Header().StateRoot()})
 	chain := repo.NewChain(b0.Header().ID())
 
-	rt := runtime.New(chain, st, &xenv.BlockContext{Time: uint64(time.Now().Unix())}, thor.NoFork)
+	rt := runtime.New(chain, st, &xenv.BlockContext{Time: uint64(time.Now().Unix())}, &thor.NoFork)
 
 	return &ctest{
 		rt:  rt,

--- a/builtin/native_calls_test.go
+++ b/builtin/native_calls_test.go
@@ -193,6 +193,7 @@ func buildGenesis(db *muxdb.MuxDB, proc func(state *state.State) error) *block.B
 	blk, _, _, _ := new(genesis.Builder).
 		Timestamp(uint64(time.Now().Unix())).
 		State(proc).
+		ForkConfig(thor.NoFork).
 		Build(state.NewStater(db))
 	return blk
 }

--- a/builtin/native_calls_test.go
+++ b/builtin/native_calls_test.go
@@ -193,7 +193,7 @@ func buildGenesis(db *muxdb.MuxDB, proc func(state *state.State) error) *block.B
 	blk, _, _, _ := new(genesis.Builder).
 		Timestamp(uint64(time.Now().Unix())).
 		State(proc).
-		ForkConfig(thor.NoFork).
+		ForkConfig(&thor.NoFork).
 		Build(state.NewStater(db))
 	return blk
 }
@@ -210,7 +210,7 @@ func TestParamsNative(t *testing.T) {
 	st := state.New(db, trie.Root{Hash: b0.Header().StateRoot()})
 	chain := repo.NewChain(b0.Header().ID())
 
-	rt := runtime.New(chain, st, &xenv.BlockContext{}, thor.NoFork)
+	rt := runtime.New(chain, st, &xenv.BlockContext{}, &thor.NoFork)
 
 	test := &ctest{
 		rt:  rt,
@@ -278,7 +278,7 @@ func TestAuthorityNative(t *testing.T) {
 	st := state.New(db, trie.Root{Hash: b0.Header().StateRoot()})
 	chain := repo.NewChain(b0.Header().ID())
 
-	rt := runtime.New(chain, st, &xenv.BlockContext{}, thor.NoFork)
+	rt := runtime.New(chain, st, &xenv.BlockContext{}, &thor.NoFork)
 
 	candidateEvent := func(nodeMaster thor.Address, action string) *tx.Event {
 		ev, _ := builtin.Authority.ABI.EventByName("Candidate")
@@ -406,7 +406,7 @@ func TestEnergyNative(t *testing.T) {
 		}
 	}
 
-	rt := runtime.New(chain, st, &xenv.BlockContext{Time: b0.Header().Timestamp()}, thor.NoFork)
+	rt := runtime.New(chain, st, &xenv.BlockContext{Time: b0.Header().Timestamp()}, &thor.NoFork)
 	test := &ctest{
 		rt:     rt,
 		abi:    builtin.Energy.ABI,
@@ -560,7 +560,7 @@ func TestPrototypeNative(t *testing.T) {
 	rt := runtime.New(chain, st, &xenv.BlockContext{
 		Time:   genesisBlock.Header().Timestamp(),
 		Number: genesisBlock.Header().Number(),
-	}, thor.NoFork)
+	}, &thor.NoFork)
 
 	code, _ := hex.DecodeString("60606040523415600e57600080fd5b603580601b6000396000f3006060604052600080fd00a165627a7a72305820edd8a93b651b5aac38098767f0537d9b25433278c9d155da2135efc06927fc960029")
 	exec, _ := rt.PrepareClause(tx.NewClause(nil).WithData(code), 0, math.MaxUint64, &xenv.TransactionContext{
@@ -805,7 +805,7 @@ func TestPrototypeNativeWithLongerBlockNumber(t *testing.T) {
 	rt := runtime.New(chain, st, &xenv.BlockContext{
 		Number: thor.MaxStateHistory + 1,
 		Time:   repo.BestBlockSummary().Header.Timestamp(),
-	}, thor.NoFork)
+	}, &thor.NoFork)
 
 	test := &ctest{
 		rt:     rt,
@@ -874,7 +874,7 @@ func TestPrototypeNativeWithBlockNumber(t *testing.T) {
 	rt := runtime.New(chain, st, &xenv.BlockContext{
 		Number: repo.BestBlockSummary().Header.Number(),
 		Time:   repo.BestBlockSummary().Header.Timestamp(),
-	}, thor.NoFork)
+	}, &thor.NoFork)
 
 	test := &ctest{
 		rt:     rt,
@@ -939,7 +939,7 @@ func TestExtensionNative(t *testing.T) {
 
 	chain := repo.NewChain(b2.Header().ID())
 
-	rt := runtime.New(chain, st, &xenv.BlockContext{Number: 2, Time: b2.Header().Timestamp(), TotalScore: b2.Header().TotalScore(), Signer: b2_singer}, thor.NoFork)
+	rt := runtime.New(chain, st, &xenv.BlockContext{Number: 2, Time: b2.Header().Timestamp(), TotalScore: b2.Header().TotalScore(), Signer: b2_singer}, &thor.NoFork)
 
 	test := &ctest{
 		rt:  rt,

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -340,7 +340,7 @@ func soloAction(ctx *cli.Context) error {
 
 	var (
 		gene       *genesis.Genesis
-		forkConfig thor.ForkConfig
+		forkConfig *thor.ForkConfig
 	)
 
 	flagGenesis := ctx.String(genesisFlag.Name)

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -346,7 +346,7 @@ func soloAction(ctx *cli.Context) error {
 	flagGenesis := ctx.String(genesisFlag.Name)
 	if flagGenesis == "" {
 		gene = genesis.NewDevnet()
-		forkConfig = thor.SoloFork
+		forkConfig = &thor.SoloFork
 	} else {
 		gene, forkConfig, err = parseGenesisFile(flagGenesis)
 		if err != nil {

--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -57,7 +57,7 @@ type Node struct {
 	comm           *comm.Communicator
 	targetGasLimit uint64
 	skipLogs       bool
-	forkConfig     thor.ForkConfig
+	forkConfig     *thor.ForkConfig
 
 	logDBFailed bool
 	bandwidth   bandwidth.Bandwidth
@@ -77,7 +77,7 @@ func New(
 	comm *comm.Communicator,
 	targetGasLimit uint64,
 	skipLogs bool,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 ) *Node {
 	return &Node{
 		packer:         packer.New(repo, stater, master.Address(), master.Beneficiary, forkConfig),

--- a/cmd/thor/node/node_benchmark_test.go
+++ b/cmd/thor/node/node_benchmark_test.go
@@ -351,7 +351,7 @@ func packTxsIntoBlock(thorChain *testchain.Chain, proposerAccount *genesis.DevAc
 }
 
 func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Chain, error) {
-	forkConfig := thor.NoFork
+	forkConfig := *thor.NoFork // value copy
 	forkConfig.VIP191 = 1
 	forkConfig.BLOCKLIST = 0
 	forkConfig.VIP214 = 2

--- a/cmd/thor/node/node_benchmark_test.go
+++ b/cmd/thor/node/node_benchmark_test.go
@@ -209,7 +209,7 @@ func benchmarkBlockProcess(b *testing.B, db *muxdb.MuxDB, accounts []genesis.Dev
 		nil,
 		10_000_000,
 		true,
-		thor.NoFork,
+		&thor.NoFork,
 	)
 
 	stats := &blockStats{}
@@ -351,7 +351,7 @@ func packTxsIntoBlock(thorChain *testchain.Chain, proposerAccount *genesis.DevAc
 }
 
 func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Chain, error) {
-	forkConfig := *thor.NoFork // value copy
+	forkConfig := &thor.NoFork // copy
 	forkConfig.VIP191 = 1
 	forkConfig.BLOCKLIST = 0
 	forkConfig.VIP214 = 2
@@ -382,7 +382,7 @@ func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Cha
 		LaunchTime: 1526400000,
 		GasLimit:   thor.InitialGasLimit,
 		ExtraData:  "",
-		ForkConfig: &forkConfig,
+		ForkConfig: forkConfig,
 		Authority:  authAccs,
 		Accounts:   stateAccs,
 		Params: genesis.Params{
@@ -422,7 +422,7 @@ func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Cha
 		stater,
 		geneBlk,
 		logDb,
-		thor.NoFork,
+		&thor.NoFork,
 	), nil
 }
 

--- a/cmd/thor/node/node_benchmark_test.go
+++ b/cmd/thor/node/node_benchmark_test.go
@@ -351,7 +351,7 @@ func packTxsIntoBlock(thorChain *testchain.Chain, proposerAccount *genesis.DevAc
 }
 
 func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Chain, error) {
-	forkConfig := &thor.NoFork // copy
+	forkConfig := thor.NoFork // copy
 	forkConfig.VIP191 = 1
 	forkConfig.BLOCKLIST = 0
 	forkConfig.VIP214 = 2
@@ -382,7 +382,7 @@ func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Cha
 		LaunchTime: 1526400000,
 		GasLimit:   thor.InitialGasLimit,
 		ExtraData:  "",
-		ForkConfig: forkConfig,
+		ForkConfig: &forkConfig,
 		Authority:  authAccs,
 		Accounts:   stateAccs,
 		Params: genesis.Params{
@@ -422,7 +422,7 @@ func createChain(db *muxdb.MuxDB, accounts []genesis.DevAccount) (*testchain.Cha
 		stater,
 		geneBlk,
 		logDb,
-		&thor.NoFork,
+		&forkConfig,
 	), nil
 }
 

--- a/cmd/thor/solo/solo.go
+++ b/cmd/thor/solo/solo.go
@@ -60,7 +60,7 @@ func New(
 	onDemand bool,
 	skipLogs bool,
 	blockInterval uint64,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 ) *Solo {
 	return &Solo{
 		repo:   repo,

--- a/cmd/thor/solo/solo_test.go
+++ b/cmd/thor/solo/solo_test.go
@@ -30,7 +30,7 @@ func newSolo() *Solo {
 	repo, _ := chain.NewRepository(db, b)
 	mempool := txpool.New(repo, stater, txpool.Options{Limit: 10000, LimitPerAccount: 16, MaxLifetime: 10 * time.Minute})
 
-	return New(repo, stater, logDb, mempool, 0, true, false, thor.BlockInterval, thor.ForkConfig{})
+	return New(repo, stater, logDb, mempool, 0, true, false, thor.BlockInterval, &thor.ForkConfig{})
 }
 
 func TestInitSolo(t *testing.T) {

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -272,7 +272,7 @@ func parseGenesisFile(uri string) (*genesis.Genesis, *thor.ForkConfig, error) {
 	decoder := json.NewDecoder(reader)
 	decoder.DisallowUnknownFields()
 
-	var forkConfig = thor.NoFork
+	var forkConfig = &thor.NoFork
 	var gen genesis.CustomGenesis
 	gen.ForkConfig = forkConfig
 

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -272,9 +272,9 @@ func parseGenesisFile(uri string) (*genesis.Genesis, *thor.ForkConfig, error) {
 	decoder := json.NewDecoder(reader)
 	decoder.DisallowUnknownFields()
 
-	var forkConfig = &thor.NoFork
+	var forkConfig = thor.NoFork
 	var gen genesis.CustomGenesis
-	gen.ForkConfig = forkConfig
+	gen.ForkConfig = &forkConfig
 
 	if err := decoder.Decode(&gen); err != nil {
 		return nil, nil, errors.Wrap(err, "decode genesis file")
@@ -285,7 +285,7 @@ func parseGenesisFile(uri string) (*genesis.Genesis, *thor.ForkConfig, error) {
 		return nil, nil, errors.Wrap(err, "build genesis")
 	}
 
-	return customGen, forkConfig, nil
+	return customGen, &forkConfig, nil
 }
 
 func makeAPIConfig(ctx *cli.Context, logAPIRequests *atomic.Bool, soloMode bool) api.Config {

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -231,11 +231,11 @@ func readPasswordFromNewTTY(prompt string) (string, error) {
 	return pass, err
 }
 
-func selectGenesis(ctx *cli.Context) (*genesis.Genesis, thor.ForkConfig, error) {
+func selectGenesis(ctx *cli.Context) (*genesis.Genesis, *thor.ForkConfig, error) {
 	network := ctx.String(networkFlag.Name)
 	if network == "" {
 		_ = cli.ShowAppHelp(ctx)
-		return nil, thor.ForkConfig{}, errors.New("network flag not specified")
+		return nil, nil, errors.New("network flag not specified")
 	}
 
 	switch network {
@@ -250,7 +250,7 @@ func selectGenesis(ctx *cli.Context) (*genesis.Genesis, thor.ForkConfig, error) 
 	}
 }
 
-func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
+func parseGenesisFile(uri string) (*genesis.Genesis, *thor.ForkConfig, error) {
 	var (
 		reader io.ReadCloser
 		err    error
@@ -258,13 +258,13 @@ func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
 	if strings.HasPrefix(uri, "http://") || strings.HasPrefix(uri, "https://") {
 		res, err := http.Get(uri) // #nosec
 		if err != nil {
-			return nil, thor.ForkConfig{}, errors.Wrap(err, "http get genesis file")
+			return nil, nil, errors.Wrap(err, "http get genesis file")
 		}
 		reader = res.Body
 	} else {
 		reader, err = os.Open(uri)
 		if err != nil {
-			return nil, thor.ForkConfig{}, errors.Wrap(err, "open genesis file")
+			return nil, nil, errors.Wrap(err, "open genesis file")
 		}
 	}
 	defer reader.Close()
@@ -274,15 +274,15 @@ func parseGenesisFile(uri string) (*genesis.Genesis, thor.ForkConfig, error) {
 
 	var forkConfig = thor.NoFork
 	var gen genesis.CustomGenesis
-	gen.ForkConfig = &forkConfig
+	gen.ForkConfig = forkConfig
 
 	if err := decoder.Decode(&gen); err != nil {
-		return nil, thor.ForkConfig{}, errors.Wrap(err, "decode genesis file")
+		return nil, nil, errors.Wrap(err, "decode genesis file")
 	}
 
 	customGen, err := genesis.NewCustomNet(&gen)
 	if err != nil {
-		return nil, thor.ForkConfig{}, errors.Wrap(err, "build genesis")
+		return nil, nil, errors.Wrap(err, "build genesis")
 	}
 
 	return customGen, forkConfig, nil
@@ -599,7 +599,7 @@ func printStartupMessage1(
 	repo *chain.Repository,
 	master *node.Master,
 	dataDir string,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 ) {
 	bestBlock := repo.BestBlockSummary()
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -27,13 +27,13 @@ type Consensus struct {
 	repo                 *chain.Repository
 	stater               *state.Stater
 	seeder               *poa.Seeder
-	forkConfig           thor.ForkConfig
+	forkConfig           *thor.ForkConfig
 	correctReceiptsRoots map[string]string
 	candidatesCache      *simplelru.LRU
 }
 
 // New create a Consensus instance.
-func New(repo *chain.Repository, stater *state.Stater, forkConfig thor.ForkConfig) *Consensus {
+func New(repo *chain.Repository, stater *state.Stater, forkConfig *thor.ForkConfig) *Consensus {
 	candidatesCache, _ := simplelru.NewLRU(16, nil)
 	return &Consensus{
 		repo:                 repo,

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -50,7 +50,7 @@ type testConsensus struct {
 	pk         *ecdsa.PrivateKey
 	parent     *block.Block
 	original   *block.Block
-	forkConfig thor.ForkConfig
+	forkConfig *thor.ForkConfig
 	tag        byte
 }
 
@@ -61,6 +61,7 @@ func newTestConsensus() (*testConsensus, error) {
 	gen := new(genesis.Builder).
 		GasLimit(thor.InitialGasLimit).
 		Timestamp(launchTime).
+		ForkConfig(thor.NoFork).
 		State(func(state *state.State) error {
 			bal, _ := new(big.Int).SetString("1000000000000000000000000000", 10)
 			state.SetCode(builtin.Authority.Address, builtin.Authority.RuntimeBytecodes())
@@ -229,7 +230,7 @@ func TestNewConsensus(t *testing.T) {
 	// Mock dependencies
 	mockRepo := &chain.Repository{}
 	mockStater := &state.Stater{}
-	mockForkConfig := thor.ForkConfig{}
+	mockForkConfig := &thor.ForkConfig{}
 
 	// Create a new consensus instance
 	consensus := New(mockRepo, mockStater, mockForkConfig)
@@ -721,7 +722,7 @@ func TestValidateBlockBody(t *testing.T) {
 					Expiration(100).
 					Clause(tx.NewClause(&thor.Address{}).WithValue(big.NewInt(0)).WithData(nil)).
 					Nonce(0).
-					ChainTag(30)
+					ChainTag(96)
 
 				tx := txSign(txBuilder)
 

--- a/consensus/consensus_test.go
+++ b/consensus/consensus_test.go
@@ -61,7 +61,7 @@ func newTestConsensus() (*testConsensus, error) {
 	gen := new(genesis.Builder).
 		GasLimit(thor.InitialGasLimit).
 		Timestamp(launchTime).
-		ForkConfig(thor.NoFork).
+		ForkConfig(&thor.NoFork).
 		State(func(state *state.State) error {
 			bal, _ := new(big.Int).SetString("1000000000000000000000000000", 10)
 			state.SetCode(builtin.Authority.Address, builtin.Authority.RuntimeBytecodes())
@@ -91,7 +91,7 @@ func newTestConsensus() (*testConsensus, error) {
 	forkConfig.VIP214 = 2
 
 	proposer := genesis.DevAccounts()[0]
-	p := packer.New(repo, stater, proposer.Address, &proposer.Address, forkConfig)
+	p := packer.New(repo, stater, proposer.Address, &proposer.Address, &forkConfig)
 	parentSum, _ := repo.GetBlockSummary(parent.Header().ID())
 	flow, err := p.Schedule(parentSum, parent.Header().Timestamp()+100*thor.BlockInterval)
 	if err != nil {
@@ -113,7 +113,7 @@ func newTestConsensus() (*testConsensus, error) {
 		return nil, err
 	}
 
-	con := New(repo, stater, forkConfig)
+	con := New(repo, stater, &forkConfig)
 
 	if _, _, err := con.Process(parentSum, b1, flow.When(), 0); err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func newTestConsensus() (*testConsensus, error) {
 	}
 
 	proposer2 := genesis.DevAccounts()[1]
-	p2 := packer.New(repo, stater, proposer2.Address, &proposer2.Address, forkConfig)
+	p2 := packer.New(repo, stater, proposer2.Address, &proposer2.Address, &forkConfig)
 	b1sum, _ := repo.GetBlockSummary(b1.Header().ID())
 	flow2, err := p2.Schedule(b1sum, b1.Header().Timestamp()+100*thor.BlockInterval)
 	if err != nil {
@@ -150,7 +150,7 @@ func newTestConsensus() (*testConsensus, error) {
 		pk:         proposer.PrivateKey,
 		parent:     b1,
 		original:   b2,
-		forkConfig: forkConfig,
+		forkConfig: &forkConfig,
 		tag:        repo.ChainTag(),
 	}, nil
 }

--- a/genesis/builder.go
+++ b/genesis/builder.go
@@ -28,7 +28,7 @@ type Builder struct {
 	calls      []call
 	extraData  [28]byte
 
-	forkConfig thor.ForkConfig
+	forkConfig *thor.ForkConfig
 }
 
 type call struct {
@@ -67,7 +67,7 @@ func (b *Builder) ExtraData(data [28]byte) *Builder {
 }
 
 // ForkConfig set fork config.
-func (b *Builder) ForkConfig(fc thor.ForkConfig) *Builder {
+func (b *Builder) ForkConfig(fc *thor.ForkConfig) *Builder {
 	b.forkConfig = fc
 	return b
 }

--- a/genesis/customnet.go
+++ b/genesis/customnet.go
@@ -48,7 +48,7 @@ func NewCustomNet(gen *CustomGenesis) (*Genesis, error) {
 	builder := new(Builder).
 		Timestamp(launchTime).
 		GasLimit(gen.GasLimit).
-		ForkConfig(*gen.ForkConfig).
+		ForkConfig(gen.ForkConfig).
 		State(func(state *state.State) error {
 			// alloc builtin contracts
 			if err := state.SetCode(builtin.Authority.Address, builtin.Authority.RuntimeBytecodes()); err != nil {

--- a/genesis/devnet.go
+++ b/genesis/devnet.go
@@ -61,12 +61,12 @@ func NewDevnet() *Genesis {
 	return NewDevnetWithConfig(thor.SoloFork)
 }
 
-func NewDevnetWithConfig(config thor.ForkConfig) *Genesis {
+func NewDevnetWithConfig(config *thor.ForkConfig) *Genesis {
 	launchTime := uint64(1526400000) // 'Wed May 16 2018 00:00:00 GMT+0800 (CST)'
 	return NewDevnetWithConfigAndLaunchtime(config, launchTime)
 }
 
-func NewDevnetWithConfigAndLaunchtime(config thor.ForkConfig, launchTime uint64) *Genesis {
+func NewDevnetWithConfigAndLaunchtime(config *thor.ForkConfig, launchTime uint64) *Genesis {
 	executor := DevAccounts()[0].Address
 	soloBlockSigner := DevAccounts()[0]
 

--- a/genesis/devnet.go
+++ b/genesis/devnet.go
@@ -58,7 +58,7 @@ func DevAccounts() []DevAccount {
 
 // NewDevnet create genesis for solo mode.
 func NewDevnet() *Genesis {
-	return NewDevnetWithConfig(thor.SoloFork)
+	return NewDevnetWithConfig(&thor.SoloFork)
 }
 
 func NewDevnetWithConfig(config *thor.ForkConfig) *Genesis {

--- a/genesis/mainnet.go
+++ b/genesis/mainnet.go
@@ -23,7 +23,7 @@ func NewMainnet() *Genesis {
 	builder := new(Builder).
 		Timestamp(launchTime).
 		GasLimit(thor.InitialGasLimit).
-		ForkConfig(thor.NoFork).
+		ForkConfig(&thor.NoFork).
 		State(func(state *state.State) error {
 			// alloc builtin contracts
 			if err := state.SetCode(builtin.Authority.Address, builtin.Authority.RuntimeBytecodes()); err != nil {

--- a/genesis/testnet.go
+++ b/genesis/testnet.go
@@ -28,7 +28,7 @@ func NewTestnet() *Genesis {
 	builder := new(Builder).
 		Timestamp(launchTime).
 		GasLimit(thor.InitialGasLimit).
-		ForkConfig(thor.NoFork).
+		ForkConfig(&thor.NoFork).
 		State(func(state *state.State) error {
 			tokenSupply := new(big.Int)
 

--- a/packer/flow_test.go
+++ b/packer/flow_test.go
@@ -55,7 +55,7 @@ func TestAdopt(t *testing.T) {
 	clause := tx.NewClause(&addr).WithValue(big.NewInt(10000))
 
 	// Create and adopt two transactions
-	pkr := packer.New(repo, stater, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address, thor.NoFork)
+	pkr := packer.New(repo, stater, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address, &thor.NoFork)
 	sum, err := repo.GetBlockSummary(b.Header().ID())
 	if err != nil {
 		t.Fatal("Error getting block summary:", err)
@@ -110,7 +110,7 @@ func TestPack(t *testing.T) {
 	forkConfig.FINALITY = 0
 
 	proposer := genesis.DevAccounts()[0]
-	p := packer.New(repo, stater, proposer.Address, &proposer.Address, forkConfig)
+	p := packer.New(repo, stater, proposer.Address, &proposer.Address, &forkConfig)
 	parentSum, _ := repo.GetBlockSummary(parent.Header().ID())
 	flow, _ := p.Schedule(parentSum, parent.Header().Timestamp()+100*thor.BlockInterval)
 
@@ -133,7 +133,7 @@ func TestAdoptErr(t *testing.T) {
 	g := new(genesis.Builder).
 		GasLimit(0).
 		Timestamp(launchTime).
-		ForkConfig(thor.NoFork).
+		ForkConfig(&thor.NoFork).
 		State(func(state *state.State) error {
 			bal, _ := new(big.Int).SetString("1000000000000000000000000000", 10)
 			state.SetCode(builtin.Authority.Address, builtin.Authority.RuntimeBytecodes())

--- a/packer/flow_test.go
+++ b/packer/flow_test.go
@@ -133,6 +133,7 @@ func TestAdoptErr(t *testing.T) {
 	g := new(genesis.Builder).
 		GasLimit(0).
 		Timestamp(launchTime).
+		ForkConfig(thor.NoFork).
 		State(func(state *state.State) error {
 			bal, _ := new(big.Int).SetString("1000000000000000000000000000", 10)
 			state.SetCode(builtin.Authority.Address, builtin.Authority.RuntimeBytecodes())

--- a/packer/flow_test.go
+++ b/packer/flow_test.go
@@ -155,7 +155,7 @@ func TestAdoptErr(t *testing.T) {
 	addr := thor.BytesToAddress([]byte("to"))
 	clause := tx.NewClause(&addr).WithValue(big.NewInt(10000))
 
-	pkr := packer.New(repo, stater, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address, thor.SoloFork)
+	pkr := packer.New(repo, stater, genesis.DevAccounts()[0].Address, &genesis.DevAccounts()[0].Address, &thor.SoloFork)
 	sum, _ := repo.GetBlockSummary(b.Header().ID())
 
 	flow, _ := pkr.Schedule(sum, uint64(time.Now().Unix()))

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -24,7 +24,7 @@ type Packer struct {
 	nodeMaster     thor.Address
 	beneficiary    *thor.Address
 	targetGasLimit uint64
-	forkConfig     thor.ForkConfig
+	forkConfig     *thor.ForkConfig
 	seeder         *poa.Seeder
 }
 
@@ -35,7 +35,7 @@ func New(
 	stater *state.Stater,
 	nodeMaster thor.Address,
 	beneficiary *thor.Address,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 ) *Packer {
 	return &Packer{
 		repo,

--- a/packer/packer_test.go
+++ b/packer/packer_test.go
@@ -85,7 +85,7 @@ func TestP(t *testing.T) {
 
 	for {
 		best := repo.BestBlockSummary()
-		p := packer.New(repo, stater, a1.Address, &a1.Address, thor.NoFork)
+		p := packer.New(repo, stater, a1.Address, &a1.Address, &thor.NoFork)
 		flow, err := p.Schedule(best, uint64(time.Now().Unix()))
 		if err != nil {
 			t.Fatal(err)
@@ -99,7 +99,7 @@ func TestP(t *testing.T) {
 		blk, stage, receipts, _ := flow.Pack(genesis.DevAccounts()[0].PrivateKey, 0, false)
 		root, _ := stage.Commit()
 		assert.Equal(t, root, blk.Header().StateRoot())
-		_, _, err = consensus.New(repo, stater, thor.NoFork).Process(best, blk, uint64(time.Now().Unix()*2), 0)
+		_, _, err = consensus.New(repo, stater, &thor.NoFork).Process(best, blk, uint64(time.Now().Unix()*2), 0)
 		assert.Nil(t, err)
 
 		if err := repo.AddBlock(blk, receipts, 0, true); err != nil {
@@ -126,7 +126,7 @@ func TestForkVIP191(t *testing.T) {
 	b0, _, _, err := new(genesis.Builder).
 		GasLimit(thor.InitialGasLimit).
 		Timestamp(launchTime).
-		ForkConfig(thor.NoFork).
+		ForkConfig(&thor.NoFork).
 		State(func(state *state.State) error {
 			// setup builtin contracts
 			state.SetCode(builtin.Authority.Address, builtin.Authority.RuntimeBytecodes())
@@ -151,7 +151,7 @@ func TestForkVIP191(t *testing.T) {
 	fc.VIP191 = 1
 
 	best := repo.BestBlockSummary()
-	p := packer.New(repo, stater, a1.Address, &a1.Address, fc)
+	p := packer.New(repo, stater, a1.Address, &a1.Address, &fc)
 	flow, err := p.Schedule(best, uint64(time.Now().Unix()))
 	if err != nil {
 		t.Fatal(err)
@@ -161,7 +161,7 @@ func TestForkVIP191(t *testing.T) {
 	root, _ := stage.Commit()
 	assert.Equal(t, root, blk.Header().StateRoot())
 
-	_, _, err = consensus.New(repo, stater, fc).Process(best, blk, uint64(time.Now().Unix()*2), 0)
+	_, _, err = consensus.New(repo, stater, &fc).Process(best, blk, uint64(time.Now().Unix()*2), 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,7 +237,7 @@ func TestMock(t *testing.T) {
 
 	a0 := genesis.DevAccounts()[0]
 
-	p := packer.New(repo, stater, a0.Address, &a0.Address, thor.NoFork)
+	p := packer.New(repo, stater, a0.Address, &a0.Address, &thor.NoFork)
 
 	best := repo.BestBlockSummary()
 
@@ -264,7 +264,7 @@ func TestSetGasLimit(t *testing.T) {
 
 	a0 := genesis.DevAccounts()[0]
 
-	p := packer.New(repo, stater, a0.Address, &a0.Address, thor.NoFork)
+	p := packer.New(repo, stater, a0.Address, &a0.Address, &thor.NoFork)
 
 	// This is just for code coverage purposes. There is no getter function for targetGasLimit to test the function.
 	p.SetTargetGasLimit(0xFFFF)

--- a/packer/packer_test.go
+++ b/packer/packer_test.go
@@ -192,7 +192,7 @@ func TestBlocklist(t *testing.T) {
 
 	stater := state.NewStater(db)
 
-	forkConfig := thor.ForkConfig{
+	forkConfig := &thor.ForkConfig{
 		VIP191:    math.MaxUint32,
 		ETH_CONST: math.MaxUint32,
 		BLOCKLIST: 0,

--- a/runtime/native_return_gas_test.go
+++ b/runtime/native_return_gas_test.go
@@ -28,7 +28,7 @@ func TestNativeCallReturnGas(t *testing.T) {
 	outer, _ := builtin.Measure.ABI.MethodByName("outer")
 	outerData, _ := outer.EncodeInput()
 
-	exec, _ := New(nil, state, &xenv.BlockContext{}, thor.NoFork).PrepareClause(
+	exec, _ := New(nil, state, &xenv.BlockContext{}, &thor.NoFork).PrepareClause(
 		tx.NewClause(&builtin.Measure.Address).WithData(innerData),
 		0,
 		math.MaxUint64,
@@ -38,7 +38,7 @@ func TestNativeCallReturnGas(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, innerOutput.VMErr)
 
-	exec, _ = New(nil, state, &xenv.BlockContext{}, thor.NoFork).PrepareClause(
+	exec, _ = New(nil, state, &xenv.BlockContext{}, &thor.NoFork).PrepareClause(
 		tx.NewClause(&builtin.Measure.Address).WithData(outerData),
 		0,
 		math.MaxUint64,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -93,7 +93,7 @@ func New(
 	chain *chain.Chain,
 	state *state.State,
 	ctx *xenv.BlockContext,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 ) *Runtime {
 	currentChainConfig := baseChainConfig
 	currentChainConfig.ConstantinopleBlock = big.NewInt(int64(forkConfig.ETH_CONST))

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -75,7 +75,7 @@ func TestContractSuicide(t *testing.T) {
 	}
 
 	origin := genesis.DevAccounts()[0].Address
-	exec, _ := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{Time: time}, thor.NoFork).
+	exec, _ := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{Time: time}, &thor.NoFork).
 		PrepareClause(tx.NewClause(&addr).WithData(methodData), 0, math.MaxUint64, &xenv.TransactionContext{Origin: origin})
 	out, _, err := exec()
 	assert.Nil(t, err)
@@ -352,7 +352,7 @@ func TestCall(t *testing.T) {
 
 	state := state.New(db, trie.Root{Hash: b0.Header().StateRoot()})
 
-	rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, thor.NoFork)
+	rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, &thor.NoFork)
 
 	method, _ := builtin.Params.ABI.MethodByName("executor")
 	data, err := method.EncodeInput()
@@ -440,7 +440,7 @@ func TestGetValues(t *testing.T) {
 	repo, _ := chain.NewRepository(db, b0)
 
 	state := state.New(db, trie.Root{Hash: b0.Header().StateRoot()})
-	rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, thor.NoFork)
+	rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, &thor.NoFork)
 
 	runtimeChain := rt.Chain()
 	runtimeState := rt.State()
@@ -470,7 +470,7 @@ func TestExecuteTransaction(t *testing.T) {
 
 	tx := GetMockTx(repo, t)
 
-	rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, thor.NoFork)
+	rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, &thor.NoFork)
 
 	receipt, err := rt.ExecuteTransaction(&tx)
 	if err != nil {
@@ -498,7 +498,7 @@ func TestExecuteTransactionFailure(t *testing.T) {
 
 	tx := GetMockFailedTx()
 
-	rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, thor.NoFork)
+	rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, &thor.NoFork)
 
 	_, err = rt.ExecuteTransaction(&tx)
 

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -149,7 +149,7 @@ func TestChainID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exec, _ := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, thor.ForkConfig{ETH_IST: 0}).
+	exec, _ := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, &thor.ForkConfig{ETH_IST: 0}).
 		PrepareClause(tx.NewClause(&addr).WithData(methodData), 0, math.MaxUint64, &xenv.TransactionContext{})
 	out, _, err := exec()
 	assert.Nil(t, err)
@@ -203,7 +203,7 @@ func TestSelfBalance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exec, _ := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, thor.ForkConfig{ETH_IST: 0}).
+	exec, _ := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, &thor.ForkConfig{ETH_IST: 0}).
 		PrepareClause(tx.NewClause(&addr).WithData(methodData), 0, math.MaxUint64, &xenv.TransactionContext{})
 	out, _, err := exec()
 	assert.Nil(t, err)
@@ -328,7 +328,7 @@ func TestBlake2(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exec, _ := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, thor.ForkConfig{ETH_IST: 0}).
+	exec, _ := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{}, &thor.ForkConfig{ETH_IST: 0}).
 		PrepareClause(tx.NewClause(&addr).WithData(methodData), 0, math.MaxUint64, &xenv.TransactionContext{})
 	out, _, err := exec()
 	assert.Nil(t, err)

--- a/test/testchain/chain.go
+++ b/test/testchain/chain.go
@@ -37,7 +37,7 @@ type Chain struct {
 	stater       *state.Stater
 	genesisBlock *block.Block
 	logDB        *logdb.LogDB
-	forkConfig   thor.ForkConfig
+	forkConfig   *thor.ForkConfig
 }
 
 func New(
@@ -48,7 +48,7 @@ func New(
 	stater *state.Stater,
 	genesisBlock *block.Block,
 	logDB *logdb.LogDB,
-	forkConfig thor.ForkConfig,
+	forkConfig *thor.ForkConfig,
 ) *Chain {
 	return &Chain{
 		db:           db,
@@ -238,7 +238,7 @@ func (c *Chain) BestBlock() (*block.Block, error) {
 }
 
 // GetForkConfig returns the current fork configuration based on the ID of the genesis block.
-func (c *Chain) GetForkConfig() thor.ForkConfig {
+func (c *Chain) GetForkConfig() *thor.ForkConfig {
 	return c.forkConfig
 }
 

--- a/test/testchain/chain.go
+++ b/test/testchain/chain.go
@@ -73,7 +73,7 @@ func NewIntegrationTestChain() (*Chain, error) {
 	stater := state.NewStater(db)
 
 	// Initialize the genesis and retrieve the genesis block
-	gene := genesis.NewDevnetWithConfigAndLaunchtime(forkConfig, uint64(time.Now().Unix()))
+	gene := genesis.NewDevnetWithConfigAndLaunchtime(&forkConfig, uint64(time.Now().Unix()))
 	geneBlk, _, _, err := gene.Build(stater)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ func NewIntegrationTestChain() (*Chain, error) {
 		stater,
 		geneBlk,
 		logDb,
-		forkConfig,
+		&forkConfig,
 	), nil
 }
 

--- a/thor/fork_config.go
+++ b/thor/fork_config.go
@@ -41,7 +41,7 @@ func (fc ForkConfig) String() string {
 }
 
 // NoFork a special config without any forks.
-var NoFork = ForkConfig{
+var NoFork = &ForkConfig{
 	VIP191:    math.MaxUint32,
 	ETH_CONST: math.MaxUint32,
 	BLOCKLIST: math.MaxUint32,
@@ -52,7 +52,7 @@ var NoFork = ForkConfig{
 
 // SoloFork is used to retain the solo genesis ID.
 // Any forks that modify the chain state should be placed in block 1.
-var SoloFork = ForkConfig{
+var SoloFork = &ForkConfig{
 	VIP191:    0,
 	ETH_CONST: 0,
 	BLOCKLIST: 0,
@@ -62,7 +62,7 @@ var SoloFork = ForkConfig{
 }
 
 // for well-known networks
-var forkConfigs = map[Bytes32]ForkConfig{
+var forkConfigs = map[Bytes32]*ForkConfig{
 	// mainnet
 	MustParseBytes32("0x00000000851caf3cfdb6e899cf5958bfb1ac3413d346d43539627e6be7ec1b4a"): {
 		VIP191:    3337300,
@@ -84,6 +84,6 @@ var forkConfigs = map[Bytes32]ForkConfig{
 }
 
 // GetForkConfig get fork config for given genesis ID.
-func GetForkConfig(genesisID Bytes32) ForkConfig {
+func GetForkConfig(genesisID Bytes32) *ForkConfig {
 	return forkConfigs[genesisID]
 }

--- a/thor/fork_config.go
+++ b/thor/fork_config.go
@@ -41,7 +41,7 @@ func (fc ForkConfig) String() string {
 }
 
 // NoFork a special config without any forks.
-var NoFork = &ForkConfig{
+var NoFork = ForkConfig{
 	VIP191:    math.MaxUint32,
 	ETH_CONST: math.MaxUint32,
 	BLOCKLIST: math.MaxUint32,

--- a/thor/fork_config.go
+++ b/thor/fork_config.go
@@ -52,7 +52,7 @@ var NoFork = ForkConfig{
 
 // SoloFork is used to retain the solo genesis ID.
 // Any forks that modify the chain state should be placed in block 1.
-var SoloFork = &ForkConfig{
+var SoloFork = ForkConfig{
 	VIP191:    0,
 	ETH_CONST: 0,
 	BLOCKLIST: 0,

--- a/thor/fork_config_test.go
+++ b/thor/fork_config_test.go
@@ -52,7 +52,7 @@ func TestGetForkConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		config := GetForkConfig(tt.id)
-		if (config != ForkConfig{}) != tt.expectFound {
+		if (config != nil) != tt.expectFound {
 			t.Errorf("GetForkConfig(%v) found = %v, want %v", tt.id, !tt.expectFound, tt.expectFound)
 		}
 	}

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -56,7 +56,7 @@ func initAPIServer(t *testing.T) (*testchain.Chain, *httptest.Server) {
 
 	router := mux.NewRouter()
 
-	accounts.New(thorChain.Repo(), thorChain.Stater(), uint64(gasLimit), thor.NoFork, thorChain.Engine(), true).
+	accounts.New(thorChain.Repo(), thorChain.Stater(), uint64(gasLimit), &thor.NoFork, thorChain.Engine(), true).
 		Mount(router, "/accounts")
 
 	mempool := txpool.New(thorChain.Repo(), thorChain.Stater(), txpool.Options{Limit: 10000, LimitPerAccount: 16, MaxLifetime: 10 * time.Minute})

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -55,7 +55,7 @@ func newPoolWithMaxLifetime(limit int, limitPerAccount int, BlocklistCacheFilePa
 	gene := new(genesis.Builder).
 		GasLimit(thor.InitialGasLimit).
 		Timestamp(timestamp).
-		ForkConfig(thor.NoFork).
+		ForkConfig(&thor.NoFork).
 		State(func(state *state.State) error {
 			bal, _ := new(big.Int).SetString("1000000000000000000000000000", 10)
 			for _, acc := range devAccounts {
@@ -679,7 +679,7 @@ func TestAddOverPendingCost(t *testing.T) {
 	db := muxdb.NewMem()
 	builder := new(genesis.Builder).
 		GasLimit(thor.InitialGasLimit).
-		ForkConfig(thor.NoFork).
+		ForkConfig(&thor.NoFork).
 		Timestamp(now).
 		State(func(state *state.State) error {
 			if err := state.SetCode(builtin.Params.Address, builtin.Params.RuntimeBytecodes()); err != nil {

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -55,6 +55,7 @@ func newPoolWithMaxLifetime(limit int, limitPerAccount int, BlocklistCacheFilePa
 	gene := new(genesis.Builder).
 		GasLimit(thor.InitialGasLimit).
 		Timestamp(timestamp).
+		ForkConfig(thor.NoFork).
 		State(func(state *state.State) error {
 			bal, _ := new(big.Int).SetString("1000000000000000000000000000", 10)
 			for _, acc := range devAccounts {
@@ -678,6 +679,7 @@ func TestAddOverPendingCost(t *testing.T) {
 	db := muxdb.NewMem()
 	builder := new(genesis.Builder).
 		GasLimit(thor.InitialGasLimit).
+		ForkConfig(thor.NoFork).
 		Timestamp(now).
 		State(func(state *state.State) error {
 			if err := state.SetCode(builtin.Params.Address, builtin.Params.RuntimeBytecodes()); err != nil {


### PR DESCRIPTION
# Description

Inspired from https://github.com/vechain/thor/pull/1054 
Reduces the allocations by having the `thor.ForkConfig` be passed around and used as a pointer instead of a value.


## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
