### PR TITLE
fix(gha): fork repo for rosetta

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -35,6 +35,7 @@ jobs:
     uses: ./.github/workflows/test-rosetta.yaml
     with:
       thor_version: ${{ github.event.pull_request.head.sha }}
+      thor_repo: https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git
 
   # This doesn't publish the image, it just tests the publishing workflow (build the image / tags / labels)
   test-docker-publish:

--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -34,8 +34,8 @@ jobs:
     name: Rosetta Tests
     uses: ./.github/workflows/test-rosetta.yaml
     with:
-      thor_version: ${{ github.event.pull_request.head.sha }}
       thor_repo: https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git
+      thor_version: ${{ github.event.pull_request.head.sha }}
 
   # This doesn't publish the image, it just tests the publishing workflow (build the image / tags / labels)
   test-docker-publish:

--- a/.github/workflows/test-rosetta.yaml
+++ b/.github/workflows/test-rosetta.yaml
@@ -3,6 +3,10 @@ name: Rosetta Tests
 on:
   workflow_call:
     inputs:
+      thor_repo:
+        required: false
+        type: string
+        default: "https://github.com/vechain/thor.git"
       thor_version:
         required: true
         type: string
@@ -12,6 +16,7 @@ jobs:
     name: Run Solo e2e Tests
     runs-on: ubuntu-latest
     env:
+      THOR_REPO: ${{ inputs.thor_repo }}
       THOR_VERSION: ${{ inputs.thor_version }}
       NETWORK: solo
       TEST_NETWORK: solo


### PR DESCRIPTION
# Description

The Rosetta repo builds a Docker image using the Thor codebase. This means that if there was a PR coming from a fork, we were just taking the commit from Thor's feature branch (falling back to the default commit if error), rather than the commit from the Thor's fork.

This PR fixes that. Closes https://github.com/vechain/protocol-board-repo/issues/654.

PS: I created it from my own fork to test it. Related logs from the execution of the checks:

```
#26 [rosetta-server thor-builder 3/3] RUN git clone https://github.com/freemanzMrojo/thor.git . &&     git checkout 5131b64230fbc191829b8a4e45589c04f5d6205b &&     make all
#26 0.163 Cloning into '.'...
#26 2.455 Note: switching to '5131b64230fbc191829b8a4e45589c04f5d6205b'.
```
