### PR TITLE
fix: queued stake for delegations

### DIFF
--- a/builtin/staker/delegations.go
+++ b/builtin/staker/delegations.go
@@ -216,12 +216,13 @@ func (d *delegations) Withdraw(delegationID thor.Bytes32) (*big.Int, error) {
 	}
 
 	amount := delegation.Stake
-	delegation.Stake = big.NewInt(0)
 
 	// Decrement queuedVET when withdrawing delegation
 	if err := d.queuedVET.Sub(amount); err != nil {
 		return nil, err
 	}
+	
+	delegation.Stake = big.NewInt(0)
 
 	// remove the delegation from the mapping after the withdraw
 	if err := d.storage.SetDelegation(delegationID, delegation); err != nil {

--- a/builtin/staker/delegations.go
+++ b/builtin/staker/delegations.go
@@ -218,6 +218,11 @@ func (d *delegations) Withdraw(delegationID thor.Bytes32) (*big.Int, error) {
 	amount := delegation.Stake
 	delegation.Stake = big.NewInt(0)
 
+	// Decrement queuedVET when withdrawing delegation
+	if err := d.queuedVET.Sub(amount); err != nil {
+		return nil, err
+	}
+
 	// remove the delegation from the mapping after the withdraw
 	if err := d.storage.SetDelegation(delegationID, delegation); err != nil {
 		return nil, err

--- a/builtin/staker/delegations.go
+++ b/builtin/staker/delegations.go
@@ -94,7 +94,6 @@ func (d *delegations) Add(
 		return thor.Bytes32{}, err
 	}
 
-	// Add queuedWeight when adding delegation
 	if err := d.queuedWeight.Add(weight); err != nil {
 		return thor.Bytes32{}, err
 	}
@@ -224,12 +223,10 @@ func (d *delegations) Withdraw(delegationID thor.Bytes32) (*big.Int, error) {
 
 	amount := delegation.Stake
 
-	// Decrement queuedVET when withdrawing delegation
 	if err := d.queuedVET.Sub(amount); err != nil {
 		return nil, err
 	}
 
-	// Decrement queuedWeight when withdrawing delegation
 	weight := delegation.Weight()
 	if err := d.queuedWeight.Sub(weight); err != nil {
 		return nil, err

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -254,12 +254,6 @@ func (s *Staker) AddDelegation(
 		logger.Info("failed to add delegation", "ValidationID", validationID, "error", err)
 		return thor.Bytes32{}, err
 	} else {
-		weight := big.NewInt(0).Mul(stake, big.NewInt(int64(multiplier)))
-		weight = big.NewInt(0).Quo(weight, big.NewInt(100))
-		err := s.queuedWeight.Add(weight)
-		if err != nil {
-			return [32]byte{}, err
-		}
 		logger.Info("added delegation", "ValidationID", validationID, "id", id)
 		return id, nil
 	}


### PR DESCRIPTION
# Description

Fix so we can subtract the delegator stake from a queued validator since housekeeping does not apply to queued validators.

Required to complete https://github.com/vechain/protocol-board-repo/issues/623.
