### PR TITLE
move reverts error from services to staker

### DIFF
--- a/builtin/staker/delegation/service.go
+++ b/builtin/staker/delegation/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/vechain/thor/v2/builtin/solidity"
-	"github.com/vechain/thor/v2/builtin/staker/reverts"
 	"github.com/vechain/thor/v2/builtin/staker/validation"
 	"github.com/vechain/thor/v2/thor"
 )
@@ -54,11 +53,6 @@ func (s *Service) Add(
 	stake uint64,
 	multiplier uint8,
 ) (*big.Int, error) {
-	// ensure input is sane
-	if multiplier == 0 {
-		return nil, reverts.New("multiplier cannot be 0")
-	}
-
 	// update the global delegation counter
 	id, err := s.idCounter.Get()
 	if err != nil {
@@ -86,13 +80,6 @@ func (s *Service) Add(
 }
 
 func (s *Service) SignalExit(delegation *Delegation, delegationID *big.Int, valCurrentIteration uint32) error {
-	if delegation.LastIteration != nil {
-		return reverts.New("delegation is already disabled for auto-renew")
-	}
-	if delegation.Stake == 0 {
-		return reverts.New("delegation is not active")
-	}
-
 	delegation.LastIteration = &valCurrentIteration
 
 	return s.setDelegation(delegationID, delegation, false)

--- a/builtin/staker/delegation/service_test.go
+++ b/builtin/staker/delegation/service_test.go
@@ -53,13 +53,6 @@ func TestService_Add_And_GetDelegation(t *testing.T) {
 	assert.Nil(t, del.LastIteration)
 }
 
-func TestService_Add_InputValidation(t *testing.T) {
-	svc, _, _ := newSvc()
-
-	_, err := svc.Add(thor.Address{}, 1, 1, 0)
-	assert.ErrorContains(t, err, "multiplier cannot be 0")
-}
-
 func TestService_SetDelegation_RoundTrip(t *testing.T) {
 	svc, _, _ := newSvc()
 	v := thor.BytesToAddress([]byte("v"))
@@ -77,38 +70,6 @@ func TestService_SetDelegation_RoundTrip(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint8(99), got.Multiplier)
 	assert.Equal(t, uint32(5), got.FirstIteration)
-}
-
-func TestService_SignalExit(t *testing.T) {
-	svc, _, _ := newSvc()
-	v := thor.BytesToAddress([]byte("v"))
-	id, err := svc.Add(v, 3, 1000, 10)
-	assert.NoError(t, err)
-
-	del, err := svc.GetDelegation(id)
-	assert.NoError(t, err)
-
-	assert.NoError(t, svc.SignalExit(del, id, 7))
-
-	del2, err := svc.GetDelegation(id)
-	assert.NoError(t, err)
-	assert.NotNil(t, del2.LastIteration)
-	assert.Equal(t, uint32(7), *del2.LastIteration)
-
-	assert.ErrorContains(t, svc.SignalExit(del2, id, 8), "already disabled")
-}
-
-func TestService_SignalExit_NotActive(t *testing.T) {
-	svc, _, _ := newSvc()
-	v := thor.BytesToAddress([]byte("v"))
-	id, err := svc.Add(v, 1, 100, 10)
-	assert.NoError(t, err)
-
-	del, err := svc.GetDelegation(id)
-	assert.NoError(t, err)
-
-	del.Stake = 0
-	assert.ErrorContains(t, svc.SignalExit(del, id, 5), "delegation is not active")
 }
 
 func TestService_Withdraw(t *testing.T) {

--- a/builtin/staker/delegations_test.go
+++ b/builtin/staker/delegations_test.go
@@ -186,7 +186,7 @@ func Test_AddDelegator_ValidatorNotFound(t *testing.T) {
 	staker, _ := newStaker(t, 75, 101, true)
 
 	_, err := staker.AddDelegation(thor.Address{}, delegationStake(), 255)
-	assert.ErrorContains(t, err, "failed to get validator")
+	assert.ErrorContains(t, err, "validation does not exist")
 }
 
 func Test_AddDelegator_ManyValidators(t *testing.T) {

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -481,7 +481,7 @@ func (s *Staker) AddDelegation(
 
 // SignalDelegationExit updates the auto-renewal status of a delegation.
 func (s *Staker) SignalDelegationExit(delegationID *big.Int) error {
-	logger.Debug("updating autorenew", "delegationID", delegationID)
+	logger.Debug("signal delegation exit", "delegationID", delegationID)
 
 	del, err := s.delegationService.GetDelegation(delegationID)
 	if err != nil {
@@ -492,6 +492,9 @@ func (s *Staker) SignalDelegationExit(delegationID *big.Int) error {
 	}
 	if del.LastIteration != nil {
 		return reverts.New("delegation is already signaled exit")
+	}
+	if del.Stake == 0 {
+		return reverts.New("delegation has already been withdrawn")
 	}
 
 	val, err := s.validationService.GetValidation(del.Validation)
@@ -508,7 +511,7 @@ func (s *Staker) SignalDelegationExit(delegationID *big.Int) error {
 	}
 
 	if err = s.delegationService.SignalExit(del, delegationID, val.CurrentIteration()); err != nil {
-		logger.Info("update autorenew failed", "delegationID", delegationID, "error", err)
+		logger.Info("signal delegation exit failed", "delegationID", delegationID, "error", err)
 		return err
 	}
 
@@ -517,7 +520,7 @@ func (s *Staker) SignalDelegationExit(delegationID *big.Int) error {
 		return err
 	}
 
-	logger.Info("updated autorenew", "delegationID", delegationID)
+	logger.Info("signal delegation exit", "delegationID", delegationID)
 	return nil
 }
 

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -217,6 +217,22 @@ func (s *Staker) AddValidation(
 		"stake", stake,
 	)
 
+	if stake < MinStakeVET || stake > MaxStakeVET {
+		return reverts.New("stake is out of range")
+	}
+
+	val, err := s.validationService.GetValidation(validator)
+	if err != nil {
+		return err
+	}
+	if !val.IsEmpty() {
+		return reverts.New("validator already exists")
+	}
+
+	if period != thor.LowStakingPeriod() && period != thor.MediumStakingPeriod() && period != thor.HighStakingPeriod() {
+		return reverts.New("period is out of boundaries")
+	}
+
 	// create a new validation
 	if err := s.validationService.Add(validator, endorser, period, stake); err != nil {
 		logger.Info("add validator failed", "validator", validator, "error", err)
@@ -224,8 +240,7 @@ func (s *Staker) AddValidation(
 	}
 
 	// update global totals
-	err := s.globalStatsService.AddQueued(stakes.NewWeightedStakeWithMultiplier(stake, validation.Multiplier))
-	if err != nil {
+	if err := s.globalStatsService.AddQueued(stakes.NewWeightedStakeWithMultiplier(stake, validation.Multiplier)); err != nil {
 		return err
 	}
 
@@ -236,7 +251,21 @@ func (s *Staker) AddValidation(
 func (s *Staker) SignalExit(validator thor.Address, endorser thor.Address) error {
 	logger.Debug("signal exit", "endorser", endorser, "validator", validator)
 
-	if err := s.validationService.SignalExit(validator, endorser); err != nil {
+	val, err := s.validationService.GetValidation(validator)
+	if err != nil {
+		return err
+	}
+	if val.IsEmpty() {
+		return reverts.New("validation does not exist")
+	}
+	if val.Endorser != endorser {
+		return reverts.New("endorser required")
+	}
+	if val.Status != validation.StatusActive {
+		return reverts.New("can't signal exit while not active")
+	}
+
+	if err := s.validationService.SignalExit(validator, val); err != nil {
 		logger.Info("signal exit failed", "validator", validator, "error", err)
 		return err
 	}
@@ -250,13 +279,30 @@ func (s *Staker) SignalExit(validator thor.Address, endorser thor.Address) error
 func (s *Staker) IncreaseStake(validator thor.Address, endorser thor.Address, amount uint64) error {
 	logger.Debug("increasing stake", "endorser", endorser, "validator", validator, "amount", amount)
 
-	if err := s.validationService.IncreaseStake(validator, endorser, amount); err != nil {
+	val, err := s.validationService.GetValidation(validator)
+	if err != nil {
+		return err
+	}
+	if val.IsEmpty() {
+		return reverts.New("validation does not exist")
+	}
+	if val.Endorser != endorser {
+		return reverts.New("endorser required")
+	}
+	if val.Status == validation.StatusExit {
+		return reverts.New("validator exited")
+	}
+	if val.Status == validation.StatusActive && val.ExitBlock != nil {
+		return reverts.New("validator has signaled exit, cannot increase stake")
+	}
+
+	if err := s.validationService.IncreaseStake(validator, val, amount); err != nil {
 		logger.Info("increase stake failed", "validator", validator, "error", err)
 		return err
 	}
 
 	// validate that new TVL is <= Max stake
-	if err := s.validateNextPeriodTVL(validator); err != nil {
+	if err := s.validateNextPeriodTVL(validator, val); err != nil {
 		return err
 	}
 
@@ -272,13 +318,45 @@ func (s *Staker) IncreaseStake(validator thor.Address, endorser thor.Address, am
 func (s *Staker) DecreaseStake(validator thor.Address, endorser thor.Address, amount uint64) error {
 	logger.Debug("decreasing stake", "endorser", endorser, "validator", validator, "amount", amount)
 
-	queued, err := s.validationService.DecreaseStake(validator, endorser, amount)
+	val, err := s.GetValidation(validator)
 	if err != nil {
+		return err
+	}
+	if val.IsEmpty() {
+		return reverts.New("validation does not exist")
+	}
+	if val.Endorser != endorser {
+		return reverts.New("endorser required")
+	}
+	if val.Status == validation.StatusExit {
+		return reverts.New("validator exited")
+	}
+	if val.Status == validation.StatusActive && val.ExitBlock != nil {
+		return reverts.New("validator has signaled exit, cannot decrease stake")
+	}
+
+	if val.Status == validation.StatusActive {
+		// We don't consider any increases, i.e., entry.QueuedVET. We only consider locked and current decreases.
+		// The reason is that validator can instantly withdraw QueuedVET at any time.
+		// We need to make sure the locked VET minus the sum of the current decreases is still above the minimum stake.
+		if val.LockedVET-val.PendingUnlockVET-amount < MinStakeVET {
+			return reverts.New("next period stake is lower than minimum stake")
+		}
+	}
+
+	if val.Status == validation.StatusQueued {
+		// All the validator's stake exists within QueuedVET, so we need to make sure it maintains a minimum of MinStake.
+		if val.QueuedVET-amount < MinStakeVET {
+			return reverts.New("next period stake is lower than minimum stake")
+		}
+	}
+
+	if err = s.validationService.DecreaseStake(validator, val, amount); err != nil {
 		logger.Info("decrease stake failed", "validator", validator, "error", err)
 		return err
 	}
 
-	if queued {
+	if val.Status == validation.StatusQueued {
 		// update global totals, use the initial multiplier
 		err = s.globalStatsService.RemoveQueued(stakes.NewWeightedStakeWithMultiplier(amount, validation.Multiplier))
 		if err != nil {
@@ -293,8 +371,18 @@ func (s *Staker) DecreaseStake(validator thor.Address, endorser thor.Address, am
 // WithdrawStake allows expired validations to withdraw their stake.
 func (s *Staker) WithdrawStake(validator thor.Address, endorser thor.Address, currentBlock uint32) (uint64, error) {
 	logger.Debug("withdrawing stake", "endorser", endorser, "validator", validator)
+	val, err := s.GetValidation(validator)
+	if err != nil {
+		return 0, err
+	}
+	if val.IsEmpty() {
+		return 0, reverts.New("validation does not exist")
+	}
+	if val.Endorser != endorser {
+		return 0, reverts.New("endorser required")
+	}
 
-	stake, queued, err := s.validationService.WithdrawStake(validator, endorser, currentBlock)
+	stake, queued, err := s.validationService.WithdrawStake(validator, val, currentBlock)
 	if err != nil {
 		logger.Info("withdraw failed", "validator", validator, "error", err)
 		return 0, err
@@ -319,7 +407,22 @@ func (s *Staker) SetOnline(validator thor.Address, blockNum uint32, online bool)
 
 func (s *Staker) SetBeneficiary(validator, endorser, beneficiary thor.Address) error {
 	logger.Debug("set beneficiary", "validator", validator, "beneficiary", beneficiary)
-	if err := s.validationService.SetBeneficiary(validator, endorser, beneficiary); err != nil {
+
+	val, err := s.GetValidation(validator)
+	if err != nil {
+		return err
+	}
+	if val.IsEmpty() {
+		return reverts.New("validation does not exist")
+	}
+	if val.Endorser != endorser {
+		return reverts.New("endorser required")
+	}
+	if val.Status == validation.StatusExit || val.ExitBlock != nil {
+		return reverts.New("validator has exited or signaled exit, cannot set beneficiary")
+	}
+
+	if err := s.validationService.SetBeneficiary(validator, val, beneficiary); err != nil {
 		logger.Info("set beneficiary failed", "validator", validator, "error", err)
 		return err
 	}
@@ -334,10 +437,16 @@ func (s *Staker) AddDelegation(
 ) (*big.Int, error) {
 	logger.Debug("adding delegation", "validator", validator, "stake", stake, "multiplier", multiplier)
 
+	if multiplier == 0 {
+		return nil, reverts.New("multiplier cannot be 0")
+	}
 	// ensure validation is ok to receive a new delegation
-	val, err := s.validationService.GetExistingValidation(validator)
+	val, err := s.validationService.GetValidation(validator)
 	if err != nil {
 		return nil, err
+	}
+	if val.IsEmpty() {
+		return nil, reverts.New("validation does not exist")
 	}
 
 	if val.Status != validation.StatusQueued && val.Status != validation.StatusActive {
@@ -357,7 +466,7 @@ func (s *Staker) AddDelegation(
 	}
 
 	// validate that new TVL is <= Max stake
-	if err = s.validateNextPeriodTVL(validator); err != nil {
+	if err = s.validateNextPeriodTVL(validator, val); err != nil {
 		return nil, err
 	}
 
@@ -378,9 +487,11 @@ func (s *Staker) SignalDelegationExit(delegationID *big.Int) error {
 	if err != nil {
 		return err
 	}
-
 	if del.IsEmpty() {
 		return reverts.New("delegation is empty")
+	}
+	if del.LastIteration != nil {
+		return reverts.New("delegation is already signaled exit")
 	}
 
 	val, err := s.validationService.GetValidation(del.Validation)
@@ -462,19 +573,14 @@ func (s *Staker) IncreaseDelegatorsReward(node thor.Address, reward *big.Int) er
 	return s.validationService.IncreaseDelegatorsReward(node, reward)
 }
 
-func (s *Staker) validateNextPeriodTVL(validator thor.Address) error {
-	val, err := s.validationService.GetValidation(validator)
-	if err != nil {
-		return err
-	}
-
+func (s *Staker) validateNextPeriodTVL(validator thor.Address, validation *validation.Validation) error {
 	agg, err := s.aggregationService.GetAggregation(validator)
 	if err != nil {
 		return err
 	}
 
 	// accumulated TVL should cannot be more than MaxStake
-	if val.NextPeriodTVL()+agg.NextPeriodTVL() > MaxStakeVET {
+	if validation.NextPeriodTVL()+agg.NextPeriodTVL() > MaxStakeVET {
 		return reverts.New("stake is out of range")
 	}
 

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -12,10 +12,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/vechain/thor/v2/builtin/params"
 	"github.com/vechain/thor/v2/builtin/staker/aggregation"
 	"github.com/vechain/thor/v2/builtin/staker/delegation"
+	"github.com/vechain/thor/v2/builtin/staker/delta"
+	"github.com/vechain/thor/v2/builtin/staker/stakes"
 	"github.com/vechain/thor/v2/builtin/staker/validation"
+	"github.com/vechain/thor/v2/muxdb"
+	"github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/thor"
+	"github.com/vechain/thor/v2/trie"
 )
 
 type TestSequence struct {
@@ -458,4 +464,294 @@ func (da *DelegationAssertions) IsStarted(expected bool) *DelegationAssertions {
 func (da *DelegationAssertions) IsFinished(expected bool) *DelegationAssertions {
 	assert.Equal(da.t, expected, da.delegation.Ended(da.validation), "delegation %s finished state mismatch", da.delegationID.String())
 	return da
+}
+
+func newTestStaker() *Staker {
+	db := muxdb.NewMem()
+	st := state.New(db, trie.Root{})
+
+	addr := thor.BytesToAddress([]byte("staker"))
+	return New(addr, st, params.New(addr, st), nil)
+}
+
+func TestValidation_SignalExit_InvalidEndorser(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := thor.BytesToAddress([]byte("endorse"))
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), 100))
+
+	err := staker.SignalExit(id, thor.BytesToAddress([]byte("wrong")))
+	assert.ErrorContains(t, err, "endorser required")
+}
+
+func TestValidation_SignalExit_NotActive(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), 100))
+
+	err := staker.SignalExit(id, end)
+	assert.ErrorContains(t, err, "can't signal exit while not active")
+}
+
+func TestService_IncreaseStake_UnknownValidator(t *testing.T) {
+	staker := newTestStaker()
+	id := thor.BytesToAddress([]byte("unknown"))
+	err := staker.IncreaseStake(id, id, 1)
+	assert.ErrorContains(t, err, "validation does not exist")
+}
+
+func TestValidation_IncreaseStake_InvalidEndorser(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := thor.BytesToAddress([]byte("endorse"))
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), 100))
+
+	err := staker.IncreaseStake(id, thor.BytesToAddress([]byte("wrong")), 10)
+	assert.ErrorContains(t, err, "endorser required")
+}
+
+func TestValidation_IncreaseStake_StatusExit(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), 100))
+
+	_, err := staker.WithdrawStake(id, end, 1)
+	assert.NoError(t, err)
+
+	err = staker.IncreaseStake(id, end, 5)
+	assert.ErrorContains(t, err, "validator exited")
+}
+
+func TestValidation_IncreaseStake_ActiveHasExitBlock(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), 100))
+
+	staker.validationService.ActivateValidator(id, 0, &delta.Renewal{
+		LockedIncrease: stakes.NewWeightedStake(0, 0),
+		LockedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+	})
+
+	err := staker.SignalExit(id, end)
+	assert.NoError(t, err)
+
+	err = staker.IncreaseStake(id, end, 5)
+	assert.ErrorContains(t, err, "validator has signaled exit, cannot increase stake")
+}
+
+func TestValidation_DecreaseStake_UnknownValidator(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("unknown"))
+	err := staker.DecreaseStake(id, id, 1)
+	assert.ErrorContains(t, err, "validation does not exist")
+}
+
+func TestValidation_DecreaseStake_InvalidEndorser(t *testing.T) {
+	staker := newTestStaker()
+	id := thor.BytesToAddress([]byte("v"))
+	end := thor.BytesToAddress([]byte("endorse"))
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), 100))
+
+	err := staker.DecreaseStake(id, thor.BytesToAddress([]byte("wrong")), 1)
+	assert.ErrorContains(t, err, "endorser required")
+}
+
+func TestValidation_DecreaseStake_StatusExit(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), 100))
+
+	staker.validationService.ActivateValidator(id, 0, &delta.Renewal{
+		LockedIncrease: stakes.NewWeightedStake(0, 0),
+		LockedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+	})
+
+	err := staker.SignalExit(id, end)
+	assert.NoError(t, err)
+
+	err = staker.DecreaseStake(id, end, 5)
+	assert.ErrorContains(t, err, "validator has signaled exit, cannot decrease stake")
+}
+
+func TestValidation_DecreaseStake_ActiveHasExitBlock(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), 100))
+
+	staker.validationService.ActivateValidator(id, 0, &delta.Renewal{
+		LockedIncrease: stakes.NewWeightedStake(0, 0),
+		LockedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+	})
+
+	err := staker.SignalExit(id, end)
+	assert.NoError(t, err)
+
+	err = staker.DecreaseStake(id, end, 5)
+	assert.ErrorContains(t, err, "validator has signaled exit, cannot decrease stake")
+}
+
+func TestValidation_DecreaseStake_ActiveTooLowNextPeriod(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.AddValidation(id, end, thor.MediumStakingPeriod(), MinStakeVET))
+
+	err := staker.DecreaseStake(id, end, 100)
+	assert.ErrorContains(t, err, "next period stake is lower than minimum stake")
+}
+
+func TestValidation_DecreaseStake_ActiveSuccess(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.validationService.Add(id, end, thor.MediumStakingPeriod(), MinStakeVET+100))
+
+	staker.validationService.ActivateValidator(id, 0, &delta.Renewal{
+		LockedIncrease: stakes.NewWeightedStake(0, 0),
+		LockedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+	})
+
+	err := staker.DecreaseStake(id, end, 100)
+	assert.NoError(t, err)
+
+	v, err := staker.validationService.GetValidation(id)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(100), v.PendingUnlockVET)
+	assert.Equal(t, MinStakeVET+100, v.LockedVET)
+}
+
+func TestValidation_DecreaseStake_QueuedTooLowNextPeriod(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.AddValidation(id, end, thor.MediumStakingPeriod(), MinStakeVET))
+
+	err := staker.DecreaseStake(id, end, 100)
+	assert.ErrorContains(t, err, "next period stake is lower than minimum stake")
+}
+
+func TestValidation_DecreaseStake_QueuedSuccess(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	end := id
+
+	assert.NoError(t, staker.AddValidation(id, end, thor.MediumStakingPeriod(), MinStakeVET+100))
+
+	assert.NoError(t, staker.DecreaseStake(id, end, 100))
+
+	v, err := staker.GetValidation(id)
+	assert.NoError(t, err)
+	assert.Equal(t, MinStakeVET, v.QueuedVET)
+	assert.Equal(t, uint64(100), v.WithdrawableVET)
+}
+
+func TestValidation_WithdrawStake_InvalidEndorser(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	endorsor := id
+	assert.NoError(t, staker.AddValidation(id, endorsor, thor.LowStakingPeriod(), MinStakeVET))
+
+	amt, err := staker.WithdrawStake(id, thor.BytesToAddress([]byte("wrong")), 0)
+	assert.Equal(t, uint64(0), amt)
+	assert.ErrorContains(t, err, "endorser required")
+}
+
+func TestValidationAdd_Error(t *testing.T) {
+	staker := newTestStaker()
+
+	id1 := thor.BytesToAddress([]byte("id1"))
+
+	assert.ErrorContains(t, staker.AddValidation(id1, id1, uint32(1), MinStakeVET), "period is out of boundaries")
+	assert.ErrorContains(t, staker.AddValidation(id1, id1, thor.LowStakingPeriod(), 0), "stake is out of range")
+	assert.NoError(t, staker.AddValidation(id1, id1, thor.LowStakingPeriod(), MinStakeVET))
+	assert.ErrorContains(t, staker.AddValidation(id1, id1, thor.LowStakingPeriod(), MinStakeVET), "validator already exists")
+}
+
+func TestValidation_SetBeneficiary_Error(t *testing.T) {
+	staker := newTestStaker()
+
+	id := thor.BytesToAddress([]byte("v"))
+	endorsor := id
+	assert.NoError(t, staker.AddValidation(id, endorsor, thor.LowStakingPeriod(), MinStakeVET))
+
+	assert.ErrorContains(t, staker.SetBeneficiary(id, thor.BytesToAddress([]byte("wrong")), id), "endorser required")
+
+	_, err := staker.WithdrawStake(id, id, 0)
+	assert.NoError(t, err)
+
+	assert.ErrorContains(t, staker.SetBeneficiary(id, id, id), "validator has exited or signaled exit, cannot set beneficiary")
+}
+
+func TestDelegation_Add_InputValidation(t *testing.T) {
+	staker := newTestStaker()
+
+	_, err := staker.AddDelegation(thor.Address{}, 1, 0)
+	assert.ErrorContains(t, err, "multiplier cannot be 0")
+}
+
+func TestDelegation_SignalExit(t *testing.T) {
+	staker := newTestStaker()
+
+	v := thor.BytesToAddress([]byte("v"))
+	assert.NoError(t, staker.AddValidation(v, v, thor.MediumStakingPeriod(), MinStakeVET))
+
+	id, err := staker.AddDelegation(v, 3, 100)
+	assert.NoError(t, err)
+
+	staker.validationService.ActivateValidator(v, 0, &delta.Renewal{
+		LockedIncrease: stakes.NewWeightedStake(0, 0),
+		LockedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+	})
+
+	_, _, err = staker.GetDelegation(id)
+	assert.NoError(t, err)
+
+	assert.NoError(t, staker.SignalDelegationExit(id))
+
+	del2, _, err := staker.GetDelegation(id)
+	assert.NoError(t, err)
+	assert.NotNil(t, del2.LastIteration)
+	assert.Equal(t, uint32(1), *del2.LastIteration)
+
+	assert.ErrorContains(t, staker.SignalDelegationExit(id), "delegation is already signaled exit")
+}
+
+func TestDelegation_SignalExit_Empty(t *testing.T) {
+	staker := newTestStaker()
+
+	assert.ErrorContains(t, staker.SignalDelegationExit(big.NewInt(2)), "delegation is empty")
 }

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -750,6 +750,24 @@ func TestDelegation_SignalExit(t *testing.T) {
 	assert.ErrorContains(t, staker.SignalDelegationExit(id), "delegation is already signaled exit")
 }
 
+func TestDelegation_SignalExit_AlreadyWithdrawn(t *testing.T) {
+	staker := newTestStaker()
+
+	v := thor.BytesToAddress([]byte("v"))
+	assert.NoError(t, staker.AddValidation(v, v, thor.MediumStakingPeriod(), MinStakeVET))
+
+	id, err := staker.AddDelegation(v, 3, 100)
+	assert.NoError(t, err)
+
+	_, _, err = staker.GetDelegation(id)
+	assert.NoError(t, err)
+	amt, err := staker.WithdrawDelegation(id)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(3), amt)
+
+	assert.ErrorContains(t, staker.SignalDelegationExit(id), "delegation has already been withdrawn")
+}
+
 func TestDelegation_SignalExit_Empty(t *testing.T) {
 	staker := newTestStaker()
 

--- a/builtin/staker/validation/service.go
+++ b/builtin/staker/validation/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/vechain/thor/v2/builtin/solidity"
 	"github.com/vechain/thor/v2/builtin/staker/delta"
 	"github.com/vechain/thor/v2/builtin/staker/linkedlist"
-	"github.com/vechain/thor/v2/builtin/staker/reverts"
 	"github.com/vechain/thor/v2/builtin/staker/stakes"
 	"github.com/vechain/thor/v2/thor"
 )
@@ -155,20 +154,6 @@ func (s *Service) Add(
 	period uint32,
 	stake uint64,
 ) error {
-	if stake < s.minStake || stake > s.maxStake {
-		return reverts.New("stake is out of range")
-	}
-	val, err := s.GetValidation(validator)
-	if err != nil {
-		return err
-	}
-	if !val.IsEmpty() {
-		return reverts.New("validator already exists")
-	}
-	if period != thor.LowStakingPeriod() && period != thor.MediumStakingPeriod() && period != thor.HighStakingPeriod() {
-		return reverts.New("period is out of boundaries")
-	}
-
 	entry := &Validation{
 		Endorser:           endorser,
 		Period:             period,
@@ -182,25 +167,14 @@ func (s *Service) Add(
 		Weight:             0,
 	}
 
-	if err = s.validatorQueue.Add(validator); err != nil {
+	if err := s.validatorQueue.Add(validator); err != nil {
 		return err
 	}
 
 	return s.repo.setValidation(validator, entry, true)
 }
 
-func (s *Service) SignalExit(validator thor.Address, endorser thor.Address) error {
-	validation, err := s.GetExistingValidation(validator)
-	if err != nil {
-		return err
-	}
-	if validation.Endorser != endorser {
-		return reverts.New("invalid endorser for node")
-	}
-	if validation.Status != StatusActive {
-		return reverts.New("can't signal exit while not active")
-	}
-
+func (s *Service) SignalExit(validator thor.Address, validation *Validation) error {
 	minBlock := validation.StartBlock + validation.Period*(validation.CurrentIteration())
 	exitBlock, err := s.SetExitBlock(validator, minBlock)
 	if err != nil {
@@ -229,128 +203,69 @@ func (s *Service) Evict(validator thor.Address, currentBlock uint32) error {
 	return s.repo.setValidation(validator, validation, false)
 }
 
-func (s *Service) IncreaseStake(validator thor.Address, endorser thor.Address, amount uint64) error {
-	entry, err := s.GetExistingValidation(validator)
-	if err != nil {
-		return err
-	}
-	if entry.Endorser != endorser {
-		return reverts.New("invalid endorser")
-	}
-	if entry.Status == StatusExit {
-		return reverts.New("validator status is not queued or active")
-	}
-	if entry.Status == StatusActive && entry.ExitBlock != nil {
-		return reverts.New("validator has signaled exit, cannot increase stake")
-	}
+func (s *Service) IncreaseStake(validator thor.Address, validation *Validation, amount uint64) error {
+	validation.QueuedVET = amount + validation.QueuedVET
 
-	entry.QueuedVET = amount + entry.QueuedVET
-
-	return s.repo.setValidation(validator, entry, false)
+	return s.repo.setValidation(validator, validation, false)
 }
 
-func (s *Service) SetBeneficiary(validator, endorser, beneficiary thor.Address) error {
-	entry, err := s.GetExistingValidation(validator)
-	if err != nil {
-		return err
-	}
-	if entry.Endorser != endorser {
-		return reverts.New("invalid endorser")
-	}
-	if entry.Status == StatusExit || entry.ExitBlock != nil {
-		return reverts.New("validator has exited or signaled exit, cannot set beneficiary")
-	}
+func (s *Service) SetBeneficiary(validator thor.Address, validation *Validation, beneficiary thor.Address) error {
 	if beneficiary.IsZero() {
-		entry.Beneficiary = nil
+		validation.Beneficiary = nil
 	} else {
-		entry.Beneficiary = &beneficiary
+		validation.Beneficiary = &beneficiary
 	}
-	if err = s.repo.setValidation(validator, entry, false); err != nil {
+	if err := s.repo.setValidation(validator, validation, false); err != nil {
 		return errors.Wrap(err, "failed to set beneficiary")
 	}
 	return nil
 }
 
-func (s *Service) DecreaseStake(validator thor.Address, endorser thor.Address, amount uint64) (bool, error) {
-	entry, err := s.GetExistingValidation(validator)
-	if err != nil {
-		return false, err
-	}
-	if entry.Endorser != endorser {
-		return false, reverts.New("invalid endorser")
-	}
-	if entry.Status == StatusExit {
-		return false, reverts.New("validator status is not queued or active")
-	}
-	if entry.Status == StatusActive && entry.ExitBlock != nil {
-		return false, reverts.New("validator has signaled exit, cannot decrease stake")
+func (s *Service) DecreaseStake(validator thor.Address, validation *Validation, amount uint64) error {
+	if validation.Status == StatusActive {
+		validation.PendingUnlockVET += amount
 	}
 
-	if entry.Status == StatusActive {
-		// We don't consider any increases, i.e., entry.QueuedVET. We only consider locked and current decreases.
-		// The reason is that validator can instantly withdraw QueuedVET at any time.
-		// We need to make sure the locked VET minus the sum of the current decreases is still above the minimum stake.
-		nextPeriodTVL := entry.LockedVET - entry.PendingUnlockVET
-		nextPeriodTVL -= amount
-		if nextPeriodTVL < s.minStake {
-			return false, reverts.New("next period stake is too low for validator")
-		}
-		entry.PendingUnlockVET += amount
+	if validation.Status == StatusQueued {
+		validation.QueuedVET -= amount
+		validation.WithdrawableVET += amount
 	}
 
-	if entry.Status == StatusQueued {
-		// All the validator's stake exists within QueuedVET, so we need to make sure it maintains a minimum of MinStake.
-		nextPeriodTVL := entry.QueuedVET - amount
-		if nextPeriodTVL < s.minStake {
-			return false, reverts.New("next period stake is too low for validator")
-		}
-		entry.QueuedVET -= amount
-		entry.WithdrawableVET += amount
-	}
-
-	return entry.Status == StatusQueued, s.repo.setValidation(validator, entry, false)
+	return s.repo.setValidation(validator, validation, false)
 }
 
 // WithdrawStake allows validations to withdraw any withdrawable stake.
 // It also verifies the endorser and updates the validator totals.
 func (s *Service) WithdrawStake(
 	validator thor.Address,
-	endorser thor.Address,
+	validation *Validation,
 	currentBlock uint32,
 ) (uint64, uint64, error) {
-	val, err := s.GetExistingValidation(validator)
-	if err != nil {
-		return 0, 0, err
-	}
-	if val.Endorser != endorser {
-		return 0, 0, reverts.New("invalid endorser")
-	}
-
 	// calculate currently available VET to withdraw
-	withdrawable := val.CalculateWithdrawableVET(currentBlock)
+	withdrawable := validation.CalculateWithdrawableVET(currentBlock)
 
 	// val has exited and waited for the cooldown period
-	if val.ExitBlock != nil && *val.ExitBlock+thor.CooldownPeriod() <= currentBlock {
-		val.CooldownVET = 0
+	if validation.ExitBlock != nil && *validation.ExitBlock+thor.CooldownPeriod() <= currentBlock {
+		validation.CooldownVET = 0
 	}
 
 	// if the validator is queued make sure to exit it
-	if val.Status == StatusQueued {
-		val.QueuedVET = 0
-		val.Status = StatusExit
+	if validation.Status == StatusQueued {
+		validation.QueuedVET = 0
+		validation.Status = StatusExit
 		if err := s.validatorQueue.Remove(validator); err != nil {
 			return 0, 0, err
 		}
 	}
-	queuedVET := val.QueuedVET
-	// remove any que
-	if val.QueuedVET > 0 {
-		val.QueuedVET = 0
+	queuedVET := validation.QueuedVET
+	// remove any queued
+	if validation.QueuedVET > 0 {
+		validation.QueuedVET = 0
 	}
 
 	// no more withdraw after this
-	val.WithdrawableVET = 0
-	if err := s.repo.setValidation(validator, val, false); err != nil {
+	validation.WithdrawableVET = 0
+	if err := s.repo.setValidation(validator, validation, false); err != nil {
 		return 0, 0, err
 	}
 
@@ -549,7 +464,7 @@ func (s *Service) GetExistingValidation(validator thor.Address) (*Validation, er
 		return nil, errors.Wrap(err, "failed to get validator")
 	}
 	if v.IsEmpty() {
-		return nil, reverts.New("failed to get validator")
+		return nil, errors.New("failed to get existing validator")
 	}
 	return v, nil
 }

--- a/builtin/staker/validation/service_test.go
+++ b/builtin/staker/validation/service_test.go
@@ -191,34 +191,6 @@ func TestService_IsActive_Flag(t *testing.T) {
 	assert.True(t, ok)
 }
 
-func TestService_SignalExit_InvalidEndorser(t *testing.T) {
-	svc, _, _ := newSvc()
-
-	id := thor.BytesToAddress([]byte("v"))
-	end := thor.BytesToAddress([]byte("endorse"))
-
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: end, Status: StatusActive, Period: thor.MediumStakingPeriod(), StartBlock: 100, CompleteIterations: 0,
-	}, true))
-
-	err := svc.SignalExit(id, thor.BytesToAddress([]byte("wrong")))
-	assert.ErrorContains(t, err, "invalid endorser for node")
-}
-
-func TestService_SignalExit_NotActive(t *testing.T) {
-	svc, _, _ := newSvc()
-
-	id := thor.BytesToAddress([]byte("v"))
-	end := id
-
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: end, Status: StatusQueued, Period: 2, StartBlock: 0,
-	}, true))
-
-	err := svc.SignalExit(id, end)
-	assert.ErrorContains(t, err, "can't signal exit while not active")
-}
-
 func TestService_SignalExit_SetsExitBlockAndPersists(t *testing.T) {
 	svc, _, _ := newSvc()
 
@@ -230,7 +202,10 @@ func TestService_SignalExit_SetsExitBlockAndPersists(t *testing.T) {
 		StartBlock: 100, Period: 10, CompleteIterations: 2,
 	}, true))
 
-	err := svc.SignalExit(id, end)
+	val, err := svc.GetExistingValidation(id)
+	assert.NoError(t, err)
+
+	err = svc.SignalExit(id, val)
 	assert.NoError(t, err)
 
 	after, err := svc.GetValidation(id)
@@ -253,52 +228,10 @@ func TestService_SignalExit_SetExitBlock_Error(t *testing.T) {
 
 	poisonExitSlot(st, contract, 15)
 
-	err := svc.SignalExit(id, end)
+	val, err := svc.GetExistingValidation(id)
+	assert.NoError(t, err)
+	err = svc.SignalExit(id, val)
 	assert.Error(t, err)
-}
-
-func TestService_IncreaseStake_UnknownValidator(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("unknown"))
-	err := svc.IncreaseStake(id, id, 1)
-	assert.ErrorContains(t, err, "failed to get validator")
-}
-
-func TestService_IncreaseStake_InvalidEndorser(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("v"))
-	endorser := thor.BytesToAddress([]byte("endorse"))
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusQueued, QueuedVET: 0,
-	}, true))
-
-	err := svc.IncreaseStake(id, thor.BytesToAddress([]byte("wrong")), 10)
-	assert.ErrorContains(t, err, "invalid endorser")
-}
-
-func TestService_IncreaseStake_StatusExit(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("v"))
-	endorser := id
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusExit,
-	}, true))
-
-	err := svc.IncreaseStake(id, endorser, 5)
-	assert.ErrorContains(t, err, "validator status is not queued or active")
-}
-
-func TestService_IncreaseStake_ActiveHasExitBlock(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("v"))
-	endorser := id
-	eb := uint32(1)
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusActive, ExitBlock: &eb,
-	}, true))
-
-	err := svc.IncreaseStake(id, endorser, 5)
-	assert.ErrorContains(t, err, "has signaled exit, cannot increase stake")
 }
 
 func TestService_IncreaseStake_SuccessQueued(t *testing.T) {
@@ -309,7 +242,10 @@ func TestService_IncreaseStake_SuccessQueued(t *testing.T) {
 		Endorser: endorser, Status: StatusQueued, QueuedVET: uint64(7),
 	}, true))
 
