### PR TITLE
refactor(staker): move trasition, housekeeping and status check to staker

### DIFF
--- a/builtin/staker/delegations_test.go
+++ b/builtin/staker/delegations_test.go
@@ -230,7 +230,7 @@ func Test_Delegator_DisableAutoRenew_PendingLocked(t *testing.T) {
 
 	// Then the delegation can't signal an exit until it has started
 	assert.ErrorContains(t, staker.SignalDelegationExit(id), "delegation has not started yet")
-	_, _, err = staker.Housekeep(validator.Period)
+	_, err = staker.Housekeep(validator.Period)
 	assert.NoError(t, err)
 	assert.NoError(t, staker.SignalDelegationExit(id))
 	aggregation, err = staker.aggregationService.GetAggregation(validator.ID)
@@ -239,7 +239,7 @@ func Test_Delegator_DisableAutoRenew_PendingLocked(t *testing.T) {
 	assert.Equal(t, stake, aggregation.ExitingVET) // ExitingVET takes effect in next staking period
 
 	// When the staking period is completed
-	_, _, err = staker.Housekeep(validator.Period)
+	_, err = staker.Housekeep(validator.Period)
 	assert.NoError(t, err)
 	aggregation, err = staker.aggregationService.GetAggregation(validator.ID)
 	assert.NoError(t, err)
@@ -330,7 +330,7 @@ func Test_Delegator_DisableAutoRenew_InAStakingPeriod(t *testing.T) {
 	assert.Equal(t, weight, queuedWeight)
 
 	// And the first staking period has occurred
-	_, _, err = staker.Housekeep(validator.Period)
+	_, err = staker.Housekeep(validator.Period)
 	assert.NoError(t, err)
 	aggregation, err := staker.aggregationService.GetAggregation(validator.ID)
 	assert.NoError(t, err)
@@ -353,7 +353,7 @@ func Test_Delegator_DisableAutoRenew_InAStakingPeriod(t *testing.T) {
 	assert.Equal(t, big.NewInt(0).String(), queuedWeight.String())
 
 	// And the funds should be withdrawable after the next iteration
-	_, _, err = staker.Housekeep(2 * validator.Period)
+	_, err = staker.Housekeep(2 * validator.Period)
 	assert.NoError(t, err)
 	_, err = staker.aggregationService.GetAggregation(validator.ID)
 	assert.NoError(t, err)
@@ -373,7 +373,7 @@ func Test_Delegator_AutoRenew_ValidatorExits(t *testing.T) {
 	assert.NoError(t, err)
 
 	// And the first staking period has occurred
-	_, _, err = staker.Housekeep(validator.Period)
+	_, err = staker.Housekeep(validator.Period)
 	assert.NoError(t, err)
 	aggregation, err := staker.aggregationService.GetAggregation(validator.ID)
 	assert.NoError(t, err)
@@ -383,7 +383,7 @@ func Test_Delegator_AutoRenew_ValidatorExits(t *testing.T) {
 	assert.NoError(t, staker.SignalExit(validator.ID, validator.Endorsor))
 
 	// And the next staking period is over
-	_, _, err = staker.Housekeep(validator.Period * 2)
+	_, err = staker.Housekeep(validator.Period * 2)
 	assert.NoError(t, err)
 	_, err = staker.aggregationService.GetAggregation(validator.ID)
 	assert.NoError(t, err)
@@ -588,7 +588,7 @@ func Test_Delegations_EnableAutoRenew_MatchStakeReached(t *testing.T) {
 	assert.False(t, delegation1.Started(validation))
 
 	// Delegation should become active
-	_, _, err = staker.Housekeep(validator.Period)
+	_, err = staker.Housekeep(validator.Period)
 	assert.NoError(t, err)
 	delegation1, _, err = staker.GetDelegation(delegationID)
 	assert.NoError(t, err)
@@ -647,7 +647,7 @@ func TestStaker_DelegationExitingVET(t *testing.T) {
 	assert.Equal(t, delStake, qStake)
 	assert.Equal(t, delWeight, qWeight)
 
-	_, _, err = staker.Housekeep(MediumStakingPeriod.Get())
+	_, err = staker.Housekeep(MediumStakingPeriod.Get())
 	assert.NoError(t, err)
 
 	delegation, validation, err = staker.GetDelegation(delegationID)
@@ -657,6 +657,6 @@ func TestStaker_DelegationExitingVET(t *testing.T) {
 	assert.NoError(t, staker.SignalDelegationExit(delegationID))
 	assert.NoError(t, staker.SignalExit(*firstActive, validation.Endorsor))
 
-	_, _, err = staker.Housekeep(MediumStakingPeriod.Get() * 2)
+	_, err = staker.Housekeep(MediumStakingPeriod.Get() * 2)
 	assert.NoError(t, err)
 }

--- a/builtin/staker/protocol.go
+++ b/builtin/staker/protocol.go
@@ -14,7 +14,7 @@ import (
 
 type Status struct {
 	Active      bool                                    // indicates if the staker contract is currently active
-	LeaderGroup map[thor.Address]*validation.Validation // the current leader group, if the staker contract is active
+	LeaderGroup map[thor.Address]*validation.Validation // the current leader group, if housekeeping performed updates
 }
 
 // EvaluateOrUpdate checks the status of the staker contract and updates its state based on the current block number.

--- a/builtin/staker/protocol.go
+++ b/builtin/staker/protocol.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package staker
+
+import (
+	"fmt"
+
+	"github.com/vechain/thor/v2/builtin/staker/validation"
+	"github.com/vechain/thor/v2/thor"
+)
+
+type Status struct {
+	Active      bool                                    // indicates if the staker contract is currently active
+	LeaderGroup map[thor.Address]*validation.Validation // the current leader group, if the staker contract is active
+}
+
+// EvaluateOrUpdate checks the status of the staker contract and updates its state based on the current block number.
+// It returns a Status object containing the activation status and the current leader group.
+// If the staker contract is not active, it attempts to transition to dPoS on transition blocks.
+// If the staker contract is active, it performs housekeeping on epoch blocks.
+func (s *Staker) EvaluateOrUpdate(forkConfig *thor.ForkConfig, current uint32) (*Status, error) {
+	// still on PoA
+	if forkConfig.HAYABUSA+forkConfig.HAYABUSA_TP > current {
+		return &Status{Active: false}, nil
+	}
+
+	var err error
+	var activated bool
+	status := &Status{
+		LeaderGroup: make(map[thor.Address]*validation.Validation),
+	}
+
+	// check if the staker contract is active
+	status.Active, err = s.IsPoSActive()
+	if err != nil {
+		return nil, err
+	}
+
+	// attempt to transition if we're on a transition block and the staker contract is not active
+	if !status.Active && current%forkConfig.HAYABUSA_TP == 0 {
+		activated, err = s.transition(current)
+		if err != nil {
+			return nil, fmt.Errorf("failed to transition to dPoS: %w", err)
+		}
+		if activated {
+			status.Active = true
+		}
+	}
+
+	// perform housekeeping if the staker contract is active
+	if status.Active && !activated {
+		_, status.LeaderGroup, err = s.Housekeep(current)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return status, nil
+}

--- a/builtin/staker/protocol.go
+++ b/builtin/staker/protocol.go
@@ -16,11 +16,11 @@ type Status struct {
 	Updates bool // indicates if there are updates to the staker contract
 }
 
-// EvaluateOrUpdate checks the status of the staker contract and updates its state based on the current block number.
+// SyncPOS checks the status of the staker contract and updates its state based on the current block number.
 // It returns a Status object containing the activation status and the current leader group.
 // If the staker contract is not active, it attempts to transition to dPoS on transition blocks.
 // If the staker contract is active, it performs housekeeping on epoch blocks.
-func (s *Staker) EvaluateOrUpdate(forkConfig *thor.ForkConfig, current uint32) (Status, error) {
+func (s *Staker) SyncPOS(forkConfig *thor.ForkConfig, current uint32) (Status, error) {
 	status := Status{}
 	// still on PoA
 	if forkConfig.HAYABUSA+forkConfig.HAYABUSA_TP > current {

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -329,30 +329,9 @@ func (s *Staker) WithdrawStake(validator thor.Address, endorsor thor.Address, cu
 	return stake, nil
 }
 
-func (s *Staker) SetOnline(validator thor.Address, blockNum uint32, online bool) (bool, error) {
+func (s *Staker) SetOnline(validator thor.Address, blockNum uint32, online bool) error {
 	logger.Debug("set node online", "validator", validator, "online", online)
-	entry, err := s.validationService.GetValidation(validator)
-	if err != nil {
-		return false, err
-	}
-	hasChanged := entry.OfflineBlock == nil != online
-	if hasChanged {
-		s.setOfflineBlock(validator, online, blockNum, entry)
-		err = s.validationService.SetValidation(validator, entry, false)
-	} else {
-		err = nil
-	}
-	return hasChanged, err
-}
-
-func (s *Staker) setOfflineBlock(validator thor.Address, online bool, blockNum uint32, val *validation.Validation) {
-	if online {
-		logger.Info("clearing offline block", "validator", validator, "online", online)
-		val.OfflineBlock = nil
-	} else {
-		logger.Info("setting offline block", "validator", validator, "online", online, "offline block", blockNum)
-		val.OfflineBlock = &blockNum
-	}
+	return s.validationService.UpdateOfflineBlock(validator, blockNum, online)
 }
 
 func (s *Staker) SetBeneficiary(validator, endorsor, beneficiary thor.Address) error {

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -167,7 +167,7 @@ func (ts *TestSequence) AssertWithdrawable(
 }
 
 func (ts *TestSequence) SetOnline(id thor.Address, blockNum uint32, online bool) *TestSequence {
-	_, err := ts.staker.SetOnline(id, blockNum, online)
+	err := ts.staker.SetOnline(id, blockNum, online)
 	assert.NoError(ts.t, err, "failed to set online status for validator %s: %v", id.String(), err)
 	return ts
 }
@@ -284,7 +284,7 @@ func (ts *TestSequence) Housekeep(block uint32) *TestSequence {
 }
 
 func (ts *TestSequence) Transition(block uint32) *TestSequence {
-	_, err := ts.staker.Transition(block)
+	_, err := ts.staker.transition(block)
 	assert.NoError(ts.t, err, "failed to transition at block %d", block)
 	return ts
 }

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -278,7 +278,7 @@ func (ts *TestSequence) ActivateNext(block uint32) *TestSequence {
 }
 
 func (ts *TestSequence) Housekeep(block uint32) *TestSequence {
-	_, _, err := ts.staker.Housekeep(block)
+	_, err := ts.staker.Housekeep(block)
 	assert.NoError(ts.t, err, "failed to perform housekeeping at block %d", block)
 	return ts
 }

--- a/builtin/staker/transition.go
+++ b/builtin/staker/transition.go
@@ -11,8 +11,8 @@ import (
 	"github.com/vechain/thor/v2/thor"
 )
 
-// Transition activates the staker contract when sufficient validators are queued
-func (s *Staker) Transition(currentBlock uint32) (bool, error) {
+// transition activates the staker contract when sufficient validators are queued
+func (s *Staker) transition(currentBlock uint32) (bool, error) {
 	if currentBlock%EpochLength.Get() != 0 {
 		return false, nil // No transition needed
 	}

--- a/builtin/staker/validation/service.go
+++ b/builtin/staker/validation/service.go
@@ -492,6 +492,21 @@ func (s *Service) ActivateValidator(
 	return validatorRenewal, nil
 }
 
+// UpdateOfflineBlock updates the offline block for a validator.
+func (s *Service) UpdateOfflineBlock(validator thor.Address, block uint32, online bool) error {
+	validation, err := s.GetExistingValidation(validator)
+	if err != nil {
+		return err
+	}
+	if online {
+		validation.OfflineBlock = nil
+	} else {
+		validation.OfflineBlock = &block
+	}
+
+	return s.SetValidation(validator, validation, false)
+}
+
 //
 // Repository methods
 //

--- a/builtin/staker/validations_test.go
+++ b/builtin/staker/validations_test.go
@@ -83,7 +83,7 @@ func newStaker(t *testing.T, amount int, maxValidators int64, initialise bool) (
 				t.Fatal(err)
 			}
 		}
-		transitioned, err := staker.Transition(0)
+		transitioned, err := staker.transition(0)
 		assert.NoError(t, err)
 		assert.True(t, transitioned)
 	}
@@ -108,7 +108,7 @@ func TestStaker(t *testing.T) {
 		{M(stkr.LockedVET()), M(zeroStake, zeroStake, nil)},
 		{M(stkr.AddValidation(validator1, validator1, uint32(360)*24*15, stakeAmount)), M(nil)},
 		{M(stkr.AddValidation(validator2, validator2, uint32(360)*24*15, stakeAmount)), M(nil)},
-		{M(stkr.Transition(0)), M(true, nil)},
+		{M(stkr.transition(0)), M(true, nil)},
 		{M(stkr.LockedVET()), M(totalStake, totalStake, nil)},
 		{M(stkr.AddValidation(validator3, validator3, uint32(360)*24*15, stakeAmount)), M(nil)},
 		{M(stkr.FirstQueued()), M(&validator3, nil)},
@@ -1379,7 +1379,7 @@ func TestStaker_Initialise(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	transitioned, err := staker.Transition(0)
+	transitioned, err := staker.transition(0)
 	assert.NoError(t, err) // should succeed
 	assert.True(t, transitioned)
 	// should be able to add validations after initialisation

--- a/builtin/staker/validations_test.go
+++ b/builtin/staker/validations_test.go
@@ -393,7 +393,7 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
-	_, _, err = staker.Housekeep(180)
+	_, err = staker.Housekeep(180)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -432,7 +432,7 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	assert.Equal(t, stake, validator.LockedVET)
 	assert.Equal(t, validation.StatusActive, validator.Status)
 
-	_, _, err = staker.Housekeep(180 * 2)
+	_, err = staker.Housekeep(180 * 2)
 	assert.NoError(t, err)
 
 	validator, err = staker.Get(addr2)
@@ -539,7 +539,7 @@ func TestStaker_Get_FullFlow_Renewal_Off(t *testing.T) {
 	assert.NoError(t, err)
 
 	// housekeep the validator
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -812,7 +812,7 @@ func TestStaker_IncreaseActive(t *testing.T) {
 	assert.Equal(t, validator.LockedVET, validator.Weight)
 
 	// verify withdraw amount decrease
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -870,7 +870,7 @@ func TestStaker_ChangeStakeActiveValidatorWithQueued(t *testing.T) {
 	assert.Equal(t, stake, validator.Weight)
 
 	// verify withdraw amount decrease
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -898,7 +898,7 @@ func TestStaker_ChangeStakeActiveValidatorWithQueued(t *testing.T) {
 	assert.Equal(t, stake, queuedWeight)
 
 	// verify queued weight is decreased
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -950,7 +950,7 @@ func TestStaker_DecreaseActive(t *testing.T) {
 	assert.Equal(t, stake, validator.Weight)
 
 	// verify withdraw amount decrease
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -995,7 +995,7 @@ func TestStaker_DecreaseActiveThenExit(t *testing.T) {
 	assert.Equal(t, stake, validator.Weight)
 
 	// verify withdraw amount decrease
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -1005,7 +1005,7 @@ func TestStaker_DecreaseActiveThenExit(t *testing.T) {
 
 	assert.NoError(t, staker.SignalExit(addr, addr))
 
-	_, _, err = staker.Housekeep(period * 2)
+	_, err = staker.Housekeep(period * 2)
 	assert.NoError(t, err)
 
 	validator, err = staker.Get(addr)
@@ -1056,7 +1056,7 @@ func TestStaker_Get_FullFlow(t *testing.T) {
 	assert.NoError(t, err)
 
 	// housekeep the validator
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -1064,7 +1064,7 @@ func TestStaker_Get_FullFlow(t *testing.T) {
 	assert.Equal(t, big.NewInt(0), validator.LockedVET)
 	assert.Equal(t, big.NewInt(0), validator.Weight)
 
-	_, _, err = staker.Housekeep(period + CooldownPeriod.Get())
+	_, err = staker.Housekeep(period + CooldownPeriod.Get())
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -1104,7 +1104,7 @@ func TestStaker_Get_FullFlow_Renewal_On(t *testing.T) {
 	assert.Equal(t, stake, validator.Weight)
 
 	// housekeep the validator
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -1157,7 +1157,7 @@ func TestStaker_Get_FullFlow_Renewal_On_Then_Off(t *testing.T) {
 	assert.NoError(t, err)
 
 	// housekeep the validator
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -1175,7 +1175,7 @@ func TestStaker_Get_FullFlow_Renewal_On_Then_Off(t *testing.T) {
 	assert.NoError(t, staker.SignalExit(addr, addr))
 
 	// housekeep the validator
-	_, _, err = staker.Housekeep(period * 2)
+	_, err = staker.Housekeep(period * 2)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr)
 	assert.NoError(t, err)
@@ -1413,7 +1413,7 @@ func TestStaker_Housekeep_TooEarly(t *testing.T) {
 	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
-	_, _, err = staker.Housekeep(0)
+	_, err = staker.Housekeep(0)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1507,7 +1507,7 @@ func TestStaker_Housekeep_ExitOne(t *testing.T) {
 	assert.NoError(t, err)
 
 	// first should be on cooldown
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1525,7 +1525,7 @@ func TestStaker_Housekeep_ExitOne(t *testing.T) {
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), totalLocked)
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(2)), totalWeight)
 
-	_, _, err = staker.Housekeep(period + CooldownPeriod.Get())
+	_, err = staker.Housekeep(period + CooldownPeriod.Get())
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1588,7 +1588,7 @@ func TestStaker_Housekeep_Cooldown(t *testing.T) {
 	assert.Equal(t, big.NewInt(0).Mul(stake, big.NewInt(3)), totalWeight)
 
 	// housekeep and exit validator 1
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1605,7 +1605,7 @@ func TestStaker_Housekeep_Cooldown(t *testing.T) {
 	assert.Equal(t, 1, totalLocked.Sign())
 
 	// housekeep and exit validator 2
-	_, _, err = staker.Housekeep(period + EpochLength.Get())
+	_, err = staker.Housekeep(period + EpochLength.Get())
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr2)
 	assert.NoError(t, err)
@@ -1615,7 +1615,7 @@ func TestStaker_Housekeep_Cooldown(t *testing.T) {
 	assert.Equal(t, big.NewInt(0), validator.WithdrawableVET)
 
 	// housekeep and exit validator 3
-	_, _, err = staker.Housekeep(period + EpochLength.Get()*2)
+	_, err = staker.Housekeep(period + EpochLength.Get()*2)
 	assert.NoError(t, err)
 
 	totalLocked, totalWeight, err = staker.LockedVET()
@@ -1658,7 +1658,7 @@ func TestStaker_Housekeep_CooldownToExited(t *testing.T) {
 	err = staker.SignalExit(addr3, addr3)
 	assert.NoError(t, err)
 
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1667,7 +1667,7 @@ func TestStaker_Housekeep_CooldownToExited(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusActive, validator.Status)
 
-	_, _, err = staker.Housekeep(period + EpochLength.Get())
+	_, err = staker.Housekeep(period + EpochLength.Get())
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1705,7 +1705,7 @@ func TestStaker_Housekeep_ExitOrder(t *testing.T) {
 	err = staker.SignalExit(addr3, addr3)
 	assert.NoError(t, err)
 
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator2, err := staker.Get(addr2)
 	assert.NoError(t, err)
@@ -1719,12 +1719,12 @@ func TestStaker_Housekeep_ExitOrder(t *testing.T) {
 	assert.Equal(t, validation.StatusActive, validator1.Status)
 
 	// renew validator 1 for next period
-	_, _, err = staker.Housekeep(period * 2)
+	_, err = staker.Housekeep(period * 2)
 	assert.NoError(t, err)
 	assert.NoError(t, staker.SignalExit(addr1, addr1))
 
 	// housekeep -> validator 3 placed intention to leave first
-	_, _, err = staker.Housekeep(period * 3)
+	_, err = staker.Housekeep(period * 3)
 	assert.NoError(t, err)
 	validator3, err = staker.Get(addr3)
 	assert.NoError(t, err)
@@ -1735,7 +1735,7 @@ func TestStaker_Housekeep_ExitOrder(t *testing.T) {
 	assert.Equal(t, validation.StatusActive, validator1.Status)
 
 	// housekeep -> validator 1 waited 1 epoch after validator 3
-	_, _, err = staker.Housekeep(period*3 + EpochLength.Get())
+	_, err = staker.Housekeep(period*3 + EpochLength.Get())
 	assert.NoError(t, err)
 	validator1, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1759,7 +1759,7 @@ func TestStaker_Housekeep_RecalculateIncrease(t *testing.T) {
 	assert.NoError(t, err)
 
 	// housekeep half way through the period, validator's locked vet should not change
-	_, _, err = staker.Housekeep(period / 2)
+	_, err = staker.Housekeep(period / 2)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1768,7 +1768,7 @@ func TestStaker_Housekeep_RecalculateIncrease(t *testing.T) {
 	assert.Equal(t, big.NewInt(1), validator.QueuedVET)
 	assert.Equal(t, stake, validator.Weight)
 
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1798,7 +1798,7 @@ func TestStaker_Housekeep_RecalculateDecrease(t *testing.T) {
 	assert.NoError(t, err)
 
 	block := uint32(360) * 24 * 13
-	_, _, err = staker.Housekeep(block)
+	_, err = staker.Housekeep(block)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1808,7 +1808,7 @@ func TestStaker_Housekeep_RecalculateDecrease(t *testing.T) {
 	assert.Equal(t, decrease, validator.PendingUnlockVET)
 
 	block = uint32(360) * 24 * 15
-	_, _, err = staker.Housekeep(block)
+	_, err = staker.Housekeep(block)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1836,7 +1836,7 @@ func TestStaker_Housekeep_DecreaseThenWithdraw(t *testing.T) {
 	assert.NoError(t, err)
 
 	block := uint32(360) * 24 * 13
-	_, _, err = staker.Housekeep(block)
+	_, err = staker.Housekeep(block)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1846,7 +1846,7 @@ func TestStaker_Housekeep_DecreaseThenWithdraw(t *testing.T) {
 	assert.Equal(t, validator.PendingUnlockVET, big.NewInt(1))
 
 	block = uint32(360) * 24 * 15
-	_, _, err = staker.Housekeep(block)
+	_, err = staker.Housekeep(block)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1903,7 +1903,7 @@ func TestStaker_DecreaseActive_DecreaseMultipleTimes(t *testing.T) {
 	assert.Equal(t, stake, validator.LockedVET)
 	assert.Equal(t, validator.PendingUnlockVET, big.NewInt(2))
 
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1931,13 +1931,13 @@ func TestStaker_Housekeep_Cannot_Exit_If_It_Breaks_Finality(t *testing.T) {
 	assert.NoError(t, err)
 
 	exitBlock := uint32(360) * 24 * 15
-	_, _, err = staker.Housekeep(exitBlock)
+	_, err = staker.Housekeep(exitBlock)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusExit, validator.Status)
 
-	_, _, err = staker.Housekeep(exitBlock + 8640)
+	_, err = staker.Housekeep(exitBlock + 8640)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -1952,7 +1952,7 @@ func TestStaker_Housekeep_Cannot_Exit_If_It_Breaks_Finality(t *testing.T) {
 	_, err = staker.activateNextValidation(exitBlock+8640, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
-	_, _, err = staker.Housekeep(exitBlock + 8640 + 360)
+	_, err = staker.Housekeep(exitBlock + 8640 + 360)
 	assert.NoError(t, err)
 	validator, err = staker.Get(addr1)
 	assert.NoError(t, err)
@@ -2030,7 +2030,7 @@ func TestStaker_Housekeep_Adds_Queued_Validators_Up_To_Limit(t *testing.T) {
 	assert.Equal(t, big.NewInt(0).String(), leaderGroupSize.String())
 
 	block := uint32(360) * 24 * 13
-	_, _, err = staker.Housekeep(block)
+	_, err = staker.Housekeep(block)
 	assert.NoError(t, err)
 	validator, err := staker.Get(addr1)
 	assert.NoError(t, err)
@@ -2082,7 +2082,7 @@ func TestStaker_IncreaseStake_Withdraw(t *testing.T) {
 	err := staker.AddValidation(addr1, addr1, period, stake)
 	assert.NoError(t, err)
 
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 
 	val, err := staker.Get(addr1)
@@ -2148,7 +2148,7 @@ func TestStaker_GetCompletedPeriods(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(0), periods)
 
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 
 	periods, err = staker.GetCompletedPeriods(proposerAddr)
@@ -2185,7 +2185,7 @@ func TestStaker_MultipleUpdates_CorrectWithdraw(t *testing.T) {
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
 	// 1st STAKING PERIOD
-	_, _, err = staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 
 	validator, err = staker.Get(acc)
@@ -2214,7 +2214,7 @@ func TestStaker_MultipleUpdates_CorrectWithdraw(t *testing.T) {
 	assert.NoError(t, staker.IncreaseStake(acc, acc, fiveHundred))
 
 	// 2nd STAKING PERIOD
-	_, _, err = staker.Housekeep(period * 2)
+	_, err = staker.Housekeep(period * 2)
 	assert.NoError(t, err)
 	validator, err = staker.Get(acc)
 	assert.NoError(t, err)
@@ -2229,7 +2229,7 @@ func TestStaker_MultipleUpdates_CorrectWithdraw(t *testing.T) {
 	assert.NoError(t, staker.SignalExit(acc, acc))
 
 	// EXITED
-	_, _, err = staker.Housekeep(period * 3)
+	_, err = staker.Housekeep(period * 3)
 	assert.NoError(t, err)
 
 	validator, err = staker.Get(acc)
@@ -2359,7 +2359,7 @@ func Test_Validator_Decrease_Exit_Withdraw(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Housekeep, should exit the validator
-	_, _, err = staker.Housekeep(LowStakingPeriod.Get())
+	_, err = staker.Housekeep(LowStakingPeriod.Get())
 	assert.NoError(t, err)
 
 	validator, err := staker.Get(acc)
@@ -2430,7 +2430,7 @@ func Test_Validator_IncreaseDecrease_Combinations(t *testing.T) {
 	assert.Equal(t, MinStake, withdraw1, "withdraw should be 0 since we are withdrawing from pending locked")
 
 	// Housekeep, should move pending locked to locked, and pending withdraw to withdrawable
-	_, _, err = staker.Housekeep(LowStakingPeriod.Get())
+	_, err = staker.Housekeep(LowStakingPeriod.Get())
 	assert.NoError(t, err)
 
 	// Withdraw again

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -89,7 +89,7 @@ func (c *Consensus) NewRuntimeForReplay(header *block.Header, skipValidation boo
 
 	if !skipValidation {
 		staker := builtin.Staker.Native(state)
-		dPosStatus, err := staker.EvaluateOrUpdate(c.forkConfig, header.Number())
+		dPosStatus, err := staker.SyncPOS(c.forkConfig, header.Number())
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -94,7 +94,7 @@ func (c *Consensus) NewRuntimeForReplay(header *block.Header, skipValidation boo
 			return nil, err
 		}
 		if dPosStatus.Active {
-			err = c.validateStakingProposer(header, parentSummary.Header, staker, dPosStatus.LeaderGroup)
+			err = c.validateStakingProposer(header, parentSummary.Header, staker)
 		} else {
 			_, err = c.validateAuthorityProposer(header, parentSummary.Header, state)
 		}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -89,16 +89,12 @@ func (c *Consensus) NewRuntimeForReplay(header *block.Header, skipValidation boo
 
 	if !skipValidation {
 		staker := builtin.Staker.Native(state)
-		posActive, _, activeGroup, err := c.syncPOS(staker, header.Number())
+		dPosStatus, err := staker.EvaluateOrUpdate(c.forkConfig, header.Number())
 		if err != nil {
 			return nil, err
 		}
-		if len(activeGroup) > 0 {
-			// invalidate cache
-			c.validatorsCache.Add(header.ParentID(), activeGroup)
-		}
-		if posActive {
-			err = c.validateStakingProposer(header, parentSummary.Header, staker, activeGroup)
+		if dPosStatus.Active {
+			err = c.validateStakingProposer(header, parentSummary.Header, staker, dPosStatus.LeaderGroup)
 		} else {
 			_, err = c.validateAuthorityProposer(header, parentSummary.Header, state)
 		}

--- a/consensus/pos_validator.go
+++ b/consensus/pos_validator.go
@@ -31,28 +31,18 @@ func (c *Consensus) validateStakingProposer(
 	if err != nil {
 		return err
 	}
-
 	var leaders map[thor.Address]*validation.Validation
-	if entry, ok := c.validatorsCache.Get(parent.ID()); ok {
-		possiblyLeaders, ok := entry.(*map[thor.Address]*validation.Validation)
-		if ok {
-			leaders = *possiblyLeaders
-		} else {
-			leaders, err = staker.LeaderGroup()
-			if err != nil {
-				return err
-			}
-		}
+	if len(providedLeaders) > 0 {
+		leaders = providedLeaders
+	} else if cached, ok := c.validatorsCache.Get(header.ParentID()); ok {
+		leaders = (cached).(map[thor.Address]*validation.Validation)
 	} else {
-		if len(providedLeaders) > 0 {
-			leaders = providedLeaders
-		} else {
-			leaders, err = staker.LeaderGroup()
-			if err != nil {
-				return err
-			}
+		leaders, err = staker.LeaderGroup()
+		if err != nil {
+			return consensusError(fmt.Sprintf("pos - cannot get leader group: %v", err))
 		}
 	}
+
 	sched, err := pos.NewScheduler(signer, leaders, parent.Number(), parent.Timestamp(), seed)
 	if err != nil {
 		return consensusError(fmt.Sprintf("pos - block signer invalid: %v %v", signer, err))
@@ -77,17 +67,12 @@ func (c *Consensus) validateStakingProposer(
 		return consensusError(fmt.Sprintf("pos - stake beneficiary mismatch: want %v, have %v", *validator.Beneficiary, header.Beneficiary()))
 	}
 
-	hasUpdates := false
 	for addr, online := range updates {
-		updated, err := staker.SetOnline(addr, header.Number(), online)
-		if err != nil {
+		if err := staker.SetOnline(addr, header.Number(), online); err != nil {
 			return err
 		}
-		if updated {
-			hasUpdates = true
-		}
 	}
-	if !hasUpdates {
+	if len(updates) == 0 {
 		c.validatorsCache.Add(header.ID(), leaders)
 	}
 

--- a/consensus/pos_validator_test.go
+++ b/consensus/pos_validator_test.go
@@ -123,7 +123,7 @@ func (h *hayabusaSetup) mintBlock(txs ...*tx.Transaction) (*chain.BlockSummary, 
 	assert.NoError(h.t, err)
 
 	st := h.chain.Stater().NewState(parent.Root())
-	_, err = builtin.Staker.Native(st).EvaluateOrUpdate(h.config, best.Header.Number())
+	_, err = builtin.Staker.Native(st).SyncPOS(h.config, best.Header.Number())
 	assert.NoError(h.t, err)
 
 	// actualGroup, err := builtin.Staker.Native(st).LeaderGroup()

--- a/consensus/pos_validator_test.go
+++ b/consensus/pos_validator_test.go
@@ -31,10 +31,7 @@ func TestConsensus_PosFork(t *testing.T) {
 
 	// mint block 2: chain should set the staker contract, still using PoA
 	best, parent, st := setup.mintBlock()
-	leaders, err := builtin.Staker.Native(st).LeaderGroup()
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(leaders))
-	err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st), leaders)
+	err := setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
 	assert.Error(t, err)
 	_, err = setup.consensus.validateAuthorityProposer(best.Header, parent.Header, st)
 	assert.NoError(t, err)
@@ -44,9 +41,7 @@ func TestConsensus_PosFork(t *testing.T) {
 
 	// mint block 4: chain should switch to PoS
 	best, parent, st = setup.mintBlock()
-	leaders, err = builtin.Staker.Native(st).LeaderGroup()
-	assert.NoError(t, err)
-	err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st), leaders)
+	err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
 	assert.NoError(t, err)
 }
 
@@ -67,9 +62,7 @@ func TestConsensus_POS_MissedSlots(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, setup.chain.AddBlock(blk, stage, receipts))
 
-	leaders, err := builtin.Staker.Native(st).LeaderGroup()
-	assert.NoError(t, err)
-	err = setup.consensus.validateStakingProposer(blk.Header(), parent.Header, builtin.Staker.Native(st), leaders)
+	err = setup.consensus.validateStakingProposer(blk.Header(), parent.Header, builtin.Staker.Native(st))
 	assert.NoError(t, err)
 	staker := builtin.Staker.Native(st)
 	validator, err := staker.Get(signer.Address)
@@ -93,9 +86,7 @@ func TestConsensus_POS_Unscheduled(t *testing.T) {
 	blk, _, _, err := flow.Pack(signer.PrivateKey, 0, false)
 	assert.NoError(t, err)
 
-	leaders, err := builtin.Staker.Native(st).LeaderGroup()
-	assert.NoError(t, err)
-	err = setup.consensus.validateStakingProposer(blk.Header(), parent.Header, builtin.Staker.Native(st), leaders)
+	err = setup.consensus.validateStakingProposer(blk.Header(), parent.Header, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "block timestamp unscheduled")
 }
 

--- a/consensus/pos_validator_test.go
+++ b/consensus/pos_validator_test.go
@@ -132,8 +132,7 @@ func (h *hayabusaSetup) mintBlock(txs ...*tx.Transaction) (*chain.BlockSummary, 
 	assert.NoError(h.t, err)
 
 	st := h.chain.Stater().NewState(parent.Root())
-	staker := builtin.Staker.Native(st)
-	_, _, _, err = h.consensus.syncPOS(staker, best.Header.Number())
+	_, err = builtin.Staker.Native(st).EvaluateOrUpdate(h.config, best.Header.Number())
 	assert.NoError(h.t, err)
 
 	// actualGroup, err := builtin.Staker.Native(st).LeaderGroup()

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -37,6 +37,9 @@ func (c *Consensus) validate(
 	if err != nil {
 		return nil, nil, err
 	}
+	if dPosStatus.Updates {
+		c.validatorsCache.Remove(parent.ID())
+	}
 
 	if err := c.validateBlockHeader(header, parent, nowTimestamp); err != nil {
 		return nil, nil, err
@@ -44,7 +47,7 @@ func (c *Consensus) validate(
 
 	var candidates *poa.Candidates
 	if dPosStatus.Active {
-		err = c.validateStakingProposer(header, parent, staker, dPosStatus.LeaderGroup)
+		err = c.validateStakingProposer(header, parent, staker)
 	} else {
 		candidates, err = c.validateAuthorityProposer(header, parent, state)
 	}

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -33,7 +33,7 @@ func (c *Consensus) validate(
 	header := block.Header()
 
 	staker := builtin.Staker.Native(state)
-	dPosStatus, err := staker.EvaluateOrUpdate(c.forkConfig, header.Number())
+	dPosStatus, err := staker.SyncPOS(c.forkConfig, header.Number())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/genesis/devnet.go
+++ b/genesis/devnet.go
@@ -228,11 +228,11 @@ func NewHayabusaDevnet(forkConfig *thor.ForkConfig) *Genesis {
 				return err
 			}
 
-			transitioned, err := builtin.Staker.Native(state).Transition(0)
+			status, err := builtin.Staker.Native(state).EvaluateOrUpdate(forkConfig, 0)
 			if err != nil {
 				return err
 			}
-			if !transitioned {
+			if !status.Active {
 				return errors.New("the transition of the validator state didn't happen")
 			}
 

--- a/genesis/devnet.go
+++ b/genesis/devnet.go
@@ -228,7 +228,7 @@ func NewHayabusaDevnet(forkConfig *thor.ForkConfig) *Genesis {
 				return err
 			}
 
-			status, err := builtin.Staker.Native(state).EvaluateOrUpdate(forkConfig, 0)
+			status, err := builtin.Staker.Native(state).SyncPOS(forkConfig, 0)
 			if err != nil {
 				return err
 			}

--- a/packer/packer.go
+++ b/packer/packer.go
@@ -67,7 +67,7 @@ func (p *Packer) Schedule(parent *chain.BlockSummary, nowTimestamp uint64) (*Flo
 	}
 
 	var sched scheduler
-	dPosStatus, err := builtin.Staker.Native(st).EvaluateOrUpdate(p.forkConfig, parent.Header.Number()+1)
+	dPosStatus, err := builtin.Staker.Native(st).SyncPOS(p.forkConfig, parent.Header.Number()+1)
 	if err != nil {
 		return nil, false, err
 	}
@@ -110,7 +110,7 @@ func (p *Packer) Mock(parent *chain.BlockSummary, targetTime uint64, gasLimit ui
 		features |= tx.DelegationFeature
 	}
 
-	dPosStatus, err := builtin.Staker.Native(state).EvaluateOrUpdate(p.forkConfig, parent.Header.Number()+1)
+	dPosStatus, err := builtin.Staker.Native(state).SyncPOS(p.forkConfig, parent.Header.Number()+1)
 	if err != nil {
 		return nil, false, err
 	}

--- a/packer/pos_scheduler.go
+++ b/packer/pos_scheduler.go
@@ -42,8 +42,7 @@ func (p *Packer) schedulePOS(parent *chain.BlockSummary, nowTimestamp uint64, st
 	updates, score := sched.Updates(newBlockTime, weight)
 
 	for addr, online := range updates {
-		_, err := staker.SetOnline(addr, parent.Header.Number()+1, online)
-		if err != nil {
+		if err := staker.SetOnline(addr, parent.Header.Number()+1, online); err != nil {
 			return thor.Address{}, 0, 0, err
 		}
 	}


### PR DESCRIPTION
# Description

- removes duplicated logic from `packer` and `consensus` to inside staker package
- don't return leadergroup from housekeeping, only a bool indicating if it needs to 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
