### PR TITLE
move energy growth stop time from state to energy

### DIFF
--- a/api/accounts/accounts.go
+++ b/api/accounts/accounts.go
@@ -19,6 +19,7 @@ import (
 	"github.com/vechain/thor/v2/api/utils"
 	"github.com/vechain/thor/v2/bft"
 	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/runtime"
 	"github.com/vechain/thor/v2/state"
@@ -97,7 +98,7 @@ func (a *Accounts) getAccount(addr thor.Address, header *block.Header, state *st
 	if err != nil {
 		return nil, err
 	}
-	energy, err := state.GetEnergy(addr, header.Timestamp())
+	energy, err := builtin.Energy.Native(state, header.Timestamp()).Get(addr)
 	if err != nil {
 		return nil, err
 	}

--- a/api/rewards/rewards.go
+++ b/api/rewards/rewards.go
@@ -55,8 +55,7 @@ func (r *Rewards) handleGetBlockRewards(w http.ResponseWriter, req *http.Request
 		return err
 	}
 
-	hayabusaTime, err := st.GetHayabusaForkTime()
-
+	hayabusaTime, err := builtin.Energy.Native(st, summary.Header.Timestamp()).GetEnergyGrowthStopTime()
 	if err != nil {
 		if r.repo.IsNotFound(err) {
 			return utils.BadRequest(errors.WithMessage(err, "hayabusa not active"))
@@ -64,7 +63,7 @@ func (r *Rewards) handleGetBlockRewards(w http.ResponseWriter, req *http.Request
 		return err
 	}
 
-	if *hayabusaTime > summary.Header.Timestamp() {
+	if hayabusaTime > summary.Header.Timestamp() {
 		return utils.BadRequest(fmt.Errorf("pre hayabusa block"))
 	}
 

--- a/builtin/energy/energy_test.go
+++ b/builtin/energy/energy_test.go
@@ -6,6 +6,7 @@
 package energy
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -174,6 +175,28 @@ func TestEnergyGrowth(t *testing.T) {
 	x.Div(x, big.NewInt(1e18))
 
 	assert.Equal(t, x, bal1)
+}
+
+func TestGetEnergyGrowthStopTime(t *testing.T) {
+	st := state.New(muxdb.NewMem(), trie.Root{})
+	p := params.New(thor.BytesToAddress([]byte("params")), st)
+	eng := New(thor.BytesToAddress([]byte("energy")), st, 10, p)
+
+	// no stop time set
+	stopTime, err := eng.GetEnergyGrowthStopTime()
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(math.MaxUint64), stopTime)
+
+	err = eng.StopEnergyGrowth()
+	assert.NoError(t, err)
+
+	stopTime, err = eng.GetEnergyGrowthStopTime()
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(10), stopTime)
+
+	// set multiple times should return error
+	err = eng.StopEnergyGrowth()
+	assert.Error(t, err, "energy growth has already stopped")
 }
 
 func TestAddIssued(t *testing.T) {

--- a/builtin/native_calls_test.go
+++ b/builtin/native_calls_test.go
@@ -760,7 +760,7 @@ func TestEnergyNative(t *testing.T) {
 	summary := thorChain.Repo().BestBlockSummary()
 	firstPOS := summary.Header.Number() + 1
 	st := thorChain.Stater().NewState(summary.Root())
-	energyAtBlock, err := st.GetEnergy(summary.Header.Beneficiary(), summary.Header.Timestamp())
+	energyAtBlock, err := builtin.Energy.Native(st, summary.Header.Timestamp()).Get(summary.Header.Beneficiary())
 	require.NoError(t, err)
 	validatorMap[summary.Header.Timestamp()] = energyAtBlock
 	require.NoError(t, err)
@@ -774,7 +774,7 @@ func TestEnergyNative(t *testing.T) {
 		require.NoError(t, thorChain.MintBlock(genesis.DevAccounts()[0]))
 		summary = thorChain.Repo().BestBlockSummary()
 		st := thorChain.Stater().NewState(summary.Root())
-		energyAtBlock, err = st.GetEnergy(summary.Header.Beneficiary(), summary.Header.Timestamp())
+		energyAtBlock, err = builtin.Energy.Native(st, summary.Header.Timestamp()).Get(summary.Header.Beneficiary())
 		require.NoError(t, err)
 		validatorMap[thorChain.Repo().BestBlockSummary().Header.Timestamp()] = energyAtBlock
 

--- a/builtin/prototype_native.go
+++ b/builtin/prototype_native.go
@@ -120,7 +120,7 @@ func init() {
 
 			if args.BlockNumber == ctx.Number {
 				env.UseGas(thor.GetBalanceGas)
-				val, err := env.State().GetEnergy(thor.Address(args.Self), ctx.Time)
+				val, err := Energy.Native(env.State(), ctx.Time).Get(thor.Address(args.Self))
 				if err != nil {
 					panic(err)
 				}
@@ -138,7 +138,7 @@ func init() {
 			state := env.State().Checkout(summary.Root())
 
 			env.UseGas(thor.GetBalanceGas)
-			val, err := state.GetEnergy(thor.Address(args.Self), summary.Header.Timestamp())
+			val, err := Energy.Native(state, summary.Header.Timestamp()).Get(thor.Address(args.Self))
 			if err != nil {
 				panic(err)
 			}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -92,7 +92,10 @@ func (c *Consensus) NewRuntimeForReplay(header *block.Header, skipValidation boo
 			c.validatorsCache.Add(header.ParentID(), activeGroup)
 		}
 		if activated {
-			builtin.Energy.Native(state, parentSummary.Header.Timestamp()).StopEnergyGrowth()
+			err := builtin.Energy.Native(state, parentSummary.Header.Timestamp()).StopEnergyGrowth()
+			if err != nil {
+				return nil, err
+			}
 		}
 		if posActive {
 			err = c.validateStakingProposer(header, parentSummary.Header, staker, activeGroup)

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -58,7 +58,10 @@ func (c *Consensus) validate(
 	}
 
 	if activated {
-		builtin.Energy.Native(state, parent.Timestamp()).StopEnergyGrowth()
+		err := builtin.Energy.Native(state, parent.Timestamp()).StopEnergyGrowth()
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	if err := c.validateBlockBody(block); err != nil {

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -83,7 +83,10 @@ func (p *Packer) Schedule(parent *chain.BlockSummary, nowTimestamp uint64) (*Flo
 	}
 
 	if activated {
-		builtin.Energy.Native(st, parent.Header.Timestamp()).StopEnergyGrowth()
+		err := builtin.Energy.Native(st, parent.Header.Timestamp()).StopEnergyGrowth()
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	rt := runtime.New(
@@ -120,7 +123,10 @@ func (p *Packer) Mock(parent *chain.BlockSummary, targetTime uint64, gasLimit ui
 	}
 
 	if activated {
-		builtin.Energy.Native(state, parent.Header.Timestamp()).StopEnergyGrowth()
+		err := builtin.Energy.Native(state, parent.Header.Timestamp()).StopEnergyGrowth()
+		if err != nil {
+			return nil, false, err
+		}
 	}
 
 	var score uint64

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -182,11 +182,11 @@ func (rt *Runtime) newEVM(stateDB *statedb.StateDB, clauseIndex uint32, txCtx *x
 			}
 			// touch energy balance when token balance changed
 			// SHOULD be performed before transfer
-			senderEnergy, err := rt.state.GetEnergy(thor.Address(sender), rt.ctx.Time)
+			senderEnergy, err := builtin.Energy.Native(rt.state, rt.ctx.Time).Get(thor.Address(sender))
 			if err != nil {
 				panic(err)
 			}
-			recipientEnergy, err := rt.state.GetEnergy(thor.Address(recipient), rt.ctx.Time)
+			recipientEnergy, err := builtin.Energy.Native(rt.state, rt.ctx.Time).Get(thor.Address(recipient))
 			if err != nil {
 				panic(err)
 			}
@@ -274,14 +274,14 @@ func (rt *Runtime) newEVM(stateDB *statedb.StateDB, clauseIndex uint32, txCtx *x
 		},
 		OnSuicideContract: func(_ *vm.EVM, contractAddr, tokenReceiver common.Address) {
 			// it's IMPORTANT to process energy before token
-			energy, err := rt.state.GetEnergy(thor.Address(contractAddr), rt.ctx.Time)
+			energy, err := builtin.Energy.Native(rt.state, rt.ctx.Time).Get(thor.Address(contractAddr))
 			if err != nil {
 				panic(err)
 			}
 			bal := stateDB.GetBalance(contractAddr)
 
 			if bal.Sign() != 0 || energy.Sign() != 0 {
-				receiverEnergy, err := rt.state.GetEnergy(thor.Address(tokenReceiver), rt.ctx.Time)
+				receiverEnergy, err := builtin.Energy.Native(rt.state, rt.ctx.Time).Get(thor.Address(tokenReceiver))
 				if err != nil {
 					panic(err)
 				}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -107,11 +107,11 @@ func TestEVMFunction(t *testing.T) {
 				assert.Equal(t, expectedEvent, out.Events[0])
 
 				assert.Equal(t, M(big.NewInt(0), nil), M(ctx.state.GetBalance(target)))
-				assert.Equal(t, M(big.NewInt(0), nil), M(ctx.state.GetEnergy(target, time)))
+				assert.Equal(t, M(big.NewInt(0), nil), M(builtin.Energy.Native(ctx.state, time).Get(target)))
 
 				bal, _ := new(big.Int).SetString("1000000000000000000000000000", 10)
 				assert.Equal(t, M(new(big.Int).Add(bal, big.NewInt(200)), nil), M(ctx.state.GetBalance(origin)))
-				assert.Equal(t, M(new(big.Int).Add(bal, big.NewInt(100)), nil), M(ctx.state.GetEnergy(origin, time)))
+				assert.Equal(t, M(new(big.Int).Add(bal, big.NewInt(100)), nil), M(builtin.Energy.Native(ctx.state, time).Get(origin)))
 			},
 		},
 		{
@@ -788,9 +788,9 @@ func TestExecuteTransaction(t *testing.T) {
 
 	t.Run("Receipt check with legacy tx before galactica fork", func(t *testing.T) {
 		st := state.New(db, trie.Root{Hash: b0.Header().StateRoot()})
-		prevPayerEnergy, err := st.GetEnergy(genesis.DevAccounts()[0].Address, b0.Header().Timestamp())
+		prevPayerEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()).Get(genesis.DevAccounts()[0].Address)
 		assert.Nil(t, err)
-		prevEndorserEnergy, err := st.GetEnergy(thor.Address{}, b0.Header().Timestamp())
+		prevEndorserEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()).Get(thor.Address{})
 		assert.Nil(t, err)
 
 		rt := runtime.New(repo.NewChain(b0.Header().ID()), st, &xenv.BlockContext{}, fc)
@@ -801,9 +801,9 @@ func TestExecuteTransaction(t *testing.T) {
 		assert.False(t, receipt.Reverted)
 		assert.NotNil(t, receipt)
 
-		currentPayerEnergy, err := st.GetEnergy(genesis.DevAccounts()[0].Address, b0.Header().Timestamp()+10)
+		currentPayerEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()+10).Get(genesis.DevAccounts()[0].Address)
 		assert.Nil(t, err)
-		currentEndorserEnergy, err := st.GetEnergy(thor.Address{}, b0.Header().Timestamp()+10)
+		currentEndorserEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()+10).Get(thor.Address{})
 		assert.Nil(t, err)
 
 		// Expecting to consume just the intrinsic gas portion
@@ -822,9 +822,9 @@ func TestExecuteTransaction(t *testing.T) {
 
 	t.Run("Receipt check with legacy tx after galactica fork", func(t *testing.T) {
 		st := state.New(db, trie.Root{Hash: b1.Header().StateRoot(), Ver: trie.Version{Major: b1.Header().Number(), Minor: 0}})
-		prevPayerEnergy, err := st.GetEnergy(genesis.DevAccounts()[0].Address, b0.Header().Timestamp())
+		prevPayerEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()).Get(genesis.DevAccounts()[0].Address)
 		assert.Nil(t, err)
-		prevEndorserEnergy, err := st.GetEnergy(thor.Address{}, b0.Header().Timestamp())
+		prevEndorserEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()).Get(thor.Address{})
 		assert.Nil(t, err)
 
 		rt := runtime.New(repo.NewChain(b0.Header().ID()), st, &xenv.BlockContext{BaseFee: big.NewInt(thor.InitialBaseFee)}, fc)
@@ -835,9 +835,9 @@ func TestExecuteTransaction(t *testing.T) {
 		assert.False(t, receipt.Reverted)
 		assert.NotNil(t, receipt)
 
-		currentPayerEnergy, err := st.GetEnergy(genesis.DevAccounts()[0].Address, b0.Header().Timestamp()+10)
+		currentPayerEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()+10).Get(genesis.DevAccounts()[0].Address)
 		assert.Nil(t, err)
-		currentEndorserEnergy, err := st.GetEnergy(thor.Address{}, b0.Header().Timestamp()+10)
+		currentEndorserEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()+10).Get(thor.Address{})
 		assert.Nil(t, err)
 
 		// Expecting to consume just the intrinsic gas portion
@@ -856,9 +856,9 @@ func TestExecuteTransaction(t *testing.T) {
 
 	t.Run("Receipt check with dyn fee tx after galactica fork", func(t *testing.T) {
 		st := state.New(db, trie.Root{Hash: b1.Header().StateRoot(), Ver: trie.Version{Major: b1.Header().Number(), Minor: 0}})
-		prevPayerEnergy, err := st.GetEnergy(genesis.DevAccounts()[0].Address, b0.Header().Timestamp())
+		prevPayerEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()).Get(genesis.DevAccounts()[0].Address)
 		assert.Nil(t, err)
-		prevEndorserEnergy, err := st.GetEnergy(thor.Address{}, b0.Header().Timestamp())
+		prevEndorserEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()).Get(thor.Address{})
 		assert.Nil(t, err)
 
 		rt := runtime.New(repo.NewChain(b0.Header().ID()), st, &xenv.BlockContext{BaseFee: big.NewInt(thor.InitialBaseFee)}, fc)
@@ -869,9 +869,9 @@ func TestExecuteTransaction(t *testing.T) {
 		assert.False(t, receipt.Reverted)
 		assert.NotNil(t, receipt)
 
-		currentPayerEnergy, err := st.GetEnergy(genesis.DevAccounts()[0].Address, b0.Header().Timestamp()+10)
+		currentPayerEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()+10).Get(genesis.DevAccounts()[0].Address)
 		assert.Nil(t, err)
-		currentEndorserEnergy, err := st.GetEnergy(thor.Address{}, b0.Header().Timestamp()+10)
+		currentEndorserEnergy, err := builtin.Energy.Native(st, b0.Header().Timestamp()+10).Get(thor.Address{})
 		assert.Nil(t, err)
 
 		// Expecting to consume just the intrinsic gas portion
@@ -948,7 +948,7 @@ func TestNoRewards(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prevEndorserEnergy, err := state.GetEnergy(thor.Address{}, b0.Header().Timestamp())
+			prevEndorserEnergy, err := builtin.Energy.Native(state, b0.Header().Timestamp()).Get(thor.Address{})
 			assert.Nil(t, err)
 
 			rt := runtime.New(repo.NewChain(b0.Header().ID()), state, &xenv.BlockContext{BaseFee: big.NewInt(thor.InitialBaseFee)}, &thor.ForkConfig{})
@@ -959,7 +959,7 @@ func TestNoRewards(t *testing.T) {
 			assert.False(t, receipt.Reverted)
 			assert.NotNil(t, receipt)
 
-			currentEndorserEnergy, err := state.GetEnergy(thor.Address{}, b0.Header().Timestamp()+10)
+			currentEndorserEnergy, err := builtin.Energy.Native(state, b0.Header().Timestamp()+10).Get(thor.Address{})
 			assert.Nil(t, err)
 
 			// Endorser gets no rewards
@@ -983,7 +983,7 @@ func TestExecuteTransactionPreHayabusa(t *testing.T) {
 
 	state := state.New(db, trie.Root{Hash: b0.Header().StateRoot()})
 
-	beneficiaryEnergyBalance, err := state.GetEnergy(beneficiary, b0.Header().Timestamp())
+	beneficiaryEnergyBalance, err := builtin.Energy.Native(state, b0.Header().Timestamp()).Get(beneficiary)
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(0), beneficiaryEnergyBalance)
 
@@ -1001,7 +1001,7 @@ func TestExecuteTransactionPreHayabusa(t *testing.T) {
 	}
 	_ = receipt
 
-	beneficiaryEnergyBalance, err = state.GetEnergy(beneficiary, b0.Header().Timestamp())
+	beneficiaryEnergyBalance, err = builtin.Energy.Native(state, b0.Header().Timestamp()).Get(beneficiary)
 	assert.NoError(t, err)
 	assert.Equal(t, receipt.Reward, beneficiaryEnergyBalance)
 
@@ -1023,7 +1023,7 @@ func TestExecuteTransactionAfterHayabusa(t *testing.T) {
 
 	state := state.New(db, trie.Root{Hash: b0.Header().StateRoot()})
 
-	beneficiaryEnergyBalance, err := state.GetEnergy(beneficiary, b0.Header().Timestamp())
+	beneficiaryEnergyBalance, err := builtin.Energy.Native(state, b0.Header().Timestamp()).Get(beneficiary)
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(0), beneficiaryEnergyBalance)
 
@@ -1045,7 +1045,7 @@ func TestExecuteTransactionAfterHayabusa(t *testing.T) {
 	}
 	_ = receipt
 
-	beneficiaryEnergyBalance, err = state.GetEnergy(beneficiary, b0.Header().Timestamp())
+	beneficiaryEnergyBalance, err = builtin.Energy.Native(state, b0.Header().Timestamp()).Get(beneficiary)
 	assert.NoError(t, err)
 	assert.Equal(t, receipt.Reward, beneficiaryEnergyBalance)
 }

--- a/state/account.go
+++ b/state/account.go
@@ -44,7 +44,7 @@ func (a *Account) IsEmpty() bool {
 var bigE18 = big.NewInt(1e18)
 
 // CalcEnergy calculates energy based on current block time.
-func (a *Account) CalcEnergy(blockTime uint64, hayabusaForkTime uint64) *big.Int {
+func (a *Account) CalcEnergy(blockTime uint64, stopTime uint64) *big.Int {
 	if a.BlockTime == 0 {
 		return a.Energy
 	}
@@ -58,18 +58,18 @@ func (a *Account) CalcEnergy(blockTime uint64, hayabusaForkTime uint64) *big.Int
 	}
 
 	growth := new(big.Int)
-	// If accounts last access block time is less than hayabusa fork time, calculate energy growth.
-	if a.BlockTime < hayabusaForkTime {
+	// If accounts last access block time is less than stop time, calculate energy growth.
+	if a.BlockTime < stopTime {
 		timeDiff := uint64(0)
-		// if current block time is less than hayabusa fork time, time diff is block time - account last access block time.
-		// the same as before hayabusa.
-		if blockTime <= hayabusaForkTime {
+		// if current block time is less than growth stop time, time diff is block time - account last access block time.
+		// the same as before growth stop.
+		if blockTime <= stopTime {
 			timeDiff = blockTime - a.BlockTime
 		} else {
-			// if current block time is greater than hayabusa fork time, we are taking the time diff only up to hayabusa block.
-			timeDiff = hayabusaForkTime - a.BlockTime
+			// if current block time is greater than growth stop time, we are taking the time diff only up to growth stop time.
+			timeDiff = stopTime - a.BlockTime
 		}
-		// the rest of calculation is same as before hayabusa.
+		// the rest of calculation is same as before growth stops.
 		growth.SetUint64(timeDiff)
 		growth.Mul(growth, a.Balance)
 		growth.Mul(growth, thor.EnergyGrowthRate)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -6,6 +6,7 @@
 package state
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
@@ -102,15 +103,26 @@ func TestEnergy(t *testing.T) {
 
 	acc := thor.BytesToAddress([]byte("a1"))
 
+	startTime := uint64(10)
 	time1 := uint64(1000)
 
 	vetBal := big.NewInt(1e18)
 	st.SetBalance(acc, vetBal)
-	st.SetEnergy(acc, &big.Int{}, 10)
+	st.SetEnergy(acc, &big.Int{}, startTime)
 
-	bal1, _ := st.GetEnergy(acc, time1)
+	bal1, _ := st.GetEnergy(acc, time1, math.MaxUint64)
 	x := new(big.Int).Mul(thor.EnergyGrowthRate, vetBal)
-	x.Mul(x, new(big.Int).SetUint64(time1-10))
+	x.Mul(x, new(big.Int).SetUint64(time1-startTime))
+	x.Div(x, big.NewInt(1e18))
+
+	assert.Equal(t, x, bal1)
+
+	// test stop energy growth
+	stopTime := uint64(20)
+	now := uint64(30)
+	bal1, _ = st.GetEnergy(acc, now, stopTime)
+	x = new(big.Int).Mul(thor.EnergyGrowthRate, vetBal)
+	x.Mul(x, new(big.Int).SetUint64(stopTime-startTime))
 	x.Div(x, big.NewInt(1e18))
 
 	assert.Equal(t, x, bal1)

--- a/thor/params.go
+++ b/thor/params.go
@@ -64,8 +64,6 @@ var (
 	InitialProposerEndorsement = new(big.Int).Mul(big.NewInt(1e18), big.NewInt(25000000))
 	InitialStargateAddress     = common.Address{}.Big()
 
-	HayabusaEnergyGrowthStopTime = BytesToBytes32([]byte("hayabusa-energy-growth-stop-time"))
-
 	EnergyGrowthRate = big.NewInt(5000000000) // WEI THOR per token(VET) per second. about 0.000432 THOR per token per day.
 
 	ScalingFactor         = big.NewInt(64)      // scaling factor for rewards curve

--- a/tracers/native/prestate.go
+++ b/tracers/native/prestate.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/tracers"
 	"github.com/vechain/thor/v2/vm"
@@ -142,7 +143,7 @@ func (t *prestateTracer) CaptureClauseEnd(_ uint64) {
 		newBalance := t.env.StateDB.GetBalance(addr)
 		newCode := t.env.StateDB.GetCode(addr)
 
-		energy, err := t.ctx.State.GetEnergy(thor.Address(addr), t.ctx.BlockTime)
+		energy, err := builtin.Energy.Native(t.ctx.State, t.ctx.BlockTime).Get(thor.Address(addr))
 		if err != nil {
 			// panic state errors, will be recovered by runtime
 			panic(err)
@@ -278,7 +279,7 @@ func (t *prestateTracer) lookupAccount(addr common.Address) {
 		return
 	}
 
-	energy, err := t.ctx.State.GetEnergy(thor.Address(addr), t.ctx.BlockTime)
+	energy, err := builtin.Energy.Native(t.ctx.State, t.ctx.BlockTime).Get(thor.Address(addr))
 	if err != nil {
 		// panic state errors, will be recovered by runtime
 		panic(err)

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/mclock"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/pkg/errors"
+	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/co"
 	"github.com/vechain/thor/v2/log"
@@ -284,7 +285,7 @@ func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmi
 		txObj.executable = executable
 		if err := p.all.Add(txObj, p.options.LimitPerAccount, func(payer thor.Address, needs *big.Int) error {
 			// check payer's balance
-			balance, err := state.GetEnergy(payer, headSummary.Header.Timestamp()+thor.BlockInterval)
+			balance, err := builtin.Energy.Native(state, headSummary.Header.Timestamp()+thor.BlockInterval).Get(payer)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Description

To have a clean view of `state`. And let `builtin.Energy.Native` to handle the energy growth stop.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
