### PR TITLE
Use static type checking vs reflect.DeepEqual

### DIFF
--- a/cmd/thor/sync_logdb.go
+++ b/cmd/thor/sync_logdb.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
-	
+
 	"github.com/pkg/errors"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/vechain/thor/v2/block"

--- a/cmd/thor/sync_logdb.go
+++ b/cmd/thor/sync_logdb.go
@@ -6,11 +6,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
-
+	"math/big"
+	
 	"github.com/pkg/errors"
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/vechain/thor/v2/block"
@@ -336,17 +337,143 @@ func verifyLogDBPerBlock(
 			}
 		}
 	}
-	if !reflect.DeepEqual(eventLogs, expectedEvLogs) {
+	if !equalEvents(eventLogs, expectedEvLogs) {
 		fmt.Println("\nDiff event logs")
 		fmt.Println(jsonDiff(expectedEvLogs, eventLogs))
 		return errors.New("incorrect logs")
 	}
-	if !reflect.DeepEqual(transferLogs, expectedTrLogs) {
+	if !equalTransfers(transferLogs, expectedTrLogs) {
 		fmt.Println("\nDiff transfer logs")
 		fmt.Println(jsonDiff(expectedTrLogs, transferLogs))
 		return errors.New("incorrect logs")
 	}
 	return nil
+}
+
+// equalEvents performs a statically typed comparison of two Event slices
+func equalEvents(a, b []*logdb.Event) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equalEvent(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalEvent performs a statically typed comparison of two Event pointers
+func equalEvent(a, b *logdb.Event) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	// fast-fail on all primitive fields
+	if a.BlockNumber != b.BlockNumber ||
+		a.LogIndex != b.LogIndex ||
+		a.BlockTime != b.BlockTime ||
+		a.TxIndex != b.TxIndex ||
+		a.ClauseIndex != b.ClauseIndex {
+		return false
+	}
+
+	// compare IDs and addresses via byte-level equality
+	if !bytes.Equal(a.BlockID.Bytes(), b.BlockID.Bytes()) ||
+		!bytes.Equal(a.TxID.Bytes(), b.TxID.Bytes()) ||
+		!bytes.Equal(a.TxOrigin.Bytes(), b.TxOrigin.Bytes()) ||
+		!bytes.Equal(a.Address.Bytes(), b.Address.Bytes()) {
+		return false
+	}
+
+	// topics: nil vs non-nil are unequal, otherwise byte-compare the contents
+	if !equalTopics(a.Topics, b.Topics) {
+		return false
+	}
+
+	// distinguish nil vs empty slice (reflect.DeepEqual would treat them unequal)
+	if (a.Data == nil) != (b.Data == nil) {
+		return false
+	}
+	if !bytes.Equal(a.Data, b.Data) {
+		return false
+	}
+
+	return true
+}
+
+// equalTopics compares two [5]*Bytes32 arrays, distinguishing nil pointers
+// and falling back to a byte-level compare of the 32-byte contents.
+func equalTopics(a, b [5]*thor.Bytes32) bool {
+	for i := range a {
+		if a[i] == nil || b[i] == nil {
+			if a[i] != b[i] {
+				return false
+			}
+			continue
+		}
+		if !bytes.Equal(a[i].Bytes(), b[i].Bytes()) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalTransfers performs a statically typed comparison of two Transfer slices
+func equalTransfers(a, b []*logdb.Transfer) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equalTransfer(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalTransfer performs a statically typed comparison of two Transfer pointers
+// and treats nil Amount as zero for semantic equality.
+func equalTransfer(a, b *logdb.Transfer) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	// fast-fail on primitive fields
+	if a.BlockNumber != b.BlockNumber ||
+		a.LogIndex != b.LogIndex ||
+		a.BlockTime != b.BlockTime ||
+		a.TxIndex != b.TxIndex ||
+		a.ClauseIndex != b.ClauseIndex {
+		return false
+	}
+
+	// compare IDs and addresses via byte-level equality
+	if !bytes.Equal(a.BlockID.Bytes(), b.BlockID.Bytes()) ||
+		!bytes.Equal(a.TxID.Bytes(), b.TxID.Bytes()) ||
+		!bytes.Equal(a.TxOrigin.Bytes(), b.TxOrigin.Bytes()) ||
+		!bytes.Equal(a.Sender.Bytes(), b.Sender.Bytes()) ||
+		!bytes.Equal(a.Recipient.Bytes(), b.Recipient.Bytes()) {
+		return false
+	}
+
+	// normalize nil<->zero for Amount
+	var aAmt, bAmt *big.Int
+	if a.Amount == nil || a.Amount.Sign() == 0 {
+		aAmt = big.NewInt(0)
+	} else {
+		aAmt = a.Amount
+	}
+	if b.Amount == nil || b.Amount.Sign() == 0 {
+		bAmt = big.NewInt(0)
+	} else {
+		bAmt = b.Amount
+	}
+	if aAmt.Cmp(bAmt) != 0 {
+		return false
+	}
+
+	return true
 }
 
 func jsonDiff(expected, actual any) string {


### PR DESCRIPTION
# Description

This is a low-priority task.
Changes the verification of the log db from using the reflect package to using statically typed validation.
Moving to statically typed checks reduces the checks in 2 orders of magnitude.

Will also run this locally to check for errors / results.

Gist for benchmark here: https://gist.github.com/otherview/3db56b838d840559100b5b024d4dcf00
Results
```
goos: darwin
goarch: arm64
pkg: github.com/vechain/thor/v2/cmd/thor
cpu: Apple M3
BenchmarkEventComparison_ReflectDeepEqual_Small
BenchmarkEventComparison_ReflectDeepEqual_Small-8       	 8635862	       120.5 ns/op	      48 B/op	       2 allocs/op
BenchmarkEventComparison_StaticTyped_Small
BenchmarkEventComparison_StaticTyped_Small-8            	626343638	         1.894 ns/op	       0 B/op	       0 allocs/op
BenchmarkEventComparison_ReflectDeepEqual_Medium
BenchmarkEventComparison_ReflectDeepEqual_Medium-8      	 9989257	       120.9 ns/op	      48 B/op	       2 allocs/op
BenchmarkEventComparison_StaticTyped_Medium
BenchmarkEventComparison_StaticTyped_Medium-8           	634405808	         1.875 ns/op	       0 B/op	       0 allocs/op
BenchmarkEventComparison_ReflectDeepEqual_Large
BenchmarkEventComparison_ReflectDeepEqual_Large-8       	 9763932	       120.9 ns/op	      48 B/op	       2 allocs/op
BenchmarkEventComparison_StaticTyped_Large
BenchmarkEventComparison_StaticTyped_Large-8            	631387314	         1.894 ns/op	       0 B/op	       0 allocs/op
BenchmarkTransferComparison_ReflectDeepEqual_Small
BenchmarkTransferComparison_ReflectDeepEqual_Small-8    	10028626	       119.0 ns/op	      48 B/op	       2 allocs/op
BenchmarkTransferComparison_StaticTyped_Small
BenchmarkTransferComparison_StaticTyped_Small-8         	637912748	         1.928 ns/op	       0 B/op	       0 allocs/op
BenchmarkTransferComparison_ReflectDeepEqual_Medium
BenchmarkTransferComparison_ReflectDeepEqual_Medium-8   	 9964311	       119.3 ns/op	      48 B/op	       2 allocs/op
BenchmarkTransferComparison_StaticTyped_Medium
BenchmarkTransferComparison_StaticTyped_Medium-8        	623274363	         1.936 ns/op	       0 B/op	       0 allocs/op
BenchmarkTransferComparison_ReflectDeepEqual_Large
BenchmarkTransferComparison_ReflectDeepEqual_Large-8    	 9912132	       120.4 ns/op	      48 B/op	       2 allocs/op
BenchmarkTransferComparison_StaticTyped_Large
BenchmarkTransferComparison_StaticTyped_Large-8         	631926782	         1.925 ns/op	       0 B/op	       0 allocs/op
BenchmarkEventComparison_ReflectDeepEqual_Equal
BenchmarkEventComparison_ReflectDeepEqual_Equal-8       	  188846	      6314 ns/op	   10360 B/op	      11 allocs/op
BenchmarkEventComparison_StaticTyped_Equal
BenchmarkEventComparison_StaticTyped_Equal-8            	  583218	      2025 ns/op	       0 B/op	       0 allocs/op
PASS
```

Fixes # [(issue)](https://github.com/vechain/otherviews-workboard/issues/185)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
