### PR TITLE
Update git hook to use env var instead of flag

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,24 +1,18 @@
 #!/usr/bin/env bash
 #
-# Scan only staged changes for any 64-character hex strings (Ethereum private keys).
-# Override with: git commit --safe-to-ignore-key
+# pre-commit hook: scan staged changes for any 64-character hex strings (Ethereum private keys).
+# To bypass this check, set SAFE_TO_IGNORE_KEY=1 when running git commit.
 
-# 1) detect override flag on parent `git commit`
-if [ -r "/proc/$PPID/cmdline" ]; then
-  parent_cmd=$(tr '\0' ' ' </proc/$PPID/cmdline)
-else
-  parent_cmd=$(ps -o args= -p "$PPID" 2>/dev/null)
-fi
-if [[ "$parent_cmd" == *"--safe-to-ignore-key"* ]]; then
+# 1) If the environment variable is set, skip the scan entirely.
+if [ -n "$SAFE_TO_IGNORE_KEY" ]; then
   exit 0
 fi
 
-# 2) scan only added (+) or modified (-) lines (not the diff headers)
-#    and look for any 64-hex-char run
+# 2) Scan only staged additions or modifications (no context lines) for any 64-hex-char run.
 if git diff --cached --diff-filter=AM -U0 | \
      grep -E --color=never '^(\+[^\+]|-[^-]).*[0-9A-Fa-f]{64}'; then
   echo
-  echo "✖ ERROR: Detected ECDSA private key in staged changes. Commit aborted."
+  echo "✖ ERROR: Detected a 64-character hex string (possible private key) in staged changes. Commit aborted."
   echo
   exit 1
 fi


### PR DESCRIPTION
# Description

Git pre-hook now uses an Env variable to skip check. 


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
