### PR TITLE
fix: reduce aggregation pending weights on withdraw

### DIFF
--- a/builtin/solidity/uint256.go
+++ b/builtin/solidity/uint256.go
@@ -6,6 +6,7 @@
 package solidity
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/vechain/thor/v2/state"
@@ -33,9 +34,13 @@ func (u *Uint256) Get() (*big.Int, error) {
 	return new(big.Int).SetBytes(storage.Bytes()), nil
 }
 
-func (u *Uint256) Set(value *big.Int) {
+func (u *Uint256) Set(value *big.Int) error {
 	storage := thor.BytesToBytes32(value.Bytes())
+	if value.Sign() == -1 {
+		return errors.New("uint cannot be negative")
+	}
 	u.state.SetStorage(u.addr, u.pos, storage)
+	return nil
 }
 
 func (u *Uint256) Add(value *big.Int) error {
@@ -47,8 +52,7 @@ func (u *Uint256) Add(value *big.Int) error {
 		return err
 	}
 	storage.Add(storage, value)
-	u.Set(storage)
-	return nil
+	return u.Set(storage)
 }
 
 func (u *Uint256) Sub(value *big.Int) error {
@@ -60,6 +64,5 @@ func (u *Uint256) Sub(value *big.Int) error {
 		return err
 	}
 	storage.Sub(storage, value)
-	u.Set(storage)
-	return nil
+	return u.Set(storage)
 }

--- a/builtin/staker/delegations.go
+++ b/builtin/staker/delegations.go
@@ -71,7 +71,9 @@ func (d *delegations) Add(
 		return thor.Bytes32{}, err
 	}
 	id = id.Add(id, big.NewInt(1))
-	d.idCounter.Set(id)
+	if err := d.idCounter.Set(id); err != nil {
+		return thor.Bytes32{}, errors.Wrap(err, "failed to increment delegation ID counter")
+	}
 
 	delegationID := thor.BytesToBytes32(id.Bytes())
 
@@ -210,7 +212,7 @@ func (d *delegations) Withdraw(delegationID thor.Bytes32) (*big.Int, error) {
 		if aggregation.WithdrawableVET.Cmp(delegation.Stake) < 0 {
 			return nil, errors.New("not enough withdraw VET")
 		}
-		aggregation.WithdrawableVET = aggregation.WithdrawableVET.Sub(aggregation.WithdrawableVET, delegation.Stake)
+		aggregation.WithdrawableVET = big.NewInt(0).Sub(aggregation.WithdrawableVET, delegation.Stake)
 	} else {
 		if delegation.AutoRenew { // delegation's stake is pending locked
 			if aggregation.PendingRecurringVET.Cmp(delegation.Stake) < 0 {


### PR DESCRIPTION
# Description

fix: aggregations weights were not reduced, so validators total weight would be higher than they should be and never get reduced

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
