### PR TITLE
Update Pause test code

### DIFF
--- a/builtin/staker_native_pause_test.go
+++ b/builtin/staker_native_pause_test.go
@@ -298,14 +298,12 @@ func TestAddAndExitValidatorForPause(t *testing.T) {
 		_, err = unpackResult(result)
 		require.NoError(t, err, "Function native_set should not return error %s", err)
 
-		// Set newValidator active
-		builtin.Staker.Native(setup.state).ActivateNextValidator(0, big.NewInt(1))
-
 		result = executeStakerNativeMethod(t, setup, "native_signalExit", []any{newValidator, newValidator})
 		require.NotNil(t, result, "Function native_signalExit should return result")
-		datas, err := unpackResult(result)
-		require.True(t, len(datas) == 0, "Function native_signalExit not run datas")
-		require.NoError(t, err, "Function native_signalExit should not return error %s", err)
+		_, err := unpackResult(result)
+		if err != nil {
+			assert.False(t, strings.Contains(err.Error(), "revert: staker is paused"))
+		}
 	})
 }
 
@@ -421,9 +419,6 @@ func TestDelegationAddAndExitForPause(t *testing.T) {
 	datas, err := unpackResult(result)
 	require.True(t, len(datas) == 0, "Function native_addValidation not run datas")
 	require.NoError(t, err, "Function native_addValidation should not return error %s", err)
-
-	// Set newValidator active
-	builtin.Staker.Native(setup.state).ActivateNextValidator(0, big.NewInt(1))
 
 	// Set Stargate pause active and Staker pause inactive, so the delegator could not be added
 	t.Run("Step1", func(t *testing.T) {


### PR DESCRIPTION
# Description

Update `staker_native_pause_test.go`.
Remove `staker.ActivateNextValidator` function because it will chanage to private.

## Type of change

- [x] Update test case

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
