### PR TITLE
move tx basic checks into runtime for re-use

### DIFF
--- a/runtime/resolved_tx.go
+++ b/runtime/resolved_tx.go
@@ -8,7 +8,6 @@ package runtime
 import (
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/pkg/errors"
 	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/consensus/fork"
@@ -28,24 +27,24 @@ type ResolvedTransaction struct {
 }
 
 // ResolveTransaction resolves the transaction and performs basic validation.
-func ResolveTransaction(tx *tx.Transaction) (*ResolvedTransaction, error) {
-	origin, err := tx.Origin()
+func ResolveTransaction(trx *tx.Transaction) (*ResolvedTransaction, error) {
+	origin, err := trx.Origin()
 	if err != nil {
 		return nil, err
 	}
-	intrinsicGas, err := tx.IntrinsicGas()
+	intrinsicGas, err := trx.IntrinsicGas()
 	if err != nil {
 		return nil, err
 	}
-	if tx.Gas() < intrinsicGas {
+	if trx.Gas() < intrinsicGas {
 		return nil, errors.New("intrinsic gas exceeds provided gas")
 	}
-	delegator, err := tx.Delegator()
+	delegator, err := trx.Delegator()
 	if err != nil {
 		return nil, err
 	}
 
-	clauses := tx.Clauses()
+	clauses := trx.Clauses()
 	sumValue := new(big.Int)
 	for _, clause := range clauses {
 		value := clause.Value()
@@ -54,13 +53,33 @@ func ResolveTransaction(tx *tx.Transaction) (*ResolvedTransaction, error) {
 		}
 
 		sumValue.Add(sumValue, value)
-		if sumValue.Cmp(math.MaxBig256) > 0 {
+		if sumValue.BitLen() > 256 {
 			return nil, errors.New("tx value too large")
 		}
 	}
 
+	if trx.Type() != tx.TypeLegacy {
+		if trx.MaxFeePerGas().Sign() < 0 {
+			return nil, errors.New("max fee per gas must be positive")
+		}
+		if trx.MaxPriorityFeePerGas().Sign() < 0 {
+			return nil, errors.New("max priority fee per gas must be positive")
+		}
+
+		if trx.MaxFeePerGas().BitLen() > 256 {
+			return nil, errors.New("max fee per gas higher than 2^256-1")
+		}
+		if trx.MaxPriorityFeePerGas().BitLen() > 256 {
+			return nil, errors.New("max priority fee per gas higher than 2^256-1")
+		}
+
+		if trx.MaxFeePerGas().Cmp(trx.MaxPriorityFeePerGas()) < 0 {
+			return nil, tx.ErrMaxFeeLessThanPriorityFee
+		}
+	}
+
 	return &ResolvedTransaction{
-		tx,
+		trx,
 		origin,
 		delegator,
 		intrinsicGas,

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -128,8 +128,8 @@ func mintTransactions(t *testing.T, thorChain *testchain.Chain) {
 
 	dynFeeTx := tx.NewBuilder(tx.TypeDynamicFee).
 		ChainTag(thorChain.Repo().ChainTag()).
-		MaxFeePerGas(thor.InitialBaseGasPrice).
-		MaxPriorityFeePerGas((&big.Int{}).Add(thor.InitialBaseGasPrice, thor.InitialBaseGasPrice)).
+		MaxPriorityFeePerGas(big.NewInt(thor.InitialBaseFee)).
+		MaxFeePerGas(new(big.Int).Add(big.NewInt(thor.InitialBaseFee), big.NewInt(thor.InitialBaseFee))).
 		Expiration(10).
 		Gas(37000).
 		Nonce(1).

--- a/tx/transaction.go
+++ b/tx/transaction.go
@@ -24,13 +24,8 @@ import (
 )
 
 var (
-	ErrTxTypeNotSupported = errors.New("transaction type not supported")
-	// ErrMaxPriorityFeeVeryHigh is a sanity error to avoid extremely big numbers specified
-	// in the priority fee field.
-	ErrMaxPriorityFeeVeryHigh = errors.New("max priority fee per gas higher than 2^256-1")
-	// ErrMaxFeeVeryHigh is a sanity error to avoid extremely big numbers specified
-	// in the max fee field.
-	ErrMaxFeeVeryHigh = errors.New("max fee per gas higher than 2^256-1")
+	ErrTxTypeNotSupported        = errors.New("transaction type not supported")
+	ErrMaxFeeLessThanPriorityFee = errors.New("maxFeePerGas is less than maxPriorityFeePerGas")
 
 	errIntrinsicGasOverflow = errors.New("intrinsic gas overflow")
 	errShortTypedTx         = errors.New("typed transaction too short")

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -223,8 +223,7 @@ func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmi
 	}
 
 	headSummary := p.repo.BestBlockSummary()
-
-	if err := ValidateTransaction(newTx, p.repo, headSummary, p.forkConfig); err != nil {
+	if err := validateTransaction(newTx, p.repo, headSummary, p.forkConfig); err != nil {
 		return err
 	}
 
@@ -242,7 +241,7 @@ func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmi
 		}
 
 		state := p.stater.NewState(headSummary.Root())
-		if err := ValidateTransactionWithState(newTx, headSummary.Header, p.forkConfig, state); err != nil {
+		if err := validateTransactionWithState(newTx, headSummary.Header, p.forkConfig, state); err != nil {
 			return err
 		}
 		executable, err := txObj.Executable(p.repo.NewChain(headSummary.Header.ID()), state, headSummary.Header, p.forkConfig)

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -643,7 +643,7 @@ func TestFillPoolWithMixedTxs(t *testing.T) {
 		StateRoot(root).
 		TotalScore(100).
 		Timestamp(now + 10).
-		BaseFee(thor.InitialBaseGasPrice).
+		BaseFee(big.NewInt(thor.InitialBaseFee)).
 		GasLimit(thor.InitialGasLimit).
 		Build()
 
@@ -1125,7 +1125,7 @@ func TestWashWithDynFeeTxAndPoolLimit(t *testing.T) {
 		TotalScore(100).
 		GasLimit(10000000).
 		StateRoot(root1).
-		BaseFee(thor.InitialBaseGasPrice).
+		BaseFee(big.NewInt(thor.InitialBaseFee)).
 		Build().WithSignature(sig[:])
 	if err := pool.repo.AddBlock(b1, nil, 0, true); err != nil {
 		t.Fatal(err)

--- a/txpool/validation_test.go
+++ b/txpool/validation_test.go
@@ -148,47 +148,11 @@ func TestValidateTransaction(t *testing.T) {
 			forkConfig:  &thor.ForkConfig{GALACTICA: 0},
 			expectedErr: nil,
 		},
-		{
-			name: "max fee per gas less than max priority fee per gas",
-			getTx: func() *tx.Transaction {
-				return tx.NewBuilder(tx.TypeDynamicFee).ChainTag(repo.ChainTag()).MaxFeePerGas(big.NewInt(10)).MaxPriorityFeePerGas(big.NewInt(100)).Build()
-			},
-			head:        &chain.BlockSummary{Header: getHeader(1)},
-			forkConfig:  &thor.ForkConfig{GALACTICA: 0},
-			expectedErr: txRejectedError{"max fee per gas (10) must be greater than max priority fee per gas (100)\n"},
-		},
-		{
-			name: "max fee per gas is negative",
-			getTx: func() *tx.Transaction {
-				return tx.NewBuilder(tx.TypeDynamicFee).ChainTag(repo.ChainTag()).MaxFeePerGas(big.NewInt(-10)).MaxPriorityFeePerGas(big.NewInt(-100)).Build()
-			},
-			head:        &chain.BlockSummary{Header: getHeader(1)},
-			forkConfig:  &thor.ForkConfig{GALACTICA: 0},
-			expectedErr: txRejectedError{"max fee per gas must be positive"},
-		},
-		{
-			name: "max priority fee per gas is negative",
-			getTx: func() *tx.Transaction {
-				return tx.NewBuilder(tx.TypeDynamicFee).ChainTag(repo.ChainTag()).MaxFeePerGas(big.NewInt(10)).MaxPriorityFeePerGas(big.NewInt(-100)).Build()
-			},
-			head:        &chain.BlockSummary{Header: getHeader(1)},
-			forkConfig:  &thor.ForkConfig{GALACTICA: 0},
-			expectedErr: txRejectedError{"max priority fee per gas must be positive"},
-		},
-		{
-			name: "max fee per gas is exceding 256 bits",
-			getTx: func() *tx.Transaction {
-				return tx.NewBuilder(tx.TypeDynamicFee).ChainTag(repo.ChainTag()).MaxFeePerGas(new(big.Int).Lsh(big.NewInt(1), 257)).MaxPriorityFeePerGas(big.NewInt(10)).Build()
-			},
-			head:        &chain.BlockSummary{Header: getHeader(1)},
-			forkConfig:  &thor.ForkConfig{GALACTICA: 0},
-			expectedErr: tx.ErrMaxFeeVeryHigh,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateTransaction(tt.getTx(), repo, tt.head, tt.forkConfig)
+			err := validateTransaction(tt.getTx(), repo, tt.head, tt.forkConfig)
 			assert.Equal(t, tt.expectedErr, err)
 		})
 	}
@@ -278,7 +242,7 @@ func TestValidateTransactionWithState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateTransactionWithState(tt.getTx(), tt.header, tt.forkConfig, state)
+			err := validateTransactionWithState(tt.getTx(), tt.header, tt.forkConfig, state)
 			assert.Equal(t, tt.expectedErr, err)
 		})
 	}


### PR DESCRIPTION
# Description

This PR moves tx basic checks into `runtime/ResolveTransaction` meaning to be used in `txpool.Add`, packing and consensus verification.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
