### PR TITLE
Adding a git hook that prevents pks from being committed

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Scan only staged changes for any 64-character hex strings (Ethereum private keys).
+# Override with: git commit --safe-to-ignore-key
+
+# 1) detect override flag on parent `git commit`
+if [ -r "/proc/$PPID/cmdline" ]; then
+  parent_cmd=$(tr '\0' ' ' </proc/$PPID/cmdline)
+else
+  parent_cmd=$(ps -o args= -p "$PPID" 2>/dev/null)
+fi
+if [[ "$parent_cmd" == *"--safe-to-ignore-key"* ]]; then
+  exit 0
+fi
+
+# 2) scan only added (+) or modified (-) lines (not the diff headers)
+#    and look for any 64-hex-char run
+if git diff --cached --diff-filter=AM -U0 | \
+     grep -E --color=never '^(\+[^\+]|-[^-]).*[0-9A-Fa-f]{64}'; then
+  echo
+  echo "✖ ERROR: Detected Ethereum private key in staged changes. Commit aborted."
+  echo
+  exit 1
+fi
+
+exit 0

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -18,7 +18,7 @@ fi
 if git diff --cached --diff-filter=AM -U0 | \
      grep -E --color=never '^(\+[^\+]|-[^-]).*[0-9A-Fa-f]{64}'; then
   echo
-  echo "✖ ERROR: Detected Ethereum private key in staged changes. Commit aborted."
+  echo "✖ ERROR: Detected ECDSA private key in staged changes. Commit aborted."
   echo
   exit 1
 fi

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MINOR = $(shell go version | cut -d' ' -f3 | cut -b 3- | cut -d. -f2)
 export GO111MODULE=on
 
 .DEFAULT_GOAL := thor
-.PHONY: thor disco all clean test
+.PHONY: thor disco all clean test install-hooks
 
 help:
 	@egrep -h '\s#@\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?#@ "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'
@@ -75,6 +75,13 @@ license-check: #@ Check license headers
 	@FILE_COUNT=$$(find . -type f -name '*.go' | wc -l); \
 	echo "Checking license headers for all .go... $$FILE_COUNT files found"; \
 	docker run -it --rm -v $$(pwd):/github/workspace apache/skywalking-eyes header check
+
+install-hooks: #@ Install Git pre-commit hook
+	@echo "▶ Installing Git hooks…"
+	@mkdir -p .git/hooks
+	@ln -sf $(CURDIR)/.git-hooks/pre-commit .git/hooks/pre-commit
+	@chmod +x .git-hooks/pre-commit .git/hooks/pre-commit
+	@echo "✅ Installed .git-hooks/pre-commit → .git/hooks/pre-commit"
 
 .DEFAULT:
 	@$(MAKE) help


### PR DESCRIPTION
# Description

This PR adds a hook to git that prevents the commit of pks.
- Adds a `make install-hooks` step to the Makefile
- Registers the .git-hooks/precomit to the .git config
- Everytime a pk gets committed it fails to commit
- If the pks are correctly committed `git commit --safe-to-ignore-key` should be used to bypass the check


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
