### PR TITLE
feat: publish binaries to release

### DIFF
--- a/.github/workflows/on-pre-release.yaml
+++ b/.github/workflows/on-pre-release.yaml
@@ -41,3 +41,15 @@ jobs:
         ghcr.io/${{ github.repository }}
       tags: |
         type=raw,value=${{ github.ref_name }}
+
+  publish-binaries:
+    name: Publish Binaries
+    uses: ./.github/workflows/release-binaries.yaml
+    secrets: inherit
+    needs:
+      - validate
+    permissions:
+      contents: write
+
+    with:
+      binary: 'thor'

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -70,3 +70,15 @@ jobs:
       tags: |
         type=raw,value=${{ github.ref_name }}
         type=raw,value=latest
+
+  publish-binaries:
+    name: Publish Binaries
+    uses: ./.github/workflows/release-binaries.yaml
+    secrets: inherit
+    needs:
+      - validate
+    permissions:
+      contents: write
+      packages: write
+    with:
+      binary: 'thor'

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,0 +1,142 @@
+name: Release Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      binary:
+        options:
+          - thor
+          - disco
+        description: 'Select the binary to build and release'
+        type: choice
+        required: true
+        default: thor
+  workflow_call:
+    inputs:
+      binary:
+        description: 'Select the binary to build and release'
+        type: string
+        required: true
+        default: thor
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-unix:
+    name: Build Linux/macOS binaries
+    runs-on: ${{ matrix.hostos }}
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            hostos: ubuntu-latest
+          - goos: linux
+            goarch: arm64
+            hostos: ubuntu-24.04-arm
+          - goos: darwin
+            goarch: arm64
+            hostos: macos-latest
+    env:
+      BINARY: ${{ inputs.binary || 'thor' }}
+      RELEASE_BINARY_NAME: ./dist/${{ inputs.binary || 'thor' }}-${{ matrix.goos }}-${{ matrix.goarch }}
+      ARCHIVE_NAME: ./dist/${{ inputs.binary || 'thor' }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+
+    environment: binary-publish
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Build Binary
+        shell: bash
+        run: |
+          make $BINARY
+          mkdir -p ./dist
+          mv ./bin/${BINARY} $RELEASE_BINARY_NAME
+          chmod +x $RELEASE_BINARY_NAME
+
+      - name: Import GPG Private Key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+
+      - name: Sign Executable with GPG
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        shell: bash
+        run: |
+          gpg --batch --yes --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --armor --detach-sign "$RELEASE_BINARY_NAME"
+
+      - name: Create archive
+        shell: bash
+        run: |
+          cd dist
+          tar czf "${ARCHIVE_NAME##*/}" "$(basename "$RELEASE_BINARY_NAME")"
+
+      - name: Upload Binary
+        uses: alexellis/upload-assets@0.4.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["${{env.RELEASE_BINARY_NAME}}", "${{env.ARCHIVE_NAME}}"]'
+
+  build-windows:
+    name: Build Windows binary
+    runs-on: windows-latest
+    env:
+      BINARY: ${{ inputs.binary || 'thor' }}
+      RELEASE_BINARY_NAME: ./dist/${{ inputs.binary || 'thor' }}-windows-amd64.exe
+      ARCHIVE_NAME: ./dist/${{ inputs.binary || 'thor' }}-windows-amd64.zip
+    environment: binary-publish
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+
+      - name: Build Binary
+        shell: pwsh
+        run: |
+          make $Env:BINARY
+          New-Item -ItemType Directory -Force -Path ./dist | Out-Null
+          Move-Item -Force "./bin/$Env:BINARY" $Env:RELEASE_BINARY_NAME
+
+      - name: Import GPG Private Key
+        shell: pwsh
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+        run: |
+          $gpgKey = $Env:GPG_PRIVATE_KEY -replace "`r`n", "`n"
+          $gpgKey | Out-File -Encoding ascii private.key
+          gpg --batch --import private.key
+
+      - name: Sign Executable with GPG
+        shell: pwsh
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          gpg --batch --yes --pinentry-mode loopback --passphrase "$Env:GPG_PASSPHRASE" --armor --detach-sign "$Env:RELEASE_BINARY_NAME"
+
+      - name: Create archive
+        shell: pwsh
+        run: |
+          Set-Location ./dist
+          Compress-Archive -Path (Split-Path -Leaf $Env:RELEASE_BINARY_NAME) -DestinationPath (Split-Path -Leaf $Env:ARCHIVE_NAME)
+
+      - name: Upload Binary
+        uses: alexellis/upload-assets@0.4.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '["${{env.RELEASE_BINARY_NAME}}", "${{env.ARCHIVE_NAME}}"]'

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ package.json
 coverage.out
 
 .idea
+
+dist/

--- a/tracers/logger/logger.go
+++ b/tracers/logger/logger.go
@@ -60,7 +60,7 @@ type Config struct {
 	Limit            int  // maximum length of output, but zero means unlimited
 }
 
-//go:generate go run github.com/fjl/gencodec -type StructLog -field-override structLogMarshaling -out gen_structlog.go
+//go:generate go run github.com/fjl/gencodec@v0.1.1 -type StructLog -field-override structLogMarshaling -out gen_structlog.go
 
 // StructLog is emitted to the EVM each cycle and lists information about the current internal state
 // prior to the execution of the statement.

--- a/tracers/native/call.go
+++ b/tracers/native/call.go
@@ -29,7 +29,7 @@ import (
 	"github.com/vechain/thor/v2/vm"
 )
 
-//go:generate go run github.com/fjl/gencodec -type callFrame -field-override callFrameMarshaling -out gen_callframe_json.go
+//go:generate go run github.com/fjl/gencodec@v0.1.1 -type callFrame -field-override callFrameMarshaling -out gen_callframe_json.go
 
 func init() {
 	tracers.DefaultDirectory.Register("callTracer", newCallTracer, false)

--- a/tracers/native/prestate.go
+++ b/tracers/native/prestate.go
@@ -30,7 +30,7 @@ import (
 	"github.com/vechain/thor/v2/vm"
 )
 
-//go:generate go run github.com/fjl/gencodec -type account -field-override accountMarshaling -out gen_account_json.go
+//go:generate go run github.com/fjl/gencodec@v0.1.1 -type account -field-override accountMarshaling -out gen_account_json.go
 
 func init() {
 	tracers.DefaultDirectory.Register("prestateTracer", newPrestateTracer, false)


### PR DESCRIPTION
# Description

- Publish thor binaries on release. See example here: https://github.com/darrenvechain/thor/releases/tag/v2.3.1
- Optionally publish disco binaries as well (on demand rather than automatic)
- Not using goreleaser as it doesn't play well with parallel builds. It expects to build all binaries at once. Cross arch build not possible with thor

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
