### PR TITLE
fix: change the weight when increasing and decreasing the stake

### DIFF
--- a/builtin/staker/validations.go
+++ b/builtin/staker/validations.go
@@ -340,6 +340,9 @@ func (v *validations) IncreaseStake(id thor.Bytes32, endorsor thor.Address, amou
 	if err := v.queuedVET.Add(amount); err != nil {
 		return err
 	}
+	if err := v.queuedWeight.Add(big.NewInt(0).Mul(amount, validatorWeightMultiplier)); err != nil {
+		return err
+	}
 
 	return v.storage.SetValidation(id, entry)
 }
@@ -379,6 +382,9 @@ func (v *validations) DecreaseStake(id thor.Bytes32, endorsor thor.Address, amou
 		entry.PendingLocked = big.NewInt(0).Sub(entry.PendingLocked, amount)
 		entry.WithdrawableVET = big.NewInt(0).Add(entry.WithdrawableVET, amount)
 		if err := v.queuedVET.Sub(amount); err != nil {
+			return err
+		}
+		if err := v.queuedWeight.Sub(big.NewInt(0).Mul(amount, validatorWeightMultiplier)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
# Description

Changing the queued weight when increasing and decreasing validator stake

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
