### PR TITLE
feat: publish binaries for releases

### DIFF
--- a/.github/workflows/on-pre-release.yaml
+++ b/.github/workflows/on-pre-release.yaml
@@ -41,3 +41,12 @@ jobs:
         ghcr.io/${{ github.repository }}
       tags: |
         type=raw,value=${{ github.ref_name }}
+
+  publish-binaries:
+    name: Publish Binaries
+    uses: ./.github/workflows/release-binaries.yaml
+    secrets: inherit
+    needs:
+      - validate
+    permissions:
+      contents: write

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -70,3 +70,12 @@ jobs:
       tags: |
         type=raw,value=${{ github.ref_name }}
         type=raw,value=latest
+
+  publish-binaries:
+    name: Publish Binaries
+    uses: ./.github/workflows/release-binaries.yaml
+    secrets: inherit
+    needs:
+      - validate
+    permissions:
+      contents: write

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,0 +1,78 @@
+name: Release Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      binary:
+        options:
+          - thor
+          - disco
+        description: 'Select the binary to build and release'
+        type: choice
+        required: true
+        default: thor
+  workflow_call:
+    inputs:
+      binary:
+        description: 'Select the binary to build and release'
+        type: string
+        required: true
+        default: thor
+
+permissions:
+  contents: write
+
+jobs:
+  build-binaries:
+    runs-on: ${{ matrix.hostos }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - goos: linux
+          goarch: amd64
+          hostos: ubuntu-latest
+        - goos: linux
+          goarch: arm64
+          hostos: ubuntu-24.04-arm
+        - goos: darwin
+          goarch: arm64
+          hostos: macos-latest
+        - goos: windows
+          goarch: amd64
+          hostos: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+
+      - name: Set Env
+        run: |
+          echo "BINARY=${{ inputs.binary || 'thor' }}" >> $GITHUB_ENV
+          echo "BIN_EXT=${{ matrix.goos == 'windows' && '.exe' || '' }}" >> $GITHUB_ENV
+
+      - name: Build Binary
+        run: make ${{ env.BINARY }}
+
+      - name: Rename Binary
+        run: |
+          mkdir -p ./dist
+          mv ./bin/${{ env.BINARY }}${{ env.BIN_EXT }} ./dist/${{ env.BINARY }}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}
+
+      - name: Upload Binary
+        uses: alexellis/upload-assets@0.4.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["./dist/*"]'
+

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -51,11 +51,6 @@ jobs:
         with:
           go-version: 1.24
 
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          install-only: true
-
       - name: Set Env
         run: |
           echo "BINARY=${{ inputs.binary || 'thor' }}" >> $GITHUB_ENV

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build-binaries:
@@ -29,40 +30,66 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - goos: linux
-          goarch: amd64
-          hostos: ubuntu-latest
-        - goos: linux
-          goarch: arm64
-          hostos: ubuntu-24.04-arm
-        - goos: darwin
-          goarch: arm64
-          hostos: macos-latest
-        - goos: windows
-          goarch: amd64
-          hostos: windows-latest
+          - goos: linux
+            goarch: amd64
+            hostos: ubuntu-latest
+            ext: ''
+            archive_ext: tar.gz
+          - goos: linux
+            goarch: arm64
+            hostos: ubuntu-24.04-arm
+            ext: ''
+            archive_ext: tar.gz
+          - goos: darwin
+            goarch: arm64
+            hostos: macos-latest
+            ext: ''
+            archive_ext: tar.gz
+          - goos: windows
+            goarch: amd64
+            hostos: windows-latest
+            ext: '.exe'
+            archive_ext: zip
+
+    env:
+      BINARY: ${{ inputs.binary || 'thor' }}
+      RELEASE_BINARY_NAME: ./dist/${{ inputs.binary || 'thor' }}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
+      ARCHIVE_NAME: ./dist/${{ inputs.binary || 'thor' }}-${{ matrix.goos }}-${{ matrix.goarch }}.${{ matrix.archive_ext }}
+
+    environment: binary-publish
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: 1.24
 
-      - name: Set Env
-        run: |
-          echo "BINARY=${{ inputs.binary || 'thor' }}" >> $GITHUB_ENV
-          echo "BIN_EXT=${{ matrix.goos == 'windows' && '.exe' || '' }}" >> $GITHUB_ENV
-
       - name: Build Binary
-        run: make ${{ env.BINARY }}
-
-      - name: Rename Binary
         run: |
+          make $BINARY
           mkdir -p ./dist
-          mv ./bin/${{ env.BINARY }}${{ env.BIN_EXT }} ./dist/${{ env.BINARY }}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}
+          mv ./bin/${BINARY}${{ matrix.ext }} $RELEASE_BINARY_NAME
+          chmod +x $RELEASE_BINARY_NAME
+
+      - name: Sign Executable with GPG
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --armor --detach-sign "$RELEASE_BINARY_NAME"
+
+      - name: Create archive
+        run: |
+          cd dist
+          if [[ "${{ matrix.archive_ext }}" == "zip" ]]; then
+            zip "${ARCHIVE_NAME##*/}" "$(basename "$RELEASE_BINARY_NAME")"
+          else
+            tar czf "${ARCHIVE_NAME##*/}" "$(basename "$RELEASE_BINARY_NAME")"
+          fi
 
       - name: Upload Binary
         uses: alexellis/upload-assets@0.4.1
@@ -70,4 +97,3 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           asset_paths: '["./dist/*"]'
-

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ package.json
 coverage.out
 
 .idea
+
+dist/

--- a/tracers/logger/logger.go
+++ b/tracers/logger/logger.go
@@ -60,7 +60,7 @@ type Config struct {
 	Limit            int  // maximum length of output, but zero means unlimited
 }
 
-//go:generate go run github.com/fjl/gencodec -type StructLog -field-override structLogMarshaling -out gen_structlog.go
+//go:generate go run github.com/fjl/gencodec@v0.1.1 -type StructLog -field-override structLogMarshaling -out gen_structlog.go
 
 // StructLog is emitted to the EVM each cycle and lists information about the current internal state
 // prior to the execution of the statement.

--- a/tracers/native/call.go
+++ b/tracers/native/call.go
@@ -29,7 +29,7 @@ import (
 	"github.com/vechain/thor/v2/vm"
 )
 
-//go:generate go run github.com/fjl/gencodec -type callFrame -field-override callFrameMarshaling -out gen_callframe_json.go
+//go:generate go run github.com/fjl/gencodec@v0.1.1 -type callFrame -field-override callFrameMarshaling -out gen_callframe_json.go
 
 func init() {
 	tracers.DefaultDirectory.Register("callTracer", newCallTracer, false)

--- a/tracers/native/prestate.go
+++ b/tracers/native/prestate.go
@@ -30,7 +30,7 @@ import (
 	"github.com/vechain/thor/v2/vm"
 )
 
-//go:generate go run github.com/fjl/gencodec -type account -field-override accountMarshaling -out gen_account_json.go
+//go:generate go run github.com/fjl/gencodec@v0.1.1 -type account -field-override accountMarshaling -out gen_account_json.go
 
 func init() {
 	tracers.DefaultDirectory.Register("prestateTracer", newPrestateTracer, false)


### PR DESCRIPTION
# Description

- Publish thor binaries on release. See example here: https://github.com/darrenvechain/thor/releases/tag/v2.4.0
- Optionally publish disco binaries as well (on demand rather than automatic)
- Not using goreleaser as it doesn't play well with parallel builds. It expects to build all binaries at once. Cross arch build not possible with thor

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
