### PR TITLE
remove ExitingVET check

### DIFF
--- a/builtin/staker/aggregation/aggregation.go
+++ b/builtin/staker/aggregation/aggregation.go
@@ -8,8 +8,6 @@ package aggregation
 import (
 	"math/big"
 
-	"github.com/pkg/errors"
-
 	"github.com/vechain/thor/v2/builtin/staker/delta"
 )
 
@@ -108,17 +106,6 @@ func (a *Aggregation) exit() (*delta.Exit, error) {
 	withdrawable := big.NewInt(0).Set(a.WithdrawableVET)
 	withdrawable.Add(withdrawable, a.LockedVET)
 	withdrawable.Add(withdrawable, a.PendingVET)
-
-	// ExitingVET should always be 0 at this point
-	// as it was moved to withdrawable at the last renew()
-	// TODO implement a test that breaks this:
-	// The auto renew validator could, in their last staking period:
-	// increase stake (pending)
-	// signal exit
-	// exit at the end
-	if a.ExitingVET.Sign() == 1 {
-		return nil, errors.New("ExitingVET should always be 0 at this point ")
-	}
 
 	// Reset the aggregation
 	a.ExitingVET = big.NewInt(0)

--- a/builtin/staker/delegations_test.go
+++ b/builtin/staker/delegations_test.go
@@ -619,7 +619,7 @@ func TestStaker_DelegationExitingVET(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, delegation.Started(validation))
 
-	_, _, err = staker.Housekeep(MediumStakingPeriod)
+	_, _, err = staker.Housekeep(MediumStakingPeriod.Get())
 	assert.NoError(t, err)
 
 	delegation, validation, err = staker.GetDelegation(delegationID)
@@ -629,6 +629,6 @@ func TestStaker_DelegationExitingVET(t *testing.T) {
 	assert.NoError(t, staker.SignalDelegationExit(delegationID))
 	assert.NoError(t, staker.SignalExit(*firstActive, validation.Endorsor))
 
-	_, _, err = staker.Housekeep(MediumStakingPeriod * 2)
+	_, _, err = staker.Housekeep(MediumStakingPeriod.Get() * 2)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
# Description

Removed ExitingVET check on `exit` and added a proposed test for it.
An error was only triggered if a delegator and validator were exiting at the same time, if this happens - the check is not required, as a validator exit will set ExitingVET and ExitingWeight to 0

Fixes https://github.com/vechain/protocol-board-repo/issues/733

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Tested with existing unit tests and added an additional unit test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
