### PR TITLE
add toWordSize

### DIFF
--- a/builtin/solidity/gas.go
+++ b/builtin/solidity/gas.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package solidity
+
+// toWordSize converts bytes length to word size, here we define a simplified rule.
+// Any length larger than 32 will be considered as 2 words. Since we do not do 32 bytes storage in native package.
+func toWordSize(length int) uint64 {
+	if length > 32 {
+		return 2
+	}
+
+	return 1
+}

--- a/builtin/solidity/mapping_test.go
+++ b/builtin/solidity/mapping_test.go
@@ -234,8 +234,8 @@ func TestMapping_MultiSlotValue(t *testing.T) {
 
 	t.Run("set big struct charges correct SstoreSetGas", func(t *testing.T) {
 		require.NoError(t, mapping.Set(key, value, true))
-		// approximate slots: ceil((1+3*(1+32))/32)=4
-		expected := 4 * thor.SstoreSetGas
+		// maximum 2 slots, defined by gas.go
+		expected := 2 * thor.SstoreSetGas
 		assert.Equal(t, expected, charger.TotalGas(), "wrong gas for big struct set")
 	})
 
@@ -247,7 +247,8 @@ func TestMapping_MultiSlotValue(t *testing.T) {
 		got, err := mapping.Get(key)
 		require.NoError(t, err)
 		assert.Equal(t, value, got)
-		assert.Equal(t, 4*thor.SloadGas, charger.TotalGas(), "wrong gas for big struct get")
+		// maximum 2 slots, defined by gas.go
+		assert.Equal(t, 2*thor.SloadGas, charger.TotalGas(), "wrong gas for big struct get")
 	})
 }
 


### PR DESCRIPTION
# Description

Previously, we are charging slot accessing and storing by word size, which is per-32 byte, this is what solidity compiler is doing, but the compiler are splitting big types into 32-byte storage slots, which result in multiple disk read.

But in our implementation, it's a bit unfair to user if we charge per 32-byte since every accessing is one disk read. So this PR proposes maximum 2 word cost for each slot. And this also relfected in the `staker_native_gas_test.go`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
