### PR TITLE
fix: slice memory allocation with excessive size value

### DIFF
--- a/api/fees/data.go
+++ b/api/fees/data.go
@@ -69,7 +69,7 @@ func (fd *FeesData) resolveRange(
 	gasUsedRatios := make([]float64, blockCount)
 	var rewards [][]*hexutil.Big
 	if len(rewardPercentiles) > 0 {
-		rewards = make([][]*hexutil.Big, blockCount)
+		rewards = make([][]*hexutil.Big, blockCount) // blockCount is now validated in api/fees/fees.go
 	}
 
 	var oldestBlockID thor.Bytes32

--- a/api/fees/fees.go
+++ b/api/fees/fees.go
@@ -27,6 +27,7 @@ import (
 )
 
 const maxRewardPercentiles = 100
+const maxBlockCount = 10000 // Define a reasonable upper limit for blockCount
 
 type Config struct {
 	APIBacktraceLimit          int
@@ -84,6 +85,10 @@ func (f *Fees) validateBlockCount(req *http.Request) (uint64, error) {
 
 	if blockCount == 0 {
 		return 0, restutil.BadRequest(errors.New("invalid blockCount, it should not be 0"))
+	}
+
+	if blockCount > maxBlockCount {
+		return 0, restutil.BadRequest(errors.New(fmt.Sprintf("invalid blockCount, it should not exceed %d", maxBlockCount)))
 	}
 
 	return blockCount, nil


### PR DESCRIPTION
https://github.com/vechain/thor/blob/fc94d255102694ec4c7ceafb2662e6291c53b94b/api/fees/data.go#L72-L72
https://github.com/vechain/thor/blob/fc94d255102694ec4c7ceafb2662e6291c53b94b/api/fees/data.go#L72-L72
fix the issue, we need to enforce a maximum allowed value for `blockCount` before it is used for memory allocation. This ensures that the program does not attempt to allocate excessively large slices based on untrusted input.

1. Introduce a constant `maxBlockCount` in `api/fees/fees.go` to define the maximum allowable value for `blockCount`.
2. Update the `validateBlockCount` function in `api/fees/fees.go` to check if `blockCount` exceeds `maxBlockCount`. If it does, return an error indicating that the value is invalid.
3. Ensure that the validated `blockCount` is used in `resolveRange` in `api/fees/data.go`.


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