-	assert.NoError(t, svc.IncreaseStake(id, endorser, uint64(3)))
+	val, err := svc.GetExistingValidation(id)
+	assert.NoError(t, err)
+
+	assert.NoError(t, svc.IncreaseStake(id, val, uint64(3)))
 
 	v, err := svc.GetValidation(id)
 	assert.NoError(t, err)
@@ -324,138 +260,14 @@ func TestService_IncreaseStake_SuccessActiveNoExit(t *testing.T) {
 		Endorser: endorser, Status: StatusActive, QueuedVET: uint64(0),
 	}, true))
 
-	assert.NoError(t, svc.IncreaseStake(id, endorser, uint64(4)))
+	val, err := svc.GetExistingValidation(id)
+	assert.NoError(t, err)
+
+	assert.NoError(t, svc.IncreaseStake(id, val, uint64(4)))
 
 	v, err := svc.GetValidation(id)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(4), v.QueuedVET)
-}
-
-func TestService_DecreaseStake_UnknownValidator(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("unknown"))
-	ok, err := svc.DecreaseStake(id, id, uint64(1))
-	assert.False(t, ok)
-	assert.ErrorContains(t, err, "failed to get validator")
-}
-
-func TestService_DecreaseStake_InvalidEndorser(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("v"))
-	endorser := thor.BytesToAddress([]byte("endorse"))
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusQueued, QueuedVET: uint64(10),
-	}, true))
-
-	ok, err := svc.DecreaseStake(id, thor.BytesToAddress([]byte("wrong")), uint64(1))
-	assert.False(t, ok)
-	assert.ErrorContains(t, err, "invalid endorser")
-}
-
-func TestService_DecreaseStake_StatusExit(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("v"))
-	endorser := id
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusExit,
-	}, true))
-
-	ok, err := svc.DecreaseStake(id, endorser, uint64(1))
-	assert.False(t, ok)
-	assert.ErrorContains(t, err, "validator status is not queued or active")
-}
-
-func TestService_DecreaseStake_ActiveHasExitBlock(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("v"))
-	endorser := id
-	eb := uint32(1)
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusActive, ExitBlock: &eb,
-		LockedVET: uint64(10),
-	}, true))
-
-	ok, err := svc.DecreaseStake(id, endorser, uint64(1))
-	assert.False(t, ok)
-	assert.ErrorContains(t, err, "has signaled exit, cannot decrease stake")
-}
-
-func TestService_DecreaseStake_ActiveTooLowNextPeriod(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("v"))
-	endorser := id
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusActive,
-		LockedVET: uint64(1), PendingUnlockVET: uint64(0),
-	}, true))
-
-	ok, err := svc.DecreaseStake(id, endorser, uint64(1))
-	assert.False(t, ok)
-	assert.ErrorContains(t, err, "next period stake is too low for validator")
-}
-
-func TestService_DecreaseStake_ActiveSuccess(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("v"))
-	endorser := id
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusActive,
-		LockedVET: uint64(5), PendingUnlockVET: uint64(0),
-	}, true))
-
-	ok, err := svc.DecreaseStake(id, endorser, uint64(2))
-	assert.False(t, ok)
-	assert.NoError(t, err)
-
-	v, err := svc.GetValidation(id)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(2), v.PendingUnlockVET)
-	assert.Equal(t, uint64(5), v.LockedVET)
-}
-
-func TestService_DecreaseStake_QueuedTooLowNextPeriod(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("q"))
-	endorser := id
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusQueued,
-		QueuedVET: uint64(1), WithdrawableVET: uint64(0),
-	}, true))
-
-	ok, err := svc.DecreaseStake(id, endorser, uint64(1))
-	assert.False(t, ok)
-	assert.ErrorContains(t, err, "next period stake is too low for validator")
-}
-
-func TestService_DecreaseStake_QueuedSuccess(t *testing.T) {
-	svc, _, _ := newSvc()
-	id := thor.BytesToAddress([]byte("q"))
-	endorser := id
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusQueued,
-		QueuedVET: uint64(5), WithdrawableVET: uint64(0),
-	}, true))
-
-	ok, err := svc.DecreaseStake(id, endorser, uint64(2))
-	assert.True(t, ok)
-	assert.NoError(t, err)
-
-	v, err := svc.GetValidation(id)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(3), v.QueuedVET)
-	assert.Equal(t, uint64(2), v.WithdrawableVET)
-}
-
-func TestService_WithdrawStake_InvalidEndorser(t *testing.T) {
-	svc, _, _ := newSvc()
-
-	id := thor.BytesToAddress([]byte("v"))
-	endorsor := id
-	assert.NoError(t, svc.Add(id, endorsor, thor.LowStakingPeriod(), uint64(10)))
-
-	amt, _, err := svc.WithdrawStake(id, thor.BytesToAddress([]byte("wrong")), 0)
-	assert.Equal(t, uint64(0), amt)
-	assert.ErrorContains(t, err, "invalid endorser")
 }
 
 func TestService_WithdrawStake_QueuedToExit(t *testing.T) {
@@ -469,7 +281,10 @@ func TestService_WithdrawStake_QueuedToExit(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, StatusQueued, val.Status)
 
-	amt, _, err := svc.WithdrawStake(id, endorser, 0)
+	val, err = svc.GetExistingValidation(id)
+	assert.NoError(t, err)
+
+	amt, _, err := svc.WithdrawStake(id, val, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(50), amt)
 
@@ -494,34 +309,17 @@ func TestService_WithdrawStake_ClearCooldownWhenMatured(t *testing.T) {
 	thor.SetConfig(thor.Config{
 		CooldownPeriod: 1,
 	})
-	amt, _, err := svc.WithdrawStake(id, endorser, 11)
+
+	val, err := svc.GetExistingValidation(id)
+	assert.NoError(t, err)
+
+	amt, _, err := svc.WithdrawStake(id, val, 11)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(45), amt)
 
 	v2, err := svc.GetValidation(id)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), v2.CooldownVET)
