### PR TITLE
chore(bind): return structs instead of interfaces

### DIFF
--- a/thorclient/bind/bind_test.go
+++ b/thorclient/bind/bind_test.go
@@ -28,7 +28,7 @@ import (
 type testEnv struct {
 	t            *testing.T
 	client       *thorclient.Client
-	bindContract Contract
+	bindContract *Contract
 	owner        *PrivateKeySigner
 	user         *PrivateKeySigner
 	testNode     testnode.Node

--- a/thorclient/bind/contract.go
+++ b/thorclient/bind/contract.go
@@ -21,34 +21,14 @@ import (
 	"github.com/vechain/thor/v2/tx"
 )
 
-// Contract is the main interface for contract interactions.
-// It provides a unified entry point for all contract operations.
-type Contract interface {
-	// Method creates a new method builder for the specified method and arguments.
-	Method(method string, args ...any) MethodBuilder
-
-	// FilterEvent creates a new filter builder for the specified event.
-	FilterEvent(eventName string) FilterBuilder
-
-	// Address returns the contract address.
-	Address() *thor.Address
-
-	// ABI returns the contract ABI.
-	ABI() *abi.ABI
-
-	// Client returns the underlying client.
-	Client() *thorclient.Client
-}
-
-// contract is the concrete implementation of Contract.
-type contract struct {
+type Contract struct {
 	client *thorclient.Client
 	abi    *abi.ABI
 	addr   *thor.Address
 }
 
 // NewContract creates a new contract instance with the given client, ABI data and address.
-func NewContract(client *thorclient.Client, abiData []byte, address *thor.Address) (Contract, error) {
+func NewContract(client *thorclient.Client, abiData []byte, address *thor.Address) (*Contract, error) {
 	if address == nil {
 		return nil, fmt.Errorf("empty contract address")
 	}
@@ -56,7 +36,7 @@ func NewContract(client *thorclient.Client, abiData []byte, address *thor.Addres
 	if err != nil {
 		return nil, err
 	}
-	return &contract{
+	return &Contract{
 		client: client,
 		abi:    &contractABI,
 		addr:   address,
@@ -64,7 +44,7 @@ func NewContract(client *thorclient.Client, abiData []byte, address *thor.Addres
 }
 
 // DeployContract deploys a contract and creates a new contract instance with the given client, ABI data and address.
-func DeployContract(client *thorclient.Client, signer Signer, abiData []byte, bytecode string) (Contract, error) {
+func DeployContract(client *thorclient.Client, signer Signer, abiData []byte, bytecode string) (*Contract, error) {
 	bc, err := hexutil.Decode(bytecode)
 	if err != nil {
 		return nil, err
@@ -120,8 +100,8 @@ func DeployContract(client *thorclient.Client, signer Signer, abiData []byte, by
 }
 
 // Method implements Contract.Method.
-func (c *contract) Method(method string, args ...any) MethodBuilder {
-	return &methodBuilder{
+func (c *Contract) Method(method string, args ...any) *MethodBuilder {
+	return &MethodBuilder{
 		contract: c,
 		method:   method,
 		args:     args,
@@ -130,9 +110,9 @@ func (c *contract) Method(method string, args ...any) MethodBuilder {
 }
 
 // FilterEvent implements Contract.Event.
-func (c *contract) FilterEvent(eventName string) FilterBuilder {
-	return &filterBuilder{
-		op: &methodBuilder{
+func (c *Contract) FilterEvent(eventName string) *FilterBuilder {
+	return &FilterBuilder{
+		op: &MethodBuilder{
 			contract: c,
 			method:   eventName,
 		},
@@ -140,16 +120,16 @@ func (c *contract) FilterEvent(eventName string) FilterBuilder {
 }
 
 // Address returns the contract address.
-func (c *contract) Address() *thor.Address {
+func (c *Contract) Address() *thor.Address {
 	return c.addr
 }
 
 // ABI returns the contract ABI.
-func (c *contract) ABI() *abi.ABI {
+func (c *Contract) ABI() *abi.ABI {
 	return c.abi
 }
 
 // Client returns the underlying HTTP client.
-func (c *contract) Client() *thorclient.Client {
+func (c *Contract) Client() *thorclient.Client {
 	return c.client
 }

--- a/thorclient/bind/filter.go
+++ b/thorclient/bind/filter.go
@@ -9,54 +9,38 @@ import (
 	"errors"
 
 	"github.com/vechain/thor/v2/api"
-
 	"github.com/vechain/thor/v2/logdb"
 	"github.com/vechain/thor/v2/thor"
 )
 
-// FilterBuilder is the interface for event filtering.
-type FilterBuilder interface {
-	// InRange sets the range for event filtering.
-	InRange(r *api.Range) FilterBuilder
-
-	// WithOptions sets the filter options.
-	WithOptions(opts *api.Options) FilterBuilder
-
-	// OrderBy sets the order for event filtering.
-	OrderBy(order logdb.Order) FilterBuilder
-
-	// Execute performs the event filtering.
-	Execute() ([]api.FilteredEvent, error)
-}
-
-// filterBuilder is the concrete implementation of FilterBuilder.
-type filterBuilder struct {
-	op      *methodBuilder
+// FilterBuilder is the concrete implementation of FilterBuilder.
+type FilterBuilder struct {
+	op      *MethodBuilder
 	evRange *api.Range
 	opts    *api.Options
 	order   logdb.Order
 }
 
 // InRange implements FilterBuilder.InRange.
-func (b *filterBuilder) InRange(r *api.Range) FilterBuilder {
+func (b *FilterBuilder) InRange(r *api.Range) *FilterBuilder {
 	b.evRange = r
 	return b
 }
 
 // WithOptions implements FilterBuilder.WithOptions.
-func (b *filterBuilder) WithOptions(opts *api.Options) FilterBuilder {
+func (b *FilterBuilder) WithOptions(opts *api.Options) *FilterBuilder {
 	b.opts = opts
 	return b
 }
 
 // OrderBy implements FilterBuilder.OrderBy.
-func (b *filterBuilder) OrderBy(order logdb.Order) FilterBuilder {
+func (b *FilterBuilder) OrderBy(order logdb.Order) *FilterBuilder {
 	b.order = order
 	return b
 }
 
 // Execute implements FilterBuilder.Execute.
-func (b *filterBuilder) Execute() ([]api.FilteredEvent, error) {
+func (b *FilterBuilder) Execute() ([]api.FilteredEvent, error) {
 	event, ok := b.op.contract.abi.Events[b.op.method]
 	if !ok {
 		return nil, errors.New("event not found: " + b.op.method)

--- a/thorclient/bind/method.go
+++ b/thorclient/bind/method.go
@@ -13,51 +13,35 @@ import (
 	"github.com/vechain/thor/v2/tx"
 )
 
-// MethodBuilder is the interface that routes to specific operation types.
-type MethodBuilder interface {
-	// WithValue sets the VET value for the operation.
-	WithValue(vet *big.Int) MethodBuilder
-
-	// Call returns a CallBuilder for read operations.
-	Call() CallBuilder
-
-	// Send returns a SendBuilder for write operations.
-	Send() SendBuilder
-
-	// Clause returns a ClauseBuilder for building transaction clauses.
-	Clause() (*tx.Clause, error)
-}
-
-// methodBuilder is the concrete implementation of MethodBuilder.
-type methodBuilder struct {
-	contract *contract
+type MethodBuilder struct {
+	contract *Contract
 	method   string
 	args     []any
 	vet      *big.Int
 }
 
 // WithValue implements MethodBuilder.WithValue.
-func (b *methodBuilder) WithValue(vet *big.Int) MethodBuilder {
+func (b *MethodBuilder) WithValue(vet *big.Int) *MethodBuilder {
 	b.vet = vet
 	return b
 }
 
 // Call implements MethodBuilder.Call.
-func (b *methodBuilder) Call() CallBuilder {
-	return &callBuilder{
+func (b *MethodBuilder) Call() *CallBuilder {
+	return &CallBuilder{
 		op: b,
 	}
 }
 
 // Send implements MethodBuilder.Send.
-func (b *methodBuilder) Send() SendBuilder {
-	return &sendBuilder{
+func (b *MethodBuilder) Send() *SendBuilder {
+	return &SendBuilder{
 		op: b,
 	}
 }
 
 // Clause implements Clause build.
-func (b *methodBuilder) Clause() (*tx.Clause, error) {
+func (b *MethodBuilder) Clause() (*tx.Clause, error) {
 	method, ok := b.contract.abi.Methods[b.method]
 	if !ok {
 		return nil, fmt.Errorf("method not found: %s", b.method)

--- a/thorclient/builtin/authority.go
+++ b/thorclient/builtin/authority.go
@@ -8,9 +8,8 @@ package builtin
 import (
 	"fmt"
 
-	"github.com/vechain/thor/v2/api"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/vechain/thor/v2/api"
 	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/logdb"
 	"github.com/vechain/thor/v2/thor"
@@ -19,7 +18,7 @@ import (
 )
 
 type Authority struct {
-	contract bind.Contract
+	contract *bind.Contract
 	revision string
 }
 
@@ -41,7 +40,7 @@ func (a *Authority) Revision(rev string) *Authority {
 	}
 }
 
-func (a *Authority) Raw() bind.Contract {
+func (a *Authority) Raw() *bind.Contract {
 	return a.contract
 }
 
@@ -103,12 +102,12 @@ func (a *Authority) Get(nodeMaster thor.Address) (*AuthorityNode, error) {
 }
 
 // Add adds a new authority node
-func (a *Authority) Add(nodeMaster, endorsor thor.Address, identity thor.Bytes32) bind.MethodBuilder {
+func (a *Authority) Add(nodeMaster, endorsor thor.Address, identity thor.Bytes32) *bind.MethodBuilder {
 	return a.contract.Method("add", common.Address(nodeMaster), common.Address(endorsor), common.Hash(identity))
 }
 
 // Revoke revokes an authority node
-func (a *Authority) Revoke(nodeMaster thor.Address) bind.MethodBuilder {
+func (a *Authority) Revoke(nodeMaster thor.Address) *bind.MethodBuilder {
 	return a.contract.Method("revoke", common.Address(nodeMaster))
 }
 

--- a/thorclient/builtin/energy.go
+++ b/thorclient/builtin/energy.go
@@ -10,9 +10,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/vechain/thor/v2/api"
-
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/vechain/thor/v2/api"
 	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/logdb"
 	"github.com/vechain/thor/v2/thor"
@@ -22,7 +21,7 @@ import (
 
 // Energy is a type-safe smart contract wrapper of VTHO.
 type Energy struct {
-	contract bind.Contract
+	contract *bind.Contract
 	revision string
 }
 
@@ -44,7 +43,7 @@ func (e *Energy) Revision(rev string) *Energy {
 	}
 }
 
-func (e *Energy) Raw() bind.Contract {
+func (e *Energy) Raw() *bind.Contract {
 	return e.contract
 }
 
@@ -112,22 +111,22 @@ func (e *Energy) Allowance(owner, spender thor.Address) (*big.Int, error) {
 }
 
 // Transfer transfers tokens to the specified address
-func (e *Energy) Transfer(to thor.Address, amount *big.Int) bind.MethodBuilder {
+func (e *Energy) Transfer(to thor.Address, amount *big.Int) *bind.MethodBuilder {
 	return e.contract.Method("transfer", to, amount)
 }
 
 // TransferFrom transfers tokens from one address to another
-func (e *Energy) TransferFrom(from, to thor.Address, amount *big.Int) bind.MethodBuilder {
+func (e *Energy) TransferFrom(from, to thor.Address, amount *big.Int) *bind.MethodBuilder {
 	return e.contract.Method("transferFrom", from, to, amount)
 }
 
 // Approve approves the spender to spend the specified amount of tokens
-func (e *Energy) Approve(spender thor.Address, amount *big.Int) bind.MethodBuilder {
+func (e *Energy) Approve(spender thor.Address, amount *big.Int) *bind.MethodBuilder {
 	return e.contract.Method("approve", spender, amount)
 }
 
 // Move transfers tokens from one address to another (alias for transferFrom)
-func (e *Energy) Move(from, to thor.Address, amount *big.Int) bind.MethodBuilder {
+func (e *Energy) Move(from, to thor.Address, amount *big.Int) *bind.MethodBuilder {
 	return e.contract.Method("move", from, to, amount)
 }
 

--- a/thorclient/builtin/executor.go
+++ b/thorclient/builtin/executor.go
@@ -8,9 +8,8 @@ package builtin
 import (
 	"fmt"
 
-	"github.com/vechain/thor/v2/api"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/vechain/thor/v2/api"
 	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/logdb"
 	"github.com/vechain/thor/v2/thor"
@@ -19,7 +18,7 @@ import (
 )
 
 type Executor struct {
-	contract bind.Contract
+	contract *bind.Contract
 	revision string
 }
 
@@ -41,7 +40,7 @@ func (e *Executor) Revision(rev string) *Executor {
 	}
 }
 
-func (e *Executor) Raw() bind.Contract {
+func (e *Executor) Raw() *bind.Contract {
 	return e.contract
 }
 
@@ -108,31 +107,31 @@ func (e *Executor) ApproverCount() (uint8, error) {
 	return count, nil
 }
 
-func (e *Executor) Propose(target thor.Address, data []byte) bind.MethodBuilder {
+func (e *Executor) Propose(target thor.Address, data []byte) *bind.MethodBuilder {
 	return e.contract.Method("propose", target, data)
 }
 
-func (e *Executor) Approve(proposalID thor.Bytes32) bind.MethodBuilder {
+func (e *Executor) Approve(proposalID thor.Bytes32) *bind.MethodBuilder {
 	return e.contract.Method("approve", proposalID)
 }
 
-func (e *Executor) Execute(proposalID thor.Bytes32) bind.MethodBuilder {
+func (e *Executor) Execute(proposalID thor.Bytes32) *bind.MethodBuilder {
 	return e.contract.Method("execute", proposalID)
 }
 
-func (e *Executor) AddApprover(address thor.Address, identity thor.Bytes32) bind.MethodBuilder {
+func (e *Executor) AddApprover(address thor.Address, identity thor.Bytes32) *bind.MethodBuilder {
 	return e.contract.Method("addApprover", address, identity)
 }
 
-func (e *Executor) RevokeApprover(address thor.Address) bind.MethodBuilder {
+func (e *Executor) RevokeApprover(address thor.Address) *bind.MethodBuilder {
 	return e.contract.Method("revokeApprover", address)
 }
 
-func (e *Executor) AttachVotingContract(votingContract thor.Address) bind.MethodBuilder {
+func (e *Executor) AttachVotingContract(votingContract thor.Address) *bind.MethodBuilder {
 	return e.contract.Method("attachVotingContract", votingContract)
 }
 
-func (e *Executor) DetachVotingContract(votingContract thor.Address) bind.MethodBuilder {
+func (e *Executor) DetachVotingContract(votingContract thor.Address) *bind.MethodBuilder {
 	return e.contract.Method("detachVotingContract", votingContract)
 }
 

--- a/thorclient/builtin/params.go
+++ b/thorclient/builtin/params.go
@@ -9,9 +9,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/vechain/thor/v2/api"
-
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/vechain/thor/v2/api"
 	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/logdb"
 	"github.com/vechain/thor/v2/thor"
@@ -20,7 +19,7 @@ import (
 )
 
 type Params struct {
-	contract bind.Contract
+	contract *bind.Contract
 	revision string
 }
 
@@ -42,11 +41,11 @@ func (p *Params) Revision(rev string) *Params {
 	}
 }
 
-func (p *Params) Raw() bind.Contract {
+func (p *Params) Raw() *bind.Contract {
 	return p.contract
 }
 
-func (p *Params) Set(key thor.Bytes32, value *big.Int) bind.MethodBuilder {
+func (p *Params) Set(key thor.Bytes32, value *big.Int) *bind.MethodBuilder {
 	return p.contract.Method("set", key, value)
 }
 

--- a/thorclient/builtin/prototype.go
+++ b/thorclient/builtin/prototype.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Prototype struct {
-	contract bind.Contract
+	contract *bind.Contract
 	revision string
 }
 
@@ -39,7 +39,7 @@ func (p *Prototype) Revision(rev string) *Prototype {
 	}
 }
 
-func (p *Prototype) Raw() bind.Contract {
+func (p *Prototype) Raw() *bind.Contract {
 	return p.contract
 }
 
@@ -53,7 +53,7 @@ func (p *Prototype) Master(contract thor.Address) (thor.Address, error) {
 }
 
 // SetMaster sets a new master for the contract
-func (p *Prototype) SetMaster(self thor.Address, newMaster thor.Address) bind.MethodBuilder {
+func (p *Prototype) SetMaster(self thor.Address, newMaster thor.Address) *bind.MethodBuilder {
 	return p.contract.Method("setMaster", self, newMaster)
 }
 
@@ -67,12 +67,12 @@ func (p *Prototype) IsUser(self thor.Address, user thor.Address) (bool, error) {
 }
 
 // AddUser adds a user to the contract
-func (p *Prototype) AddUser(self thor.Address, user thor.Address) bind.MethodBuilder {
+func (p *Prototype) AddUser(self thor.Address, user thor.Address) *bind.MethodBuilder {
 	return p.contract.Method("addUser", self, user)
 }
 
 // RemoveUser removes a user from the contract
-func (p *Prototype) RemoveUser(self thor.Address, user thor.Address) bind.MethodBuilder {
+func (p *Prototype) RemoveUser(self thor.Address, user thor.Address) *bind.MethodBuilder {
 	return p.contract.Method("removeUser", self, user)
 }
 
@@ -97,7 +97,7 @@ func (p *Prototype) CreditPlan(self thor.Address) (*big.Int, *big.Int, error) {
 }
 
 // SetCreditPlan sets the credit plan for the contract
-func (p *Prototype) SetCreditPlan(self thor.Address, credit *big.Int, recoveryRate *big.Int) bind.MethodBuilder {
+func (p *Prototype) SetCreditPlan(self thor.Address, credit *big.Int, recoveryRate *big.Int) *bind.MethodBuilder {
 	return p.contract.Method("setCreditPlan", self, credit, recoveryRate)
 }
 
@@ -120,17 +120,17 @@ func (p *Prototype) IsSponsor(self thor.Address, sponsor thor.Address) (bool, er
 }
 
 // SelectSponsor selects a sponsor for the contract
-func (p *Prototype) SelectSponsor(self thor.Address, sponsor thor.Address) bind.MethodBuilder {
+func (p *Prototype) SelectSponsor(self thor.Address, sponsor thor.Address) *bind.MethodBuilder {
 	return p.contract.Method("selectSponsor", self, sponsor)
 }
 
 // Sponsor sponsors the contract
-func (p *Prototype) Sponsor(self thor.Address) bind.MethodBuilder {
+func (p *Prototype) Sponsor(self thor.Address) *bind.MethodBuilder {
 	return p.contract.Method("sponsor", self)
 }
 
 // Unsponsor removes sponsorship from the contract
-func (p *Prototype) Unsponsor(self thor.Address) bind.MethodBuilder {
+func (p *Prototype) Unsponsor(self thor.Address) *bind.MethodBuilder {
 	return p.contract.Method("unsponsor", self)
 }
 

--- a/thorclient/builtin/staker.go
+++ b/thorclient/builtin/staker.go
@@ -219,7 +219,7 @@ func (s *Staker) DecreaseStake(validationID thor.Bytes32, amount *big.Int) *bind
 	return s.contract.Method("decreaseStake", validationID, amount)
 }
 
-func (s *Staker) IncreaseStake(validationID thor.Bytes32, amount *big.Int)* bind.MethodBuilder {
+func (s *Staker) IncreaseStake(validationID thor.Bytes32, amount *big.Int) *bind.MethodBuilder {
 	return s.contract.Method("increaseStake", validationID).WithValue(amount)
 }
 

--- a/thorclient/builtin/staker.go
+++ b/thorclient/builtin/staker.go
@@ -37,7 +37,7 @@ func MinStake() *big.Int {
 }
 
 type Staker struct {
-	contract bind.Contract
+	contract *bind.Contract
 	revision string
 }
 
@@ -74,7 +74,7 @@ func (s *Staker) FirstActive() (*Validator, thor.Bytes32, error) {
 	return v, id, err
 }
 
-func (s *Staker) Raw() bind.Contract {
+func (s *Staker) Raw() *bind.Contract {
 	return s.contract
 }
 
@@ -191,35 +191,35 @@ func (s *Staker) Get(id thor.Bytes32) (*Validator, error) {
 	return validator, nil
 }
 
-func (s *Staker) AddValidator(master thor.Address, stake *big.Int, period uint32, autoRenew bool) bind.MethodBuilder {
+func (s *Staker) AddValidator(master thor.Address, stake *big.Int, period uint32, autoRenew bool) *bind.MethodBuilder {
 	return s.contract.Method("addValidator", master, period, autoRenew).WithValue(stake)
 }
 
-func (s *Staker) AddDelegation(validationID thor.Bytes32, stake *big.Int, autoRenew bool, multiplier uint8) bind.MethodBuilder {
+func (s *Staker) AddDelegation(validationID thor.Bytes32, stake *big.Int, autoRenew bool, multiplier uint8) *bind.MethodBuilder {
 	return s.contract.Method("addDelegation", validationID, autoRenew, multiplier).WithValue(stake)
 }
 
-func (s *Staker) UpdateDelegationAutoRenew(delegationID thor.Bytes32, autoRenew bool) bind.MethodBuilder {
+func (s *Staker) UpdateDelegationAutoRenew(delegationID thor.Bytes32, autoRenew bool) *bind.MethodBuilder {
 	return s.contract.Method("updateDelegationAutoRenew", delegationID, autoRenew)
 }
 
-func (s *Staker) UpdateAutoRenew(validationID thor.Bytes32, autoRenew bool) bind.MethodBuilder {
+func (s *Staker) UpdateAutoRenew(validationID thor.Bytes32, autoRenew bool) *bind.MethodBuilder {
 	return s.contract.Method("updateAutoRenew", validationID, autoRenew)
 }
 
-func (s *Staker) WithdrawDelegation(delegationID thor.Bytes32) bind.MethodBuilder {
+func (s *Staker) WithdrawDelegation(delegationID thor.Bytes32) *bind.MethodBuilder {
 	return s.contract.Method("withdrawDelegation", delegationID)
 }
 
-func (s *Staker) Withdraw(validationID thor.Bytes32) bind.MethodBuilder {
+func (s *Staker) Withdraw(validationID thor.Bytes32) *bind.MethodBuilder {
 	return s.contract.Method("withdraw", validationID)
 }
 
-func (s *Staker) DecreaseStake(validationID thor.Bytes32, amount *big.Int) bind.MethodBuilder {
+func (s *Staker) DecreaseStake(validationID thor.Bytes32, amount *big.Int) *bind.MethodBuilder {
 	return s.contract.Method("decreaseStake", validationID, amount)
 }
 
-func (s *Staker) IncreaseStake(validationID thor.Bytes32, amount *big.Int) bind.MethodBuilder {
+func (s *Staker) IncreaseStake(validationID thor.Bytes32, amount *big.Int)* bind.MethodBuilder {
 	return s.contract.Method("increaseStake", validationID).WithValue(amount)
 }
 

--- a/thorclient/builtin/staker_test.go
+++ b/thorclient/builtin/staker_test.go
@@ -36,7 +36,7 @@ func TestStaker(t *testing.T) {
 	require.NoError(t, err)
 
 	// set authorities - required for initial staker setup
-	var authorityTxs []bind.SendBuilder
+	var authorityTxs []*bind.SendBuilder
 	executor := bind.NewSigner(genesis.DevAccounts()[0].PrivateKey)
 	stargate := bind.NewSigner(genesis.DevAccounts()[0].PrivateKey)
 	for _, acc := range genesis.DevAccounts()[1:] {


### PR DESCRIPTION
# Description

bind -> return structs instead of interfaces (https://bryanftan.medium.com/accept-interfaces-return-structs-in-go-d4cab29a301b)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
