### PR TITLE
Block max block proposers if config is locked

### DIFF
--- a/builtin/params/params.go
+++ b/builtin/params/params.go
@@ -6,6 +6,7 @@
 package params
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/rlp"
@@ -38,6 +39,10 @@ func (p *Params) Get(key thor.Bytes32) (value *big.Int, err error) {
 
 // Set native way to set param.
 func (p *Params) Set(key thor.Bytes32, value *big.Int) error {
+	if key == thor.KeyMaxBlockProposers && thor.IsLocked() {
+		return fmt.Errorf("cannot set max-block-proposers config param")
+	}
+
 	return p.state.EncodeStorage(p.addr, key, func() ([]byte, error) {
 		if value.Sign() == 0 {
 			return nil, nil

--- a/builtin/params/params_test.go
+++ b/builtin/params/params_test.go
@@ -27,4 +27,17 @@ func TestParamsGetSet(t *testing.T) {
 	getv, err := p.Get(key)
 	assert.Nil(t, err)
 	assert.Equal(t, setv, getv)
+
+	err = p.Set(thor.KeyMaxBlockProposers, big.NewInt(2))
+	assert.Nil(t, err)
+	getMbp, err := p.Get(thor.KeyMaxBlockProposers)
+	assert.Nil(t, err)
+	assert.Equal(t, big.NewInt(2), getMbp)
+
+	thor.LockConfig()
+	err = p.Set(thor.KeyMaxBlockProposers, big.NewInt(10))
+	assert.ErrorContains(t, err, "cannot set max-block-proposers config param")
+	getMbp, err = p.Get(thor.KeyMaxBlockProposers)
+	assert.Nil(t, err)
+	assert.Equal(t, big.NewInt(2), getMbp)
 }

--- a/thor/config.go
+++ b/thor/config.go
@@ -89,6 +89,10 @@ func LockConfig() {
 	locked = true
 }
 
+func IsLocked() bool {
+	return locked
+}
+
 func BlockInterval() uint64 {
 	return blockInterval
 }


### PR DESCRIPTION
# Description

Disable setting of max block proposer key if config is locked

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
