### PR TITLE
set approvers only when param executor is set to default executor add…

### DIFF
--- a/genesis/customnet.go
+++ b/genesis/customnet.go
@@ -68,7 +68,8 @@ func NewCustomNet(gen *CustomGenesis) (*Genesis, error) {
 				return err
 			}
 
-			if len(gen.Executor.Approvers) > 0 {
+			// if executor is the default executor, set the executor code
+			if executor == builtin.Executor.Address && len(gen.Executor.Approvers) > 0 {
 				if err := state.SetCode(builtin.Executor.Address, builtin.Executor.RuntimeBytecodes()); err != nil {
 					return err
 				}
@@ -176,8 +177,8 @@ func NewCustomNet(gen *CustomGenesis) (*Genesis, error) {
 		builder.Call(tx.NewClause(&builtin.Authority.Address).WithData(data), executor)
 	}
 
-	if len(gen.Executor.Approvers) > 0 {
-		// add initial approvers
+	// if executor is the default executor, set the approvers
+	if executor == builtin.Executor.Address && len(gen.Executor.Approvers) > 0 {
 		for _, approver := range gen.Executor.Approvers {
 			data := mustEncodeInput(builtin.Executor.ABI, "addApprover", approver.Address, approver.Identity)
 			builder.Call(tx.NewClause(&builtin.Executor.Address).WithData(data), executor)


### PR DESCRIPTION
…ress

# Description

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
