### PR TITLE
add delegation.islocked

### DIFF
--- a/builtin/staker/delegation/delegation.go
+++ b/builtin/staker/delegation/delegation.go
@@ -65,3 +65,20 @@ func (d *Delegation) Ended(val *validation.Validation) bool {
 	}
 	return *d.LastIteration < currentStakingPeriod
 }
+
+// IsLocked returns whether the delegation is locked
+// It returns true if:
+// - the delegation has started
+// - AND the delegation has not ended
+// - AND the delegation has stake
+func (d *Delegation) IsLocked(val *validation.Validation) bool {
+	if d.IsEmpty() {
+		return false
+	}
+
+	if d.Stake == 0 {
+		return false
+	}
+
+	return d.Started(val) && !d.Ended(val)
+}

--- a/builtin/staker/delegation/delegation_test.go
+++ b/builtin/staker/delegation/delegation_test.go
@@ -82,3 +82,39 @@ func TestDelegation(t *testing.T) {
 	del.LastIteration = &lastIter
 	assert.False(t, del.Ended(&val))
 }
+
+func TestDelegation_IsLocked(t *testing.T) {
+	del := Delegation{
+		Validation:     thor.Address{},
+		Stake:          0,
+		Multiplier:     0,
+		LastIteration:  nil,
+		FirstIteration: 0,
+	}
+
+	val := validation.Validation{
+		Endorser:           thor.Address{},
+		Period:             0,
+		CompleteIterations: 0,
+		Status:             validation.StatusActive,
+		OfflineBlock:       nil,
+		StartBlock:         0,
+		ExitBlock:          nil,
+		LockedVET:          0,
+		PendingUnlockVET:   0,
+		QueuedVET:          0,
+		CooldownVET:        0,
+		WithdrawableVET:    0,
+		Weight:             0,
+	}
+	assert.False(t, del.IsLocked(&val))
+
+	val.CompleteIterations = 1
+	assert.False(t, del.IsLocked(&val))
+
+	del.Stake = 1000
+	assert.True(t, del.IsLocked(&val))
+
+	val.Status = validation.StatusExit
+	assert.False(t, del.IsLocked(&val))
+}

--- a/builtin/staker/delegation/service.go
+++ b/builtin/staker/delegation/service.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/ethereum/go-ethereum/common/math"
-
 	"github.com/vechain/thor/v2/builtin/solidity"
 	"github.com/vechain/thor/v2/builtin/staker/reverts"
 	"github.com/vechain/thor/v2/builtin/staker/validation"
@@ -105,9 +103,6 @@ func (s *Service) Withdraw(del *Delegation, delegationID *big.Int, val *validati
 	withdrawableStake := del.Stake
 
 	del.Stake = 0
-	if val.CurrentIteration() < del.FirstIteration {
-		del.FirstIteration = math.MaxUint32
-	}
 	if err := s.setDelegation(delegationID, del, false); err != nil {
 		return 0, err
 	}

--- a/builtin/staker/delegations_test.go
+++ b/builtin/staker/delegations_test.go
@@ -6,7 +6,6 @@
 package staker
 
 import (
-	"math"
 	"math/big"
 	"testing"
 
@@ -687,7 +686,7 @@ func TestStaker_DelegationWithdrawPending(t *testing.T) {
 	delegation, validation, err = staker.GetDelegation(delegationID)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), delegation.Stake)
-	assert.Equal(t, uint32(math.MaxUint32), delegation.FirstIteration)
 	assert.Nil(t, delegation.LastIteration)
-	assert.False(t, delegation.Started(validation))
+
+	assert.False(t, delegation.IsLocked(validation))
 }

--- a/builtin/staker_native.go
+++ b/builtin/staker_native.go
@@ -360,12 +360,11 @@ func init() {
 				lastPeriod = *delegation.LastIteration
 			}
 
-			locked := delegation.Started(validation) && !delegation.Ended(validation)
 			return []any{
 				delegation.Validation,
 				toWei(delegation.Stake),
 				delegation.Multiplier,
-				locked,
+				delegation.IsLocked(validation),
 				delegation.FirstIteration,
 				lastPeriod,
 			}, nil


### PR DESCRIPTION
# Description

This PR is another solution for https://github.com/vechain/thor/pull/1297, have talked with stargate team. They'll firstly get delegation status from `getDelegation` check stake first. And we'll make sure isLocked always return false when there is no stake.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
