### PR TITLE
Darren/fix/solo blocks with same timestamps

### DIFF
--- a/builtin/staker/aggregation/aggregation.go
+++ b/builtin/staker/aggregation/aggregation.go
@@ -8,8 +8,6 @@ package aggregation
 import (
 	"math/big"
 
-	"github.com/pkg/errors"
-
 	"github.com/vechain/thor/v2/builtin/staker/delta"
 )
 
@@ -108,17 +106,6 @@ func (a *Aggregation) exit() (*delta.Exit, error) {
 	withdrawable := big.NewInt(0).Set(a.WithdrawableVET)
 	withdrawable.Add(withdrawable, a.LockedVET)
 	withdrawable.Add(withdrawable, a.PendingVET)
-
-	// ExitingVET should always be 0 at this point
-	// as it was moved to withdrawable at the last renew()
-	// TODO implement a test that breaks this:
-	// The auto renew validator could, in their last staking period:
-	// increase stake (pending)
-	// signal exit
-	// exit at the end
-	if a.ExitingVET.Sign() == 1 {
-		return nil, errors.New("ExitingVET should always be 0 at this point ")
-	}
 
 	// Reset the aggregation
 	a.ExitingVET = big.NewInt(0)

--- a/builtin/staker/aggregation/aggregation.go
+++ b/builtin/staker/aggregation/aggregation.go
@@ -8,6 +8,8 @@ package aggregation
 import (
 	"math/big"
 
+	"github.com/pkg/errors"
+	
 	"github.com/vechain/thor/v2/builtin/staker/delta"
 )
 
@@ -106,6 +108,17 @@ func (a *Aggregation) exit() (*delta.Exit, error) {
 	withdrawable := big.NewInt(0).Set(a.WithdrawableVET)
 	withdrawable.Add(withdrawable, a.LockedVET)
 	withdrawable.Add(withdrawable, a.PendingVET)
+
+	// ExitingVET should always be 0 at this point
+	// as it was moved to withdrawable at the last renew()
+	// TODO implement a test that breaks this:
+	// The auto renew validator could, in their last staking period:
+	// increase stake (pending)
+	// signal exit
+	// exit at the end
+	if a.ExitingVET.Sign() == 1 {
+		return nil, errors.New("ExitingVET should always be 0 at this point ")
+	}
 
 	// Reset the aggregation
 	a.ExitingVET = big.NewInt(0)

--- a/builtin/staker/aggregation/aggregation.go
+++ b/builtin/staker/aggregation/aggregation.go
@@ -9,7 +9,7 @@ import (
 	"math/big"
 
 	"github.com/pkg/errors"
-	
+
 	"github.com/vechain/thor/v2/builtin/staker/delta"
 )
 

--- a/cmd/thor/solo/core.go
+++ b/cmd/thor/solo/core.go
@@ -71,7 +71,7 @@ func (c *Core) Pack(pendingTxs tx.Transactions, onDemand bool) ([]*tx.Transactio
 
 	// If on-demand and now equals the best timestamp, this will create blocks with future timestamps
 	// Otherwise, new blocks have the same timestamp as the best block
-	if  c.options.OnDemand {
+	if c.options.OnDemand {
 		now = best.Header.Timestamp() + c.options.BlockInterval
 	}
 

--- a/cmd/thor/solo/core.go
+++ b/cmd/thor/solo/core.go
@@ -69,7 +69,7 @@ func (c *Core) Pack(pendingTxs tx.Transactions, onDemand bool) ([]*tx.Transactio
 	best := c.repo.BestBlockSummary()
 	now := uint64(time.Now().Unix())
 
-	// If on-demand, this will create blocks with future timestamps
+	// If on-demand and now equals the best timestamp, this will create blocks with future timestamps
 	// Otherwise, new blocks have the same timestamp as the best block
 	minOnDemandTime := best.Header.Timestamp() + c.options.BlockInterval
 	if c.options.OnDemand && minOnDemandTime > now {

--- a/cmd/thor/solo/core.go
+++ b/cmd/thor/solo/core.go
@@ -69,6 +69,13 @@ func (c *Core) Pack(pendingTxs tx.Transactions, onDemand bool) ([]*tx.Transactio
 	best := c.repo.BestBlockSummary()
 	now := uint64(time.Now().Unix())
 
+	// If on-demand, this will create blocks with future timestamps
+	// Otherwise, new blocks have the same timestamp as the best block
+	minOnDemandTime := best.Header.Timestamp() + c.options.BlockInterval
+	if c.options.OnDemand && minOnDemandTime > now {
+		now = minOnDemandTime
+	}
+
 	var txsToRemove []*tx.Transaction
 
 	if c.options.GasLimit == 0 {

--- a/cmd/thor/solo/core.go
+++ b/cmd/thor/solo/core.go
@@ -71,9 +71,8 @@ func (c *Core) Pack(pendingTxs tx.Transactions, onDemand bool) ([]*tx.Transactio
 
 	// If on-demand and now equals the best timestamp, this will create blocks with future timestamps
 	// Otherwise, new blocks have the same timestamp as the best block
-	minOnDemandTime := best.Header.Timestamp() + c.options.BlockInterval
-	if c.options.OnDemand && minOnDemandTime > now {
-		now = minOnDemandTime
+	if  c.options.OnDemand {
+		now = best.Header.Timestamp() + c.options.BlockInterval
 	}
 
 	var txsToRemove []*tx.Transaction


### PR DESCRIPTION
# Description

fix for solo: prevent blocks using the same timestamp. This changes essentially creates blocks with future timestamps if solo is creating a lot of blocks

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
