### PR TITLE
clean up queued stake to use uint64

### DIFF
--- a/builtin/staker/aggregation/aggregation.go
+++ b/builtin/staker/aggregation/aggregation.go
@@ -45,7 +45,7 @@ func (a *Aggregation) IsEmpty() bool {
 // NextPeriodTVL is the total value locked (TVL) for the next period.
 // It is the sum of the currently recurring VET, plus any pending recurring and one-time VET.
 func (a *Aggregation) NextPeriodTVL() uint64 {
-	return a.LockedVET + a.PendingVET
+	return a.LockedVET + a.PendingVET - a.ExitingVET
 }
 
 // renew transitions delegations to the next staking period.
@@ -57,7 +57,7 @@ func (a *Aggregation) NextPeriodTVL() uint64 {
 func (a *Aggregation) renew() *globalstats.Renewal {
 	lockedIncrease := stakes.NewWeightedStake(a.PendingVET, a.PendingWeight)
 	lockedDecrease := stakes.NewWeightedStake(a.ExitingVET, a.ExitingWeight)
-	queuedDecrease := stakes.NewWeightedStake(a.PendingVET, a.PendingWeight)
+	queuedDecrease := a.PendingVET
 
 	// Move Pending => Locked
 	a.LockedVET += a.PendingVET
@@ -88,7 +88,7 @@ func (a *Aggregation) exit() *globalstats.Exit {
 	// Return these values to modify contract totals
 	exit := globalstats.Exit{
 		ExitedTVL:      stakes.NewWeightedStake(a.LockedVET, a.LockedWeight),
-		QueuedDecrease: stakes.NewWeightedStake(a.PendingVET, a.PendingWeight),
+		QueuedDecrease: a.PendingVET,
 	}
 
 	// Reset the aggregation

--- a/builtin/staker/aggregation/aggregation_test.go
+++ b/builtin/staker/aggregation/aggregation_test.go
@@ -22,7 +22,7 @@ func TestAggregation(t *testing.T) {
 	agg.ExitingVET = uint64(8000)
 	agg.ExitingWeight = uint64(16000)
 
-	assert.Equal(t, uint64(19000), agg.NextPeriodTVL())
+	assert.Equal(t, uint64(11000), agg.NextPeriodTVL()) // 10000+9000-8000
 
 	renewal := agg.renew()
 
@@ -44,8 +44,7 @@ func TestAggregation(t *testing.T) {
 	exit := agg.exit()
 	assert.Equal(t, uint64(11000), exit.ExitedTVL.VET)
 	assert.Equal(t, uint64(22000), exit.ExitedTVL.Weight)
-	assert.Equal(t, uint64(7000), exit.QueuedDecrease.VET)
-	assert.Equal(t, uint64(14000), exit.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(7000), exit.QueuedDecrease)
 
 	assert.Equal(t, uint64(0), agg.LockedVET)
 	assert.Equal(t, uint64(0), agg.LockedWeight)

--- a/builtin/staker/aggregation/service_test.go
+++ b/builtin/staker/aggregation/service_test.go
@@ -89,8 +89,7 @@ func TestService_Renew(t *testing.T) {
 	assert.Equal(t, uint64(1000), renew2.LockedIncrease.Weight)
 	assert.Equal(t, uint64(1000), renew2.LockedDecrease.VET)
 	assert.Equal(t, uint64(2000), renew2.LockedDecrease.Weight)
-	assert.Equal(t, uint64(500), renew2.QueuedDecrease.VET)
-	assert.Equal(t, uint64(1000), renew2.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(500), renew2.QueuedDecrease)
 
 	agg, err := svc.GetAggregation(v)
 	assert.NoError(t, err)
@@ -114,8 +113,7 @@ func TestService_Exit(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(2000), exit.ExitedTVL.VET)
 	assert.Equal(t, uint64(4000), exit.ExitedTVL.Weight)
-	assert.Equal(t, uint64(800), exit.QueuedDecrease.VET)
-	assert.Equal(t, uint64(1600), exit.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(800), exit.QueuedDecrease)
 
 	agg, err := svc.GetAggregation(v)
 	assert.NoError(t, err)

--- a/builtin/staker/globalstats/delta.go
+++ b/builtin/staker/globalstats/delta.go
@@ -10,14 +10,14 @@ import "github.com/vechain/thor/v2/builtin/staker/stakes"
 type Renewal struct {
 	LockedIncrease *stakes.WeightedStake
 	LockedDecrease *stakes.WeightedStake
-	QueuedDecrease *stakes.WeightedStake
+	QueuedDecrease uint64 // stake/VET only
 }
 
 func NewRenewal() *Renewal {
 	return &Renewal{
 		LockedIncrease: &stakes.WeightedStake{},
 		LockedDecrease: &stakes.WeightedStake{},
-		QueuedDecrease: &stakes.WeightedStake{},
+		QueuedDecrease: 0,
 	}
 }
 
@@ -29,13 +29,13 @@ func (r *Renewal) Add(other *Renewal) *Renewal {
 
 	r.LockedIncrease.Add(other.LockedIncrease)
 	r.LockedDecrease.Add(other.LockedDecrease)
-	r.QueuedDecrease.Add(other.QueuedDecrease)
+	r.QueuedDecrease += other.QueuedDecrease
 	return r
 }
 
 type Exit struct {
 	ExitedTVL      *stakes.WeightedStake
-	QueuedDecrease *stakes.WeightedStake
+	QueuedDecrease uint64 // stake/VET only
 }
 
 // Add sets e to the sum of itself and other.
@@ -45,6 +45,6 @@ func (e *Exit) Add(other *Exit) *Exit {
 	}
 
 	e.ExitedTVL.Add(other.ExitedTVL)
-	e.QueuedDecrease.Add(other.QueuedDecrease)
+	e.QueuedDecrease += other.QueuedDecrease
 	return e
 }

--- a/builtin/staker/globalstats/delta_test.go
+++ b/builtin/staker/globalstats/delta_test.go
@@ -24,12 +24,12 @@ func TestRenewal_Add(t *testing.T) {
 	base := &Renewal{
 		LockedIncrease: stakes.NewWeightedStake(10, 20),
 		LockedDecrease: stakes.NewWeightedStake(30, 40),
-		QueuedDecrease: stakes.NewWeightedStake(50, 60),
+		QueuedDecrease: 50,
 	}
 	inc := &Renewal{
 		LockedIncrease: stakes.NewWeightedStake(1, 2),
 		LockedDecrease: stakes.NewWeightedStake(3, 4),
-		QueuedDecrease: stakes.NewWeightedStake(1, 2),
+		QueuedDecrease: 1,
 	}
 
 	got := base.Add(inc)
@@ -38,8 +38,7 @@ func TestRenewal_Add(t *testing.T) {
 	assert.Equal(t, uint64(22), got.LockedIncrease.Weight)
 	assert.Equal(t, uint64(33), got.LockedDecrease.VET)
 	assert.Equal(t, uint64(44), got.LockedDecrease.Weight)
-	assert.Equal(t, uint64(51), got.QueuedDecrease.VET)
-	assert.Equal(t, uint64(62), got.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(51), got.QueuedDecrease)
 }
 
 func TestRenewal_Add_Nil(t *testing.T) {
@@ -58,30 +57,28 @@ func TestRenewal_Add_Nil(t *testing.T) {
 func TestExit_Add(t *testing.T) {
 	base := &Exit{
 		ExitedTVL:      stakes.NewWeightedStake(100, 200),
-		QueuedDecrease: stakes.NewWeightedStake(300, 400),
+		QueuedDecrease: 300,
 	}
 	inc := &Exit{
 		ExitedTVL:      stakes.NewWeightedStake(1, 2),
-		QueuedDecrease: stakes.NewWeightedStake(3, 4),
+		QueuedDecrease: 3,
 	}
 
 	got := base.Add(inc)
 	assert.Same(t, base, got)
 	assert.Equal(t, uint64(101), got.ExitedTVL.VET)
 	assert.Equal(t, uint64(202), got.ExitedTVL.Weight)
-	assert.Equal(t, uint64(303), got.QueuedDecrease.VET)
-	assert.Equal(t, uint64(404), got.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(303), got.QueuedDecrease)
 }
 
 func TestExit_Add_Nil(t *testing.T) {
 	base := &Exit{
 		ExitedTVL:      stakes.NewWeightedStake(10, 20),
-		QueuedDecrease: stakes.NewWeightedStake(30, 40),
+		QueuedDecrease: 30,
 	}
 	got := base.Add(nil)
 	assert.Same(t, base, got)
 	assert.Equal(t, uint64(10), got.ExitedTVL.VET)
 	assert.Equal(t, uint64(20), got.ExitedTVL.Weight)
-	assert.Equal(t, uint64(30), got.QueuedDecrease.VET)
-	assert.Equal(t, uint64(40), got.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(30), got.QueuedDecrease)
 }

--- a/builtin/staker/globalstats/service_test.go
+++ b/builtin/staker/globalstats/service_test.go
@@ -41,10 +41,10 @@ func TestService_QueuedStake_Empty(t *testing.T) {
 func TestService_AddRemove_Queued(t *testing.T) {
 	svc, _, _ := newSvc()
 
-	st := stakes.NewWeightedStakeWithMultiplier(1000, 200) // weight: 2000
-	assert.NoError(t, svc.AddQueued(st))
+	stake := uint64(1000)
+	assert.NoError(t, svc.AddQueued(stake))
 
-	assert.NoError(t, svc.RemoveQueued(st))
+	assert.NoError(t, svc.RemoveQueued(stake))
 	qVET, err := svc.GetQueuedStake()
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), qVET)
@@ -54,12 +54,12 @@ func TestService_ApplyRenewal(t *testing.T) {
 	svc, _, _ := newSvc()
 
 	// seed some queued for decrease
-	assert.NoError(t, svc.AddQueued(stakes.NewWeightedStakeWithMultiplier(500, 200))) // weight 1000
+	assert.NoError(t, svc.AddQueued(500)) // weight 1000
 
 	r := &Renewal{
 		LockedIncrease: stakes.NewWeightedStake(500, 1000),
 		LockedDecrease: stakes.NewWeightedStake(200, 400),
-		QueuedDecrease: stakes.NewWeightedStake(500, 1000),
+		QueuedDecrease: 500,
 	}
 	assert.NoError(t, svc.ApplyRenewal(r))
 
@@ -76,18 +76,18 @@ func TestService_ApplyRenewal(t *testing.T) {
 func TestService_ApplyExit(t *testing.T) {
 	svc, _, _ := newSvc()
 
-	assert.NoError(t, svc.AddQueued(stakes.NewWeightedStakeWithMultiplier(1000, 200)))
+	assert.NoError(t, svc.AddQueued(1000))
 	assert.NoError(t, svc.ApplyRenewal(&Renewal{
 		LockedIncrease: stakes.NewWeightedStake(1000, 2000),
 		LockedDecrease: stakes.NewWeightedStake(0, 0),
-		QueuedDecrease: stakes.NewWeightedStake(1000, 2000),
+		QueuedDecrease: 1000,
 	}))
 
-	assert.NoError(t, svc.AddQueued(stakes.NewWeightedStakeWithMultiplier(300, 200))) // weight 600
+	assert.NoError(t, svc.AddQueued(300)) // weight 600
 
 	exit := &Exit{
 		ExitedTVL:      stakes.NewWeightedStake(400, 800),
-		QueuedDecrease: stakes.NewWeightedStake(300, 600),
+		QueuedDecrease: 300,
 	}
 	assert.NoError(t, svc.ApplyExit(exit))
 

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -543,7 +543,7 @@ func TestValidation_IncreaseStake_ActiveHasExitBlock(t *testing.T) {
 	staker.validationService.ActivateValidator(id, 0, &globalstats.Renewal{
 		LockedIncrease: stakes.NewWeightedStake(0, 0),
 		LockedDecrease: stakes.NewWeightedStake(0, 0),
-		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: 0,
 	})
 
 	err := staker.SignalExit(id, end)
@@ -583,7 +583,7 @@ func TestValidation_DecreaseStake_StatusExit(t *testing.T) {
 	staker.validationService.ActivateValidator(id, 0, &globalstats.Renewal{
 		LockedIncrease: stakes.NewWeightedStake(0, 0),
 		LockedDecrease: stakes.NewWeightedStake(0, 0),
-		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: 0,
 	})
 
 	err := staker.SignalExit(id, end)
@@ -604,7 +604,7 @@ func TestValidation_DecreaseStake_ActiveHasExitBlock(t *testing.T) {
 	staker.validationService.ActivateValidator(id, 0, &globalstats.Renewal{
 		LockedIncrease: stakes.NewWeightedStake(0, 0),
 		LockedDecrease: stakes.NewWeightedStake(0, 0),
-		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: 0,
 	})
 
 	err := staker.SignalExit(id, end)
@@ -637,7 +637,7 @@ func TestValidation_DecreaseStake_ActiveSuccess(t *testing.T) {
 	staker.validationService.ActivateValidator(id, 0, &globalstats.Renewal{
 		LockedIncrease: stakes.NewWeightedStake(0, 0),
 		LockedDecrease: stakes.NewWeightedStake(0, 0),
-		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: 0,
 	})
 
 	err := staker.DecreaseStake(id, end, 100)
@@ -734,7 +734,7 @@ func TestDelegation_SignalExit(t *testing.T) {
 	staker.validationService.ActivateValidator(v, 0, &globalstats.Renewal{
 		LockedIncrease: stakes.NewWeightedStake(0, 0),
 		LockedDecrease: stakes.NewWeightedStake(0, 0),
-		QueuedDecrease: stakes.NewWeightedStake(0, 0),
+		QueuedDecrease: 0,
 	})
 
 	_, _, err = staker.GetDelegation(id)

--- a/builtin/staker/stakes/stakes.go
+++ b/builtin/staker/stakes/stakes.go
@@ -37,7 +37,3 @@ func (s *WeightedStake) Sub(new *WeightedStake) {
 	s.VET -= new.VET
 	s.Weight -= new.Weight
 }
-
-func (s *WeightedStake) AddWeight(weight uint64) {
-	s.Weight += weight
-}

--- a/builtin/staker/validation/service.go
+++ b/builtin/staker/validation/service.go
@@ -204,7 +204,7 @@ func (s *Service) Evict(validator thor.Address, currentBlock uint32) error {
 }
 
 func (s *Service) IncreaseStake(validator thor.Address, validation *Validation, amount uint64) error {
-	validation.QueuedVET = amount + validation.QueuedVET
+	validation.QueuedVET += amount
 
 	return s.repo.setValidation(validator, validation, false)
 }
@@ -380,8 +380,7 @@ func (s *Service) ActivateValidator(
 		return nil, errors.New("cannot activate validator with already locked vet")
 	}
 
-	// queued stake always use the initial multiplier
-	queuedDecrease := stakes.NewWeightedStakeWithMultiplier(val.QueuedVET, Multiplier)
+	queuedDecrease := val.QueuedVET
 
 	// QueuedVET is now locked
 	val.LockedVET = val.QueuedVET

--- a/builtin/staker/validation/service_test.go
+++ b/builtin/staker/validation/service_test.go
@@ -624,8 +624,7 @@ func TestService_Renew(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(350), delta.LockedIncrease.VET)
 	assert.Equal(t, uint64(700), delta.LockedIncrease.Weight)
-	assert.Equal(t, uint64(350), delta.QueuedDecrease.VET)
-	assert.Equal(t, uint64(350), delta.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(350), delta.QueuedDecrease)
 
 	val, err = svc.GetValidation(id1)
 	assert.NoError(t, err)
@@ -654,8 +653,7 @@ func TestService_Renew(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(200), delta.LockedIncrease.VET)
 	assert.Equal(t, uint64(400), delta.LockedIncrease.Weight)
-	assert.Equal(t, uint64(200), delta.QueuedDecrease.VET)
-	assert.Equal(t, uint64(200), delta.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(200), delta.QueuedDecrease)
 
 	val, err = svc.GetValidation(id1)
 	assert.NoError(t, err)

--- a/builtin/staker/validation/validation.go
+++ b/builtin/staker/validation/validation.go
@@ -172,7 +172,7 @@ func (v *Validation) renew(delegationWeight uint64) *globalstats.Renewal {
 
 func (v *Validation) exit() *globalstats.Exit {
 	ExitedTVL := stakes.NewWeightedStakeWithMultiplier(v.LockedVET, v.multiplier()) // use the acting multiplier for locked stake
-	QueuedDecrease := v.QueuedVET                                                  // queued weight is always initial weight
+	QueuedDecrease := v.QueuedVET                                                   // queued weight is always initial weight
 
 	v.Status = StatusExit
 	// move locked to cooldown

--- a/builtin/staker/validation/validation_test.go
+++ b/builtin/staker/validation/validation_test.go
@@ -44,7 +44,7 @@ func TestValidation_Totals(t *testing.T) {
 	assert.Equal(t, uint64(1000), totals.TotalLockedWeight)
 	assert.Equal(t, uint64(1200), totals.TotalQueuedStake)
 	assert.Equal(t, uint64(1200), totals.TotalExitingStake)
-	assert.Equal(t, uint64(2900), totals.NextPeriodWeight)
+	assert.Equal(t, uint64(3000), totals.NextPeriodWeight) // (1000-900+800)*2 + (1000+800-600)
 
 	exitBlock := uint32(2)
 	val := baseVal
@@ -54,7 +54,7 @@ func TestValidation_Totals(t *testing.T) {
 	assert.Equal(t, uint64(1000), totals.TotalLockedWeight)
 	assert.Equal(t, uint64(1200), totals.TotalQueuedStake)
 	assert.Equal(t, uint64(1500), totals.TotalExitingStake)
-	assert.Equal(t, uint64(3400), totals.NextPeriodWeight)
+	assert.Equal(t, uint64(0), totals.NextPeriodWeight)
 }
 
 func TestValidation_IsPeriodEnd(t *testing.T) {
@@ -77,6 +77,5 @@ func TestValidation_Exit(t *testing.T) {
 
 	assert.Equal(t, uint64(1000), delta.ExitedTVL.VET)
 	assert.Equal(t, uint64(1000), delta.ExitedTVL.Weight)
-	assert.Equal(t, uint64(800), delta.QueuedDecrease.VET)
-	assert.Equal(t, uint64(800), delta.QueuedDecrease.Weight)
+	assert.Equal(t, uint64(800), delta.QueuedDecrease)
 }

--- a/builtin/staker/validations_test.go
+++ b/builtin/staker/validations_test.go
@@ -2953,7 +2953,7 @@ func TestStaker_TestWeights_IncreaseStake(t *testing.T) {
 	assert.Equal(t, baseStake, totals.TotalLockedWeight)
 	assert.Equal(t, stakeDecrease, totals.TotalExitingStake)
 	assert.Equal(t, stakeIncrease+delStake, totals.TotalQueuedStake)
-	assert.Equal(t, baseStake+expectedWeight-stakeDecrease, totals.NextPeriodWeight)
+	assert.Equal(t, baseStake+expectedWeight-stakeDecrease*2, totals.NextPeriodWeight)
 
 	stakingPeriod := thor.MediumStakingPeriod()
 	newTestSequence(t, staker).Housekeep(stakingPeriod * 2)
@@ -3052,7 +3052,7 @@ func TestStaker_TestWeights_DecreaseStake(t *testing.T) {
 	assert.Equal(t, baseStake, totals.TotalLockedWeight)
 	assert.Equal(t, stakeDecrease, totals.TotalExitingStake)
 	assert.Equal(t, delStake, totals.TotalQueuedStake)
-	assert.Equal(t, baseStake+expectedWeight-stakeDecrease, totals.NextPeriodWeight)
+	assert.Equal(t, baseStake+expectedWeight-stakeDecrease*2, totals.NextPeriodWeight)
 
 	// decreasing stake shouldn't affect multipliers
 	additionalDecrease := uint64(500)
@@ -3075,7 +3075,7 @@ func TestStaker_TestWeights_DecreaseStake(t *testing.T) {
 	assert.Equal(t, baseStake, totals.TotalLockedWeight)
 	assert.Equal(t, stakeDecrease, totals.TotalExitingStake)
 	assert.Equal(t, delStake, totals.TotalQueuedStake)
-	assert.Equal(t, baseStake+expectedWeight-stakeDecrease, totals.NextPeriodWeight)
+	assert.Equal(t, baseStake+expectedWeight-stakeDecrease*2, totals.NextPeriodWeight)
 
 	stakingPeriod := thor.MediumStakingPeriod()
 	newTestSequence(t, staker).Housekeep(stakingPeriod * 2)


### PR DESCRIPTION
# Description

Also

- Included `exsitingVET` in aggregations
- Reworked version of `Validation.Totals`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
