### PR TITLE
Cleanup staker ops

### DIFF
--- a/builtin/staker/aggregation/aggregation.go
+++ b/builtin/staker/aggregation/aggregation.go
@@ -51,12 +51,8 @@ func (a *Aggregation) IsEmpty() bool {
 
 // NextPeriodTVL is the total value locked (TVL) for the next period.
 // It is the sum of the currently recurring VET, plus any pending recurring and one-time VET.
-// Does not include CurrentOneTimeVET since that stake is due to withdraw.
 func (a *Aggregation) NextPeriodTVL() *big.Int {
-	nextTVL := big.NewInt(0)
-	nextTVL.Add(nextTVL, a.LockedVET)
-	nextTVL.Add(nextTVL, a.PendingVET)
-	return nextTVL
+	return big.NewInt(0).Add(a.LockedVET, a.PendingVET)
 }
 
 // renew transitions delegations to the next staking period.

--- a/builtin/staker/delegations_test.go
+++ b/builtin/staker/delegations_test.go
@@ -158,7 +158,7 @@ func Test_AddDelegator_StakeRange(t *testing.T) {
 
 	// should NOT be able to stake greater than max stake
 	_, err = staker.AddDelegation(validators[1].ID, MaxStake, 255)
-	assert.ErrorContains(t, err, "validation's next period stake exceeds max stake")
+	assert.ErrorContains(t, err, "stake is out of range")
 
 	// should be able stake 1 VET
 	id1, err := staker.AddDelegation(validators[2].ID, big.NewInt(1), 255)
@@ -180,14 +180,14 @@ func Test_AddDelegator_StakeRange(t *testing.T) {
 
 	// should not be able to stake more than max stake
 	_, err = staker.AddDelegation(validator.ID, big.NewInt(1000000000000000000), 255)
-	assert.ErrorContains(t, err, "validation's next period stake exceeds max stake")
+	assert.ErrorContains(t, err, "stake is out of range")
 }
 
 func Test_AddDelegator_ValidatorNotFound(t *testing.T) {
 	staker, _ := newStaker(t, 75, 101, true)
 
 	_, err := staker.AddDelegation(thor.Address{}, delegationStake(), 255)
-	assert.ErrorContains(t, err, "validation not found")
+	assert.ErrorContains(t, err, "failed to get validator")
 }
 
 func Test_AddDelegator_ManyValidators(t *testing.T) {

--- a/builtin/staker/validation/service.go
+++ b/builtin/staker/validation/service.go
@@ -305,7 +305,7 @@ func (s *Service) WithdrawStake(endorsor thor.Address, id thor.Address, currentB
 			return nil, err
 		}
 	}
-	// remove any que
+	// remove any queued
 	if val.QueuedVET.Sign() > 0 {
 		val.QueuedVET = big.NewInt(0)
 	}

--- a/builtin/staker/validation/validation.go
+++ b/builtin/staker/validation/validation.go
@@ -30,11 +30,11 @@ type Validation struct {
 	StartBlock         uint32       // the block number when the validation started the first staking period
 	ExitBlock          *uint32      `rlp:"nil"` // the block number when the validation moved to cooldown
 
-	LockedVET          *big.Int // the amount of VET locked for the current staking period, for the validator only
-	NextPeriodDecrease *big.Int // the amount of VET that will be unlocked in the next staking period. DOES NOT contribute to the TVL
-	PendingLocked      *big.Int // the amount of VET that will be locked in the next staking period
-	CooldownVET        *big.Int // the amount of VET that is locked into the validation's cooldown
-	WithdrawableVET    *big.Int // the amount of VET that is currently withdrawable
+	LockedVET        *big.Int // the amount of VET locked for the current staking period, for the validator only
+	PendingUnlockVET *big.Int // the amount of VET that will be unlocked in the next staking period. DOES NOT contribute to the TVL
+	QueuedVET        *big.Int // the amount of VET queued to be locked in the next staking period
+	CooldownVET      *big.Int // the amount of VET that is locked into the validation's cooldown
+	WithdrawableVET  *big.Int // the amount of VET that is currently withdrawable
 
 	Weight *big.Int // LockedVET x2 + total weight from delegators
 
@@ -62,8 +62,8 @@ func (v *Validation) IsPeriodEnd(current uint32) bool {
 
 // NextPeriodTVL returns the amount of VET that will be locked in the next staking period for the validator only.
 func (v *Validation) NextPeriodTVL() *big.Int {
-	validationTotal := big.NewInt(0).Add(v.LockedVET, v.PendingLocked)
-	validationTotal = big.NewInt(0).Sub(validationTotal, v.NextPeriodDecrease)
+	validationTotal := big.NewInt(0).Add(v.LockedVET, v.QueuedVET)
+	validationTotal = big.NewInt(0).Sub(validationTotal, v.PendingUnlockVET)
 	return validationTotal
 }
 
@@ -75,21 +75,21 @@ func (v *Validation) CurrentIteration() uint32 {
 }
 
 // Renew moves the stakes and weights around as follows:
-// 1. Move PendingLocked => Locked
-// 2. Decrease LockedVET by NextPeriodDecrease
-// 3. Increase WithdrawableVET by NextPeriodDecrease
-// 4. Set PendingLocked to 0
-// 5. Set NextPeriodDecrease to 0
+// 1. Move QueuedVET => Locked
+// 2. Decrease LockedVET by PendingUnlockVET
+// 3. Increase WithdrawableVET by PendingUnlockVET
+// 4. Set QueuedVET to 0
+// 5. Set PendingUnlockVET to 0
 func (v *Validation) Renew() *delta.Renewal {
 	newLockedVET := big.NewInt(0)
 
-	newLockedVET.Add(newLockedVET, v.PendingLocked)
-	newLockedVET.Sub(newLockedVET, v.NextPeriodDecrease)
+	newLockedVET.Add(newLockedVET, v.QueuedVET)
+	newLockedVET.Sub(newLockedVET, v.PendingUnlockVET)
 
-	queuedDecrease := big.NewInt(0).Set(v.PendingLocked)
-	v.WithdrawableVET = big.NewInt(0).Add(v.WithdrawableVET, v.NextPeriodDecrease)
-	v.PendingLocked = big.NewInt(0)
-	v.NextPeriodDecrease = big.NewInt(0)
+	queuedDecrease := big.NewInt(0).Set(v.QueuedVET)
+	v.WithdrawableVET = big.NewInt(0).Add(v.WithdrawableVET, v.PendingUnlockVET)
+	v.QueuedVET = big.NewInt(0)
+	v.PendingUnlockVET = big.NewInt(0)
 
 	// Apply x2 multiplier for validation's stake
 	newLockedWeight := big.NewInt(0).Mul(newLockedVET, pkgValidatorWeightMultiplier)

--- a/builtin/staker/validation/validation.go
+++ b/builtin/staker/validation/validation.go
@@ -104,3 +104,19 @@ func (v *Validation) Renew() *delta.Renewal {
 		QueuedDecreaseWeight: queuedDecreaseWeight,
 	}
 }
+
+// CalculateWithdrawableVET returns the validator withdrawable amount for a given block + period
+func (v *Validation) CalculateWithdrawableVET(currentBlock uint32, cooldownPeriod uint32) *big.Int {
+	withdrawAmount := big.NewInt(0).Set(v.WithdrawableVET)
+
+	// validator has exited and waited for the cooldown period
+	if v.ExitBlock != nil && *v.ExitBlock+cooldownPeriod <= currentBlock {
+		withdrawAmount = withdrawAmount.Add(withdrawAmount, v.CooldownVET)
+	}
+
+	if v.QueuedVET.Sign() > 0 {
+		withdrawAmount = withdrawAmount.Add(withdrawAmount, v.QueuedVET)
+	}
+
+	return withdrawAmount
+}

--- a/builtin/staker/validations_test.go
+++ b/builtin/staker/validations_test.go
@@ -347,7 +347,7 @@ func TestStaker_AddValidator(t *testing.T) {
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.False(t, validator.IsEmpty())
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
 	err = staker.AddValidator(addr2, addr2, uint32(360)*24*15, stake)
@@ -356,7 +356,7 @@ func TestStaker_AddValidator(t *testing.T) {
 	validator, err = staker.Get(addr2)
 	assert.NoError(t, err)
 	assert.False(t, validator.IsEmpty())
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
 	err = staker.AddValidator(addr3, addr3, uint32(360)*24*30, stake)
@@ -365,7 +365,7 @@ func TestStaker_AddValidator(t *testing.T) {
 	validator, err = staker.Get(addr2)
 	assert.NoError(t, err)
 	assert.False(t, validator.IsEmpty())
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
 	err = staker.AddValidator(addr4, addr4, uint32(360)*24*14, stake)
@@ -391,7 +391,7 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.False(t, validator.IsEmpty())
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
 	_, _, err = staker.Housekeep(180)
@@ -408,7 +408,7 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	validator, err = staker.Get(addr2)
 	assert.NoError(t, err)
 	assert.False(t, validator.IsEmpty())
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
 	err = staker.AddValidator(addr3, addr3, uint32(360)*24*30, stake)
@@ -417,7 +417,7 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	validator, err = staker.Get(addr3)
 	assert.NoError(t, err)
 	assert.False(t, validator.IsEmpty())
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
 	err = staker.AddValidator(addr4, addr4, uint32(360)*24*14, stake)
@@ -469,7 +469,7 @@ func TestStaker_Get(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.False(t, validator.IsEmpty())
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
 	_, err = staker.ActivateNextValidator(0, getTestMaxLeaderSize(staker.params))
@@ -500,7 +500,7 @@ func TestStaker_Get_FullFlow_Renewal_Off(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	// activate the validator
@@ -553,7 +553,7 @@ func TestStaker_WithdrawQueued(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	// verify queued
@@ -587,7 +587,7 @@ func TestStaker_IncreaseQueued(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	// increase stake queued
@@ -596,13 +596,13 @@ func TestStaker_IncreaseQueued(t *testing.T) {
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
-	newAmount := big.NewInt(0).Add(validator.PendingLocked, validator.LockedVET)
+	newAmount := big.NewInt(0).Add(validator.QueuedVET, validator.LockedVET)
 	assert.Equal(t, newAmount, expectedStake)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
 	assert.False(t, validator.IsEmpty())
 	assert.Equal(t, validator.Status, validation.StatusQueued)
-	assert.Equal(t, validator.PendingLocked, expectedStake)
+	assert.Equal(t, validator.QueuedVET, expectedStake)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 }
 
@@ -623,7 +623,7 @@ func TestStaker_IncreaseQueued_Order(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	err = staker.AddValidator(addr1, addr1, uint32(360)*24*15, stake)
@@ -632,7 +632,7 @@ func TestStaker_IncreaseQueued_Order(t *testing.T) {
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	err = staker.AddValidator(addr2, addr2, uint32(360)*24*15, stake)
@@ -641,7 +641,7 @@ func TestStaker_IncreaseQueued_Order(t *testing.T) {
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	// verify order
@@ -661,7 +661,7 @@ func TestStaker_IncreaseQueued_Order(t *testing.T) {
 	assert.Equal(t, *queued, addr)
 	entry, err := staker.Get(*queued)
 	assert.NoError(t, err)
-	assert.Equal(t, stake, entry.PendingLocked)
+	assert.Equal(t, stake, entry.QueuedVET)
 	assert.Equal(t, big.NewInt(0), entry.Weight)
 
 	queuedAddr, err := staker.Next(*queued)
@@ -669,7 +669,7 @@ func TestStaker_IncreaseQueued_Order(t *testing.T) {
 	assert.Equal(t, queuedAddr, addr1)
 	entry, err = staker.Get(queuedAddr)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedIncreaseStake, entry.PendingLocked)
+	assert.Equal(t, expectedIncreaseStake, entry.QueuedVET)
 	assert.Equal(t, big.NewInt(0), entry.Weight)
 
 	queuedAddr, err = staker.Next(queuedAddr)
@@ -677,7 +677,7 @@ func TestStaker_IncreaseQueued_Order(t *testing.T) {
 	assert.Equal(t, queuedAddr, addr2)
 	entry, err = staker.Get(queuedAddr)
 	assert.NoError(t, err)
-	assert.Equal(t, stake, entry.PendingLocked)
+	assert.Equal(t, stake, entry.QueuedVET)
 	assert.Equal(t, big.NewInt(0), entry.Weight)
 }
 
@@ -698,7 +698,7 @@ func TestStaker_DecreaseQueued_Order(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	err = staker.AddValidator(addr1, addr1, uint32(360)*24*15, stake)
@@ -707,7 +707,7 @@ func TestStaker_DecreaseQueued_Order(t *testing.T) {
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	err = staker.AddValidator(addr2, addr2, uint32(360)*24*15, stake)
@@ -716,7 +716,7 @@ func TestStaker_DecreaseQueued_Order(t *testing.T) {
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	// verify order
@@ -737,14 +737,14 @@ func TestStaker_DecreaseQueued_Order(t *testing.T) {
 	assert.Equal(t, *queued, addr)
 	entry, err := staker.Get(*queued)
 	assert.NoError(t, err)
-	assert.Equal(t, stake, entry.PendingLocked)
+	assert.Equal(t, stake, entry.QueuedVET)
 	assert.Equal(t, big.NewInt(0), entry.Weight)
 	next, err := staker.Next(*queued)
 	assert.NoError(t, err)
 	assert.Equal(t, next, addr1)
 	entry, err = staker.Get(next)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedDecreaseStake, entry.PendingLocked)
+	assert.Equal(t, expectedDecreaseStake, entry.QueuedVET)
 	assert.Equal(t, big.NewInt(0), entry.Weight)
 
 	next, err = staker.Next(next)
@@ -752,7 +752,7 @@ func TestStaker_DecreaseQueued_Order(t *testing.T) {
 	assert.Equal(t, next, addr2)
 	entry, err = staker.Get(next)
 	assert.NoError(t, err)
-	assert.Equal(t, stake, entry.PendingLocked)
+	assert.Equal(t, stake, entry.QueuedVET)
 	assert.Equal(t, big.NewInt(0), entry.Weight)
 }
 
@@ -779,12 +779,12 @@ func TestStaker_IncreaseActive(t *testing.T) {
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
-	newStake := big.NewInt(0).Add(validator.PendingLocked, validator.LockedVET)
+	newStake := big.NewInt(0).Add(validator.QueuedVET, validator.LockedVET)
 	assert.Equal(t, expectedStake, newStake)
 
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedStake, big.NewInt(0).Add(validator.LockedVET, validator.PendingLocked))
+	assert.Equal(t, expectedStake, big.NewInt(0).Add(validator.LockedVET, validator.QueuedVET))
 	assert.Equal(t, big.NewInt(0).Mul(validator.LockedVET, big.NewInt(2)), validator.Weight)
 
 	// verify withdraw amount decrease
@@ -818,7 +818,7 @@ func TestStaker_ChangeStakeActiveValidatorWithQueued(t *testing.T) {
 	validator2, err := staker.Get(addr2)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator2.Status)
-	assert.Equal(t, stake, validator2.PendingLocked)
+	assert.Equal(t, stake, validator2.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator2.Weight)
 	queuedVET, queuedWeight, err := staker.QueuedStake()
 	assert.NoError(t, err)
@@ -831,7 +831,7 @@ func TestStaker_ChangeStakeActiveValidatorWithQueued(t *testing.T) {
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
-	newStake := big.NewInt(0).Add(validator.PendingLocked, validator.LockedVET)
+	newStake := big.NewInt(0).Add(validator.QueuedVET, validator.LockedVET)
 	assert.Equal(t, expectedStake, newStake)
 
 	// the queued stake also increases
@@ -842,7 +842,7 @@ func TestStaker_ChangeStakeActiveValidatorWithQueued(t *testing.T) {
 
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedStake, big.NewInt(0).Add(validator.LockedVET, validator.PendingLocked))
+	assert.Equal(t, expectedStake, big.NewInt(0).Add(validator.LockedVET, validator.QueuedVET))
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), validator.Weight)
 
 	// verify withdraw amount decrease
@@ -865,7 +865,7 @@ func TestStaker_ChangeStakeActiveValidatorWithQueued(t *testing.T) {
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
-	assert.Equal(t, decreaseAmount, validator.NextPeriodDecrease)
+	assert.Equal(t, decreaseAmount, validator.PendingUnlockVET)
 	assert.Equal(t, big.NewInt(0).Mul(expectedStake, big.NewInt(2)), validator.Weight)
 
 	queuedVET, queuedWeight, err = staker.QueuedStake()
@@ -915,14 +915,14 @@ func TestStaker_DecreaseActive(t *testing.T) {
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
-	newStake := big.NewInt(0).Add(validator.PendingLocked, validator.LockedVET)
+	newStake := big.NewInt(0).Add(validator.QueuedVET, validator.LockedVET)
 	assert.Equal(t, stake, newStake)
-	assert.Equal(t, decrease, validator.NextPeriodDecrease)
+	assert.Equal(t, decrease, validator.PendingUnlockVET)
 
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, stake, validator.LockedVET)
-	assert.Equal(t, decrease, validator.NextPeriodDecrease)
+	assert.Equal(t, decrease, validator.PendingUnlockVET)
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), validator.Weight)
 
 	// verify withdraw amount decrease
@@ -962,12 +962,12 @@ func TestStaker_DecreaseActiveThenExit(t *testing.T) {
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, stake, validator.LockedVET)
-	assert.Equal(t, decrease, validator.NextPeriodDecrease)
+	assert.Equal(t, decrease, validator.PendingUnlockVET)
 
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, stake, validator.LockedVET)
-	assert.Equal(t, decrease, validator.NextPeriodDecrease)
+	assert.Equal(t, decrease, validator.PendingUnlockVET)
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), validator.Weight)
 
 	// verify withdraw amount decrease
@@ -977,7 +977,7 @@ func TestStaker_DecreaseActiveThenExit(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(1000), validator.WithdrawableVET)
 	assert.Equal(t, expectedStake, validator.LockedVET)
-	assert.Equal(t, big.NewInt(0), validator.NextPeriodDecrease)
+	assert.Equal(t, big.NewInt(0), validator.PendingUnlockVET)
 
 	assert.NoError(t, staker.SignalExit(addr, addr))
 
@@ -990,7 +990,7 @@ func TestStaker_DecreaseActiveThenExit(t *testing.T) {
 	assert.Equal(t, big.NewInt(1000), validator.WithdrawableVET)
 	assert.Equal(t, big.NewInt(0), validator.LockedVET)
 	assert.Equal(t, expectedStake, validator.CooldownVET)
-	assert.Equal(t, big.NewInt(0), validator.PendingLocked)
+	assert.Equal(t, big.NewInt(0), validator.QueuedVET)
 }
 
 func TestStaker_Get_FullFlow(t *testing.T) {
@@ -1012,7 +1012,7 @@ func TestStaker_Get_FullFlow(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	// activate the validator
@@ -1067,7 +1067,7 @@ func TestStaker_Get_FullFlow_Renewal_On(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	// activate the validator
@@ -1116,7 +1116,7 @@ func TestStaker_Get_FullFlow_Renewal_On_Then_Off(t *testing.T) {
 	validator, err := staker.Get(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
-	assert.Equal(t, stake, validator.PendingLocked)
+	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
 	// activate the validator
@@ -1159,7 +1159,7 @@ func TestStaker_Get_FullFlow_Renewal_On_Then_Off(t *testing.T) {
 	assert.Equal(t, stake, validator.CooldownVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 	assert.Equal(t, big.NewInt(0), validator.LockedVET)
-	assert.Equal(t, big.NewInt(0), validator.PendingLocked)
+	assert.Equal(t, big.NewInt(0), validator.QueuedVET)
 
 	// withdraw the stake
 	withdrawAmount, err := staker.WithdrawStake(addr, addr, period*2+cooldownPeriod)
@@ -1741,7 +1741,7 @@ func TestStaker_Housekeep_RecalculateIncrease(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusActive, validator.Status)
 	assert.Equal(t, stake, validator.LockedVET)
-	assert.Equal(t, big.NewInt(1), validator.PendingLocked)
+	assert.Equal(t, big.NewInt(1), validator.QueuedVET)
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), validator.Weight)
 
 	_, _, err = staker.Housekeep(period)
@@ -1753,7 +1753,7 @@ func TestStaker_Housekeep_RecalculateIncrease(t *testing.T) {
 	assert.Equal(t, stake, validator.LockedVET)
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), validator.Weight)
 	assert.Equal(t, validator.WithdrawableVET, big.NewInt(0))
-	assert.Equal(t, validator.PendingLocked, big.NewInt(0))
+	assert.Equal(t, validator.QueuedVET, big.NewInt(0))
 }
 
 func TestStaker_Housekeep_RecalculateDecrease(t *testing.T) {
@@ -1781,7 +1781,7 @@ func TestStaker_Housekeep_RecalculateDecrease(t *testing.T) {
 	assert.Equal(t, validation.StatusActive, validator.Status)
 	assert.Equal(t, stake, validator.LockedVET)
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), validator.Weight)
-	assert.Equal(t, decrease, validator.NextPeriodDecrease)
+	assert.Equal(t, decrease, validator.PendingUnlockVET)
 
 	block = uint32(360) * 24 * 15
 	_, _, err = staker.Housekeep(block)
@@ -1819,7 +1819,7 @@ func TestStaker_Housekeep_DecreaseThenWithdraw(t *testing.T) {
 	assert.Equal(t, validation.StatusActive, validator.Status)
 	assert.Equal(t, stake, validator.LockedVET)
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), validator.Weight)
-	assert.Equal(t, validator.NextPeriodDecrease, big.NewInt(1))
+	assert.Equal(t, validator.PendingUnlockVET, big.NewInt(1))
 
 	block = uint32(360) * 24 * 15
 	_, _, err = staker.Housekeep(block)
@@ -1869,7 +1869,7 @@ func TestStaker_DecreaseActive_DecreaseMultipleTimes(t *testing.T) {
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.Equal(t, stake, validator.LockedVET)
-	assert.Equal(t, validator.NextPeriodDecrease, big.NewInt(1))
+	assert.Equal(t, validator.PendingUnlockVET, big.NewInt(1))
 
 	err = staker.DecreaseStake(addr1, addr1, big.NewInt(1))
 	assert.NoError(t, err)
@@ -1877,7 +1877,7 @@ func TestStaker_DecreaseActive_DecreaseMultipleTimes(t *testing.T) {
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.Equal(t, stake, validator.LockedVET)
-	assert.Equal(t, validator.NextPeriodDecrease, big.NewInt(2))
+	assert.Equal(t, validator.PendingUnlockVET, big.NewInt(2))
 
 	_, _, err = staker.Housekeep(period)
 	assert.NoError(t, err)
@@ -2080,7 +2080,7 @@ func TestStaker_QueuedValidator_Withdraw(t *testing.T) {
 	assert.Equal(t, big.NewInt(0), val.LockedVET)
 	assert.Equal(t, big.NewInt(0), val.Weight)
 	assert.Equal(t, big.NewInt(0), val.WithdrawableVET)
-	assert.Equal(t, big.NewInt(0), val.PendingLocked)
+	assert.Equal(t, big.NewInt(0), val.QueuedVET)
 }
 
 func TestStaker_IncreaseStake_Withdraw(t *testing.T) {
@@ -2112,7 +2112,7 @@ func TestStaker_IncreaseStake_Withdraw(t *testing.T) {
 	assert.Equal(t, stake, val.LockedVET)
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), val.Weight)
 	assert.Equal(t, big.NewInt(0), val.WithdrawableVET)
-	assert.Equal(t, big.NewInt(0), val.PendingLocked)
+	assert.Equal(t, big.NewInt(0), val.QueuedVET)
 }
 
 func TestStaker_GetRewards(t *testing.T) {
@@ -2361,7 +2361,7 @@ func Test_Validator_IncreaseDecrease_Combinations(t *testing.T) {
 	err := staker.AddValidator(acc, acc, LowStakingPeriod, MinStake)
 	assert.NoError(t, err)
 
-	// Increase and decrease - both should be okay since we're only dealing with PendingLocked
+	// Increase and decrease - both should be okay since we're only dealing with QueuedVET
 	assert.NoError(t, staker.IncreaseStake(acc, acc, MinStake)) // 25m + 25m = 50m
 	assert.NoError(t, staker.DecreaseStake(acc, acc, MinStake)) // 25m - 50m = 25m
 
@@ -2384,7 +2384,7 @@ func Test_Validator_IncreaseDecrease_Combinations(t *testing.T) {
 	assert.NoError(t, staker.IncreaseStake(acc, acc, MinStake))
 	// Decrease stake (NOT ok): 25m - 25m = 0. The Previous increase is not applied since it is still currently withdrawable.
 	assert.ErrorContains(t, staker.DecreaseStake(acc, acc, MinStake), "next period stake is too low for validator")
-	// Instantly withdraw - This is bad, it pulls from the PendingLocked, which means total stake later will be 0.
+	// Instantly withdraw - This is bad, it pulls from the QueuedVET, which means total stake later will be 0.
 	// The decrease previously marked as okay since the current TVL + pending TVL was greater than the min stake.
 	withdraw1, err := staker.WithdrawStake(acc, acc, 0)
 	assert.NoError(t, err)

--- a/consensus/poa_validator.go
+++ b/consensus/poa_validator.go
@@ -149,9 +149,9 @@ func (c *Consensus) authorityBalanceCheck(header *block.Header, st *state.State,
 		if err != nil {
 			return false, err
 		}
-		if validator.IsEmpty() || validator.PendingLocked == nil {
+		if validator.IsEmpty() || validator.QueuedVET == nil {
 			return false, nil
 		}
-		return validator.PendingLocked.Cmp(minBalance) >= 0, nil
+		return validator.QueuedVET.Cmp(minBalance) >= 0, nil
 	}
 }

--- a/consensus/poa_validator_test.go
+++ b/consensus/poa_validator_test.go
@@ -44,7 +44,7 @@ func TestAuthority_Hayabusa_TransitionPeriod(t *testing.T) {
 	// check the staker contract has the correct stake
 	masterStake, err := getMasterStake(setup.chain, blk.Header)
 	assert.NoError(t, err)
-	assert.Equal(t, masterStake.PendingLocked.Cmp(minStake), 0)
+	assert.Equal(t, masterStake.QueuedVET.Cmp(minStake), 0)
 }
 
 func getEndorsorBalance(blk *block.Header, chain *testchain.Chain) (*big.Int, error) {


### PR DESCRIPTION
# Description

This PR updates minor items in the staker package, namely:

- Adds missing comments
- Simplifies some calculations
- Adds a GetExistingValidation that contains the isEmpty check
- Moves the GetWithdrawable to a property in the validator struct
- `validation.NextPeriodDecrease` is now `PendingUnlockVET`
- `valdiation.PendingLocked` is now `QueuedVET`


Fixes # [(issue)](https://github.com/vechain/protocol-board-repo/issues/610)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