-	assert.Equal(t, uint64(0), v2.WithdrawableVET)
-}
-
-func TestService_WithdrawStake_ActiveClearsQueuedAndWithdrawable(t *testing.T) {
-	svc, _, _ := newSvc()
-
-	id := thor.BytesToAddress([]byte("act"))
-	endorser := id
-	assert.NoError(t, svc.repo.setValidation(id, &Validation{
-		Endorser: endorser, Status: StatusActive,
-		QueuedVET: uint64(12), WithdrawableVET: uint64(3),
-	}, true))
-
-	amt, _, err := svc.WithdrawStake(id, endorser, 0)
-	assert.NoError(t, err)
-	assert.Equal(t, uint64(15), amt)
-
-	v2, err := svc.GetValidation(id)
-	assert.NoError(t, err)
-	assert.Equal(t, StatusActive, v2.Status)
-	assert.Equal(t, uint64(0), v2.QueuedVET)
 	assert.Equal(t, uint64(0), v2.WithdrawableVET)
 }
 
@@ -544,6 +342,30 @@ func TestService_GetDelegatorRewards_Positive(t *testing.T) {
 	got, err = svc.GetDelegatorRewards(id, 2)
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(140), got)
+}
+
+func TestService_WithdrawStake_ActiveClearsQueuedAndWithdrawable(t *testing.T) {
+	svc, _, _ := newSvc()
+
+	id := thor.BytesToAddress([]byte("act"))
+	endorser := id
+	assert.NoError(t, svc.repo.setValidation(id, &Validation{
+		Endorser: endorser, Status: StatusActive,
+		QueuedVET: uint64(12), WithdrawableVET: uint64(3),
+	}, true))
+
+	val, err := svc.GetExistingValidation(id)
+	assert.NoError(t, err)
+
+	amt, _, err := svc.WithdrawStake(id, val, 0)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(15), amt)
+
+	v2, err := svc.GetValidation(id)
+	assert.NoError(t, err)
+	assert.Equal(t, StatusActive, v2.Status)
+	assert.Equal(t, uint64(0), v2.QueuedVET)
+	assert.Equal(t, uint64(0), v2.WithdrawableVET)
 }
 
 func TestService_GetDelegatorRewards_Error(t *testing.T) {
@@ -695,13 +517,10 @@ func TestService_Add_Error(t *testing.T) {
 	id1 := thor.BytesToAddress([]byte("id1"))
 	id2 := thor.BytesToAddress([]byte("id2"))
 
-	assert.ErrorContains(t, svc.Add(id1, id1, uint32(1), uint64(1)), "period is out of boundaries")
-	assert.ErrorContains(t, svc.Add(id1, id1, thor.LowStakingPeriod(), uint64(0)), "stake is out of range")
 	assert.NoError(t, svc.Add(id1, id1, thor.LowStakingPeriod(), uint64(1)))
-	assert.ErrorContains(t, svc.Add(id1, id1, thor.LowStakingPeriod(), uint64(1)), "validator already exists")
-
 	poisonValidationSlot(st, addr, id1)
-	assert.Error(t, svc.Add(id1, id1, thor.LowStakingPeriod(), uint64(1)))
+	_, err := svc.GetExistingValidation(id1)
+	assert.Error(t, err)
 
 	slot := thor.Blake2b(id1.Bytes(), slotValidations.Bytes())
 	st.SetRawStorage(addr, slot, rlp.RawValue{0x0})
@@ -734,7 +553,7 @@ func TestService_Evict(t *testing.T) {
 }
 
 func TestService_SetBeneficiary(t *testing.T) {
-	svc, addr, st := newSvc()
+	svc, _, _ := newSvc()
 	id1 := thor.BytesToAddress([]byte("id1"))
 	assert.NoError(t, svc.Add(id1, id1, thor.LowStakingPeriod(), uint64(1)))
 
@@ -742,22 +561,15 @@ func TestService_SetBeneficiary(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Nil(t, val.Beneficiary)
 
-	assert.NoError(t, svc.SetBeneficiary(id1, id1, id1))
+	assert.NoError(t, svc.SetBeneficiary(id1, val, id1))
 	val, err = svc.GetValidation(id1)
 	assert.NoError(t, err)
 	assert.Equal(t, &id1, val.Beneficiary)
 
-	assert.NoError(t, svc.SetBeneficiary(id1, id1, thor.Address{}))
+	assert.NoError(t, svc.SetBeneficiary(id1, val, thor.Address{}))
 	val, err = svc.GetValidation(id1)
 	assert.NoError(t, err)
 	assert.Nil(t, val.Beneficiary)
-
-	assert.ErrorContains(t, svc.SetBeneficiary(id1, thor.Address{}, id1), "invalid endorser")
-	assert.NoError(t, svc.Evict(id1, 2))
-	assert.ErrorContains(t, svc.SetBeneficiary(id1, id1, id1), "validator has exited or signaled exit, cannot set beneficiary")
-
-	poisonValidationSlot(st, addr, id1)
-	assert.Error(t, svc.SetBeneficiary(id1, id1, id1))
 }
 
 func TestService_UpdateOfflineBlock(t *testing.T) {
@@ -790,12 +602,15 @@ func TestService_Renew(t *testing.T) {
 	id1 := thor.BytesToAddress([]byte("id1"))
 	assert.NoError(t, svc.Add(id1, id1, thor.LowStakingPeriod(), uint64(50)))
 
-	err := svc.IncreaseStake(id1, id1, uint64(600))
-	assert.NoError(t, err)
-	_, err = svc.DecreaseStake(id1, id1, uint64(300))
+	val, err := svc.GetValidation(id1)
 	assert.NoError(t, err)
 
-	val, err := svc.GetValidation(id1)
+	err = svc.IncreaseStake(id1, val, uint64(600))
+	assert.NoError(t, err)
+	err = svc.DecreaseStake(id1, val, uint64(300))
+	assert.NoError(t, err)
+
+	val, err = svc.GetValidation(id1)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), val.LockedVET)
 	assert.Equal(t, uint64(0), val.Weight)
@@ -821,9 +636,9 @@ func TestService_Renew(t *testing.T) {
 	assert.Equal(t, uint64(0), val.CooldownVET)
 	assert.Equal(t, uint64(300), val.WithdrawableVET)
 
-	err = svc.IncreaseStake(id1, id1, uint64(400))
+	err = svc.IncreaseStake(id1, val, uint64(400))
 	assert.NoError(t, err)
-	_, err = svc.DecreaseStake(id1, id1, uint64(200))
+	err = svc.DecreaseStake(id1, val, uint64(200))
 	assert.NoError(t, err)
 
 	val, err = svc.GetValidation(id1)

--- a/builtin/staker_native.go
+++ b/builtin/staker_native.go
@@ -6,6 +6,7 @@
 package builtin
 
 import (
+	"fmt"
 	"math"
 	"math/big"
 
@@ -454,7 +455,7 @@ func init() {
 						return results
 					}
 					if reverts.IsRevertErr(err) {
-						env.Revert(err.Error())
+						env.Revert(fmt.Sprintf("staker: %s", err.Error()))
 						return nil
 					}
 					panic(err) // unexpected error

--- a/builtin/staker_native_gas_test.go
+++ b/builtin/staker_native_gas_test.go
@@ -152,7 +152,7 @@ func TestStakerNativeGasCosts(t *testing.T) {
 		// },
 		{
 			function:    "native_increaseStake",
-			expectedGas: 16200,
+			expectedGas: 15800,
 			args: []any{
 				account1,
 				account1,
@@ -174,7 +174,7 @@ func TestStakerNativeGasCosts(t *testing.T) {
 		},
 		{
 			function:    "native_addDelegation",
-			expectedGas: 21600,
+			expectedGas: 21200,
 			args: []any{
 				account1,
 				staker.MinStake,

--- a/pos/sched_test.go
+++ b/pos/sched_test.go
@@ -73,6 +73,7 @@ func TestScheduler_Distribution(t *testing.T) {
 	// e.g., 1 million usually gets all tolerances down to about 2% (i.e., 0.02)
 	iterations := 100_000
 	type stakeFunc func(index int, acc thor.Address) uint64
+	rnd := rand.New(rand.NewSource(412342)) //nolint:gosec
 
 	testCases := []struct {
 		name      string
@@ -106,7 +107,7 @@ func TestScheduler_Distribution(t *testing.T) {
 				diff := maxWeight - minWeight
 
 				// Generate random number in [0, diff)
-				n := rand.Intn(int(diff)) //nolint:gosec
+				n := rnd.Intn(int(diff)) //nolint:gosec
 				// Add min to shift range to [min, max)
 				randomValue := minWeight + uint64(n)
 

--- a/xenv/revert.go
+++ b/xenv/revert.go
@@ -18,7 +18,7 @@ type errReverted struct {
 }
 
 func (e *errReverted) Error() string {
-	return "builtin reverted: " + e.message
+	return e.message
 }
 
 func (e *errReverted) Bytes() []byte {


### PR DESCRIPTION
# Description

Limits the error checking in the first space, also moved error check test from service to staker tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
