### PR TITLE
Decrease stake weight

### DIFF
--- a/builtin/staker/housekeeping.go
+++ b/builtin/staker/housekeeping.go
@@ -123,8 +123,12 @@ func (s *Staker) performRenewalUpdates(id thor.Bytes32, validator *Validation) e
 	if err := s.queuedVET.Sub(queuedDecrease); err != nil {
 		return err
 	}
-	if err := s.queuedWeight.Add(big.NewInt(0).Neg(changeWeight)); err != nil {
-		return err
+	// the queued weight should decrease only if the validator is queued or the weight is increasingAdd commentMore actions
+	// because of an increased stake transaction or new delegators
+	if validator.Status == StatusQueued || changeWeight.Cmp(big.NewInt(0)) > 0 {
+		if err := s.queuedWeight.Add(big.NewInt(0).Neg(changeWeight)); err != nil {
+			return err
+		}
 	}
 	return s.storage.SetValidation(id, validator)
 }


### PR DESCRIPTION
# Description

Fixing the queuedWeight changes and add test that increases and then decreases a validator's stake during two stake periods

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
