### PR TITLE
fix: reject delegation renew changes for exited validations

### DIFF
--- a/builtin/staker/delegations.go
+++ b/builtin/staker/delegations.go
@@ -115,6 +115,9 @@ func (d *delegations) DisableAutoRenew(delegationID thor.Bytes32) error {
 	if delegation.Stake.Sign() == 0 {
 		return errors.New("delegation is not active")
 	}
+	if validation.Status == StatusExit {
+		return errors.New("delegation is not active, withdraw is available")
+	}
 
 	weight := delegation.Weight()
 
@@ -157,6 +160,9 @@ func (d *delegations) EnableAutoRenew(delegationID thor.Bytes32) error {
 	}
 	if delegation.AutoRenew {
 		return errors.New("delegation is already autoRenew")
+	}
+	if validation.Status == StatusExit {
+		return errors.New("delegation is not active, withdraw is available")
 	}
 	weight := delegation.Weight()
 


### PR DESCRIPTION
# Description

Fix: disallow changes to aggregations when validations status is exited. It corrupts the state since exited aggregations move all funds to `WithdrawableVET`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
