### PR TITLE
fix(api): logs endpoints returning empty results

### DIFF
--- a/api/transfers/transfers_test.go
+++ b/api/transfers/transfers_test.go
@@ -65,7 +65,7 @@ func TestOption(t *testing.T) {
 	filter := api.TransferFilter{
 		CriteriaSet: make([]*logdb.TransferCriteria, 0),
 		Range:       nil,
-		Options:     &api.Options{Limit: 6},
+		Options:     &api.Options{Limit: ptr(6)},
 		Order:       logdb.DESC,
 	}
 
@@ -74,7 +74,7 @@ func TestOption(t *testing.T) {
 	assert.Equal(t, "options.limit exceeds the maximum allowed value of 5", strings.Trim(string(res), "\n"))
 	assert.Equal(t, http.StatusForbidden, statusCode)
 
-	filter.Options.Limit = 5
+	filter.Options.Limit = ptr(5)
 	_, statusCode, err = tclient.RawHTTPClient().RawHTTPPost("/logs/transfer", filter)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)
@@ -129,7 +129,7 @@ func TestOptionalData(t *testing.T) {
 			filter := api.TransferFilter{
 				CriteriaSet: make([]*logdb.TransferCriteria, 0),
 				Range:       nil,
-				Options:     &api.Options{Limit: 5, IncludeIndexes: tc.includeIndexes},
+				Options:     &api.Options{Limit: ptr(5), IncludeIndexes: tc.includeIndexes},
 				Order:       logdb.DESC,
 			}
 
@@ -274,4 +274,8 @@ func newReceipt() *tx.Receipt {
 			},
 		},
 	}
+}
+
+func ptr(v uint64) *uint64 {
+	return &v
 }

--- a/thorclient/api_test.go
+++ b/thorclient/api_test.go
@@ -400,6 +400,7 @@ func testEventsEndpoint(t *testing.T, _ *testchain.Chain, ts *httptest.Server) {
 	// 1. Test POST /events (Filter events)
 	t.Run("FilterEvents", func(t *testing.T) {
 		// Define the payload for filtering events
+		limit := uint64(10)
 		payload := &api.EventFilter{
 			CriteriaSet: []*api.EventCriteria{
 				{
@@ -412,7 +413,7 @@ func testEventsEndpoint(t *testing.T, _ *testchain.Chain, ts *httptest.Server) {
 			Range: nil,
 			Options: &api.Options{
 				Offset: 0,
-				Limit:  10,
+				Limit:  &limit,
 			},
 			Order: "",
 		}


### PR DESCRIPTION
# Description

- In master, when `options` are defined, limit is set to 0, even thought it is emitted. Results in no logs in response

```bash
curl --request POST \
  --url https://mainnet.vechain.org/logs/event \
  --header 'Accept: application/json, text/plain' \
  --header 'Content-Type: application/json' \
  --data '{
  "range" : {
    "from" : 2
  },
  "options" : {
    "includeIndexes" : true
  },
  "criteriaSet" : null
}'
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
