### PR TITLE
make CalcBaseFee accept all range of parent header

### DIFF
--- a/consensus/upgrade/galactica/galactica.go
+++ b/consensus/upgrade/galactica/galactica.go
@@ -29,8 +29,10 @@ var (
 
 // CalcBaseFee calculates the basefee of the header.
 func CalcBaseFee(parent *block.Header, forkConfig *thor.ForkConfig) *big.Int {
-	// If the current block is the first Galactica block, return the InitialBaseFee.
-	if parent.Number()+1 == forkConfig.GALACTICA {
+	if parent.Number()+1 < forkConfig.GALACTICA {
+		return nil
+	} else if parent.Number()+1 == forkConfig.GALACTICA {
+		// If the current block is the first Galactica block, return the InitialBaseFee.
 		return new(big.Int).SetUint64(thor.InitialBaseFee)
 	}
 

--- a/consensus/upgrade/galactica/galactica_test.go
+++ b/consensus/upgrade/galactica/galactica_test.go
@@ -65,6 +65,18 @@ func TestCalcBaseFeeEdgeCases(t *testing.T) {
 				assert.True(t, baseFee.Cmp(big.NewInt(thor.InitialBaseFee)) == 0)
 			},
 		},
+		{
+			name: "Before galactica fork",
+			f: func(t *testing.T) {
+				var parentID thor.Bytes32
+				binary.BigEndian.PutUint32(parentID[:], 2)
+
+				// parent.Number() = 3
+				parent := new(block.Builder).ParentID(parentID).Build().Header()
+				baseFee := CalcBaseFee(parent, config())
+				assert.Nil(t, baseFee)
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -127,12 +127,6 @@ func (p *Packer) Schedule(parent *chain.BlockSummary, nowTimestamp uint64) (flow
 		}
 	}
 
-	var baseFee *big.Int
-
-	if parent.Header.Number()+1 >= p.forkConfig.GALACTICA {
-		baseFee = galactica.CalcBaseFee(parent.Header, p.forkConfig)
-	}
-
 	rt := runtime.New(
 		p.repo.NewChain(parent.Header.ID()),
 		state,
@@ -143,7 +137,7 @@ func (p *Packer) Schedule(parent *chain.BlockSummary, nowTimestamp uint64) (flow
 			Time:        newBlockTime,
 			GasLimit:    p.gasLimit(parent.Header.GasLimit()),
 			TotalScore:  parent.Header.TotalScore() + score,
-			BaseFee:     baseFee,
+			BaseFee:     galactica.CalcBaseFee(parent.Header, p.forkConfig),
 		},
 		p.forkConfig)
 


### PR DESCRIPTION
# Description

Normalization happens inside the `CalcBaseFee` method. No need to have the `if number >= galactica` logic outside.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
