### PR TITLE
chore: init staker params once

### DIFF
--- a/builtin/staker/housekeep.go
+++ b/builtin/staker/housekeep.go
@@ -32,7 +32,7 @@ type ValidatorRenewal struct {
 
 // Housekeep performs epoch transitions at epoch boundaries
 func (s *Staker) Housekeep(currentBlock uint32) (bool, map[thor.Address]*validation.Validation, error) {
-	if currentBlock%epochLength != 0 {
+	if currentBlock%EpochLength.Get() != 0 {
 		return false, nil, nil
 	}
 
@@ -61,7 +61,7 @@ func (s *Staker) Housekeep(currentBlock uint32) (bool, map[thor.Address]*validat
 // ComputeEpochTransition calculates all state changes needed for an epoch transition
 func (s *Staker) ComputeEpochTransition(currentBlock uint32) (*EpochTransition, error) {
 	var err error
-	if currentBlock%epochLength != 0 {
+	if currentBlock%EpochLength.Get() != 0 {
 		return nil, nil // No transition needed
 	}
 


### PR DESCRIPTION
# Description

- This reduces reads to state. The params only get debugged once, instead of every time the staker is initialised
- It also ensures params cannot be set by an outside package

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
