### PR TITLE
add post process block hook in node && move ascii art into it

### DIFF
--- a/cmd/thor/node/ascii_art.go
+++ b/cmd/thor/node/ascii_art.go
@@ -5,9 +5,12 @@
 
 package node
 
+import (
+	"os"
+	"strings"
+)
+
 const GalacticaASCIIArt = `
-
-
                                                       /\ /\
                                                      /  \---._
                                                     / / ` + "`" + `     ` + "`" + `\
@@ -48,4 +51,16 @@ const GalacticaASCIIArt = `
       / _ \   / .'   \_||_/ | | \_|  | |    \ \   / / / _ \  |_/ | | \_|  | |_ \_|  | | ` + "`" + `. \ 
      / ___ \  | |           | |      | |     \ \ / / / ___ \     | |      |  _| _   | |  | | 
    _/ /   \ \_\ ` + "`" + `.___.'\   _| |_    _| |_     \ ' /_/ /   \ \_  _| |_    _| |__/ | _| |_.' / 
-  |____| |____|` + "`" + `.____ .'  |_____|  |_____|     \_/|____| |____||_____|  |________||______.'`
+  |____| |____|` + "`" + `.____ .'  |_____|  |_____|     \_/|____| |____||_____|  |________||______.'
+`
+
+var printed bool
+
+func printGalacticaWelcomeInfo() {
+	if !printed {
+		// remove the leading new line symbol as previous printed log will have a new line symbol
+		str, _ := strings.CutPrefix(GalacticaASCIIArt, "\n")
+		os.Stdout.WriteString(str)
+		printed = true
+	}
+}

--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -281,14 +281,13 @@ func (n *Node) txStashLoop(ctx context.Context) {
 func (n *Node) guardBlockProcessing(blockNum uint32, process func(conflicts uint32) error) (err error) {
 	n.processLock.Lock()
 	defer func() {
-		n.processLock.Unlock()
-
 		// post process block hook, executed only if the block is processed successfully
 		if err == nil {
 			if n.initialSynced && blockNum == n.forkConfig.GALACTICA {
 				printGalacticaWelcomeInfo()
 			}
 		}
+		n.processLock.Unlock()
 	}()
 
 	if blockNum > n.maxBlockNum {

--- a/cmd/thor/node/packer_loop.go
+++ b/cmd/thor/node/packer_loop.go
@@ -32,6 +32,7 @@ func (n *Node) packerLoop(ctx context.Context) {
 		return
 	case <-n.comm.Synced():
 	}
+	n.initialSynced = true
 	logger.Info("synchronization process done")
 
 	var (
@@ -190,10 +191,6 @@ func (n *Node) pack(flow *packer.Flow) (err error) {
 		n.processFork(newBlock, oldBest.Header.ID())
 		commitElapsed := mclock.Now() - startTime - execElapsed
 
-		if newBlock.Header().Number() == n.forkConfig.GALACTICA {
-			fmt.Println(GalacticaASCIIArt)
-		}
-
 		n.comm.BroadcastBlock(newBlock)
 		logger.Info("📦 new block packed",
 			"txs", len(receipts),
@@ -201,12 +198,6 @@ func (n *Node) pack(flow *packer.Flow) (err error) {
 			"et", fmt.Sprintf("%v|%v", common.PrettyDuration(execElapsed), common.PrettyDuration(commitElapsed)),
 			"id", shortID(newBlock.Header().ID()),
 		)
-		// TODO: log to be removed when fork is stable
-		if newBlock.Header().Number()+1 == n.forkConfig.GALACTICA {
-			logger.Info("Last block before Galactica fork activates!")
-		} else if newBlock.Header().Number() == n.forkConfig.GALACTICA {
-			logger.Info("Galactica fork activated!")
-		}
 
 		if v, updated := n.bandwidth.Update(newBlock.Header(), time.Duration(realElapsed)); updated {
 			logger.Trace("bandwidth updated", "gps", v)


### PR DESCRIPTION
# Description

Also put some limitations to print ascii art function:

- Requires initial sync to be finished (not printed during catch up stage)
- Printed only once to prevent temp-soft-fork when fork happens

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
