### PR TITLE
fix(validations): wipe the exit block when setting active validator to auto renew

### DIFF
--- a/builtin/staker/validations.go
+++ b/builtin/staker/validations.go
@@ -281,7 +281,7 @@ func (v *validations) UpdateAutoRenew(endorsor thor.Address, id thor.Bytes32, au
 
 	if validator.Status == StatusActive {
 		if autoRenew {
-			if err := v.storage.SetExitEpoch(*validator.ExitBlock, id); err != nil {
+			if err := v.storage.SetExitEpoch(*validator.ExitBlock, thor.Bytes32{}); err != nil {
 				return err
 			}
 			validator.ExitBlock = nil


### PR DESCRIPTION
# Description

wipe the exit block when setting active validator to auto renew

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
