### PR TITLE
Uncouple Delegation Service SignalExit from Validation

### DIFF
--- a/builtin/staker/delegation/service.go
+++ b/builtin/staker/delegation/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/vechain/thor/v2/builtin/solidity"
-	"github.com/vechain/thor/v2/builtin/staker/validation"
 	"github.com/vechain/thor/v2/thor"
 )
 
@@ -87,8 +86,7 @@ func (s *Service) Add(
 	return delegationID, nil
 }
 
-// todo uncouple this
-func (s *Service) SignalExit(delegationID *big.Int, val *validation.Validation) error {
+func (s *Service) SignalExit(delegationID *big.Int, valCurrentIteration uint32) error {
 	delegation, err := s.GetDelegation(delegationID)
 	if err != nil {
 		return err
@@ -100,15 +98,8 @@ func (s *Service) SignalExit(delegationID *big.Int, val *validation.Validation) 
 	if delegation.Stake.Sign() == 0 {
 		return errors.New("delegation is not active")
 	}
-	if !delegation.Started(val) {
-		return errors.New("delegation has not started yet, funds can be withdrawn")
-	}
-	if delegation.Ended(val) {
-		return errors.New("delegation has ended, funds can be withdrawn")
-	}
 
-	last := val.CurrentIteration()
-	delegation.LastIteration = &last
+	delegation.LastIteration = &valCurrentIteration
 
 	return s.SetDelegation(delegationID, delegation, false)
 }

--- a/builtin/staker_native_gas_test.go
+++ b/builtin/staker_native_gas_test.go
@@ -195,7 +195,7 @@ func TestStakerNativeGasCosts(t *testing.T) {
 		},
 		{
 			function:    "native_withdrawDelegation",
-			expectedGas: 22400,
+			expectedGas: 22200,
 			args: []any{
 				big.NewInt(1), // IDs are incremental, starting at 1
 			},
@@ -205,7 +205,7 @@ func TestStakerNativeGasCosts(t *testing.T) {
 		// TODO: How can we mint thousands of blocks and perform housekeeping?
 		{
 			function:    "native_signalDelegationExit",
-			expectedGas: 1600,
+			expectedGas: 1200,
 			args: []any{
 				big.NewInt(1), // IDs are incremental, starting at 1
 			},


### PR DESCRIPTION
# Description

As per title. This PR ensures the delegation services are decoupled from the validation object.
Also applied minor fixes like removing the extra delegation get in the withdraw method.

Fixes # [(issue)](https://github.com/vechain/protocol-board-repo/issues/731)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
