### PR TITLE
fix: invalidate cache after beneficiary set events

### DIFF
--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -23,12 +23,13 @@ import (
 	"github.com/vechain/thor/v2/thor"
 )
 
-// TODO: Do these need to be set in params.sol, or some other dynamic way?
-var (
-	logger = log.WithContext("pkg", "staker")
-
+const (
 	MinStakeVET = uint64(25e6)  // 25M VET
 	MaxStakeVET = uint64(600e6) // 600M VET
+)
+
+var (
+	logger = log.WithContext("pkg", "staker")
 	// exported for other packages to use
 	MinStake = big.NewInt(0).Mul(new(big.Int).SetUint64(MinStakeVET), big.NewInt(1e18))
 	MaxStake = big.NewInt(0).Mul(new(big.Int).SetUint64(MaxStakeVET), big.NewInt(1e18))

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -94,7 +94,7 @@ func (c *Consensus) NewRuntimeForReplay(header *block.Header, skipValidation boo
 			return nil, err
 		}
 		if dPosStatus.Active {
-			err = c.validateStakingProposer(header, parentSummary.Header, staker)
+			_, err = c.validateStakingProposer(header, parentSummary.Header, staker)
 		} else {
 			_, err = c.validateAuthorityProposer(header, parentSummary.Header, state)
 		}

--- a/consensus/poa_validator.go
+++ b/consensus/poa_validator.go
@@ -16,7 +16,7 @@ import (
 	"github.com/vechain/thor/v2/tx"
 )
 
-func (c *Consensus) validateAuthorityProposer(header *block.Header, parent *block.Header, st *state.State) (*poa.Candidates, error) {
+func (c *Consensus) validateAuthorityProposer(header *block.Header, parent *block.Header, st *state.State) (*poaCacher, error) {
 	signer, err := header.Signer()
 	if err != nil {
 		return nil, consensusError(fmt.Sprintf("block signer unavailable: %v", err))
@@ -79,11 +79,17 @@ func (c *Consensus) validateAuthorityProposer(header *block.Header, parent *bloc
 		}
 	}
 
-	return candidates, nil
+	return &poaCacher{candidates, c.forkConfig}, nil
 }
 
-// handleAuthorityEvents checks each block for authority related events, and updates the candidates list accordingly.
-func (c *Consensus) authorityCacheHandler(candidates *poa.Candidates, header *block.Header, receipts tx.Receipts) error {
+type poaCacher struct {
+	candidates *poa.Candidates
+	forkConfig *thor.ForkConfig
+}
+
+var _ cacher = (*poaCacher)(nil)
+
+func (p poaCacher) Handle(header *block.Header, receipts tx.Receipts) (any, error) {
 	hasAuthorityEvent := func() bool {
 		for _, r := range receipts {
 			for _, o := range r.Outputs {
@@ -105,7 +111,7 @@ func (c *Consensus) authorityCacheHandler(candidates *poa.Candidates, header *bl
 			for _, r := range receipts {
 				for _, o := range r.Outputs {
 					for _, ev := range o.Events {
-						if header.Number() >= c.forkConfig.HAYABUSA && ev.Address == builtin.Staker.Address {
+						if header.Number() >= p.forkConfig.HAYABUSA && ev.Address == builtin.Staker.Address {
 							return true
 						}
 						if ev.Address == builtin.Params.Address {
@@ -113,7 +119,7 @@ func (c *Consensus) authorityCacheHandler(candidates *poa.Candidates, header *bl
 						}
 					}
 					for _, t := range o.Transfers {
-						if candidates.IsEndorsor(t.Sender) || candidates.IsEndorsor(t.Recipient) {
+						if p.candidates.IsEndorsor(t.Sender) || p.candidates.IsEndorsor(t.Recipient) {
 							return true
 						}
 					}
@@ -123,10 +129,9 @@ func (c *Consensus) authorityCacheHandler(candidates *poa.Candidates, header *bl
 		}()
 
 		if hasEndorsorEvent {
-			candidates.InvalidateCache()
+			p.candidates.InvalidateCache()
 		}
-		c.validatorsCache.Add(header.ID(), candidates)
 	}
 
-	return nil
+	return p.candidates, nil
 }

--- a/consensus/poa_validator_test.go
+++ b/consensus/poa_validator_test.go
@@ -16,10 +16,7 @@ import (
 	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/builtin/authority"
 	"github.com/vechain/thor/v2/builtin/staker/validation"
-	"github.com/vechain/thor/v2/chain"
-	"github.com/vechain/thor/v2/muxdb"
 	"github.com/vechain/thor/v2/poa"
-	"github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/test/testchain"
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/tx"
@@ -81,14 +78,8 @@ func TestAuthority_Hayabusa_NegativeCases(t *testing.T) {
 }
 
 func TestAuthorityCacheHandler_Success(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
 	mockForkConfig.HAYABUSA = 0
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidateList := []*authority.Candidate{
 		{
@@ -135,18 +126,13 @@ func TestAuthorityCacheHandler_Success(t *testing.T) {
 		},
 	}
 
-	err := consensus.authorityCacheHandler(candidates, header, receipts)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_NilCandidates(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	header := new(block.Builder).
 		ParentID(thor.BytesToBytes32([]byte("parent123"))).
@@ -161,18 +147,13 @@ func TestAuthorityCacheHandler_NilCandidates(t *testing.T) {
 
 	receipts := tx.Receipts{}
 
-	err := consensus.authorityCacheHandler(nil, header, receipts)
+	cacher := &poaCacher{nil, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_EmptyCandidates(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidates := poa.NewCandidates([]*authority.Candidate{})
 
@@ -189,18 +170,13 @@ func TestAuthorityCacheHandler_EmptyCandidates(t *testing.T) {
 
 	receipts := tx.Receipts{}
 
-	err := consensus.authorityCacheHandler(candidates, header, receipts)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_WithAuthorityEvents(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidateList := []*authority.Candidate{
 		{
@@ -242,20 +218,15 @@ func TestAuthorityCacheHandler_WithAuthorityEvents(t *testing.T) {
 		},
 	}
 
-	err := consensus.authorityCacheHandler(candidates, header, receipts)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_WithStakerEvents(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{
 		HAYABUSA: 100,
 	}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidateList := []*authority.Candidate{
 		{
@@ -296,18 +267,13 @@ func TestAuthorityCacheHandler_WithStakerEvents(t *testing.T) {
 		},
 	}
 
-	err := consensus.authorityCacheHandler(candidates, header, receipts)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_WithParamsEvents(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidateList := []*authority.Candidate{
 		{
@@ -348,18 +314,13 @@ func TestAuthorityCacheHandler_WithParamsEvents(t *testing.T) {
 		},
 	}
 
-	err := consensus.authorityCacheHandler(candidates, header, receipts)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_WithEndorsorTransfers(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidateList := []*authority.Candidate{
 		{
@@ -399,18 +360,13 @@ func TestAuthorityCacheHandler_WithEndorsorTransfers(t *testing.T) {
 		},
 	}
 
-	err := consensus.authorityCacheHandler(candidates, header, receipts)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_WithMultipleEvents(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidateList := []*authority.Candidate{
 		{
@@ -457,18 +413,13 @@ func TestAuthorityCacheHandler_WithMultipleEvents(t *testing.T) {
 		},
 	}
 
-	err := consensus.authorityCacheHandler(candidates, header, receipts)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_WithNilReceipts(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidateList := []*authority.Candidate{
 		{
@@ -492,18 +443,13 @@ func TestAuthorityCacheHandler_WithNilReceipts(t *testing.T) {
 		Beneficiary(thor.Address{}).
 		Build().Header()
 
-	err := consensus.authorityCacheHandler(candidates, header, nil)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, nil)
 	assert.NoError(t, err)
 }
 
 func TestAuthorityCacheHandler_WithEmptyReceipts(t *testing.T) {
-	db := muxdb.NewMem()
-	stater := state.NewStater(db)
-
-	mockRepo := &chain.Repository{}
 	mockForkConfig := &thor.ForkConfig{}
-
-	consensus := New(mockRepo, stater, mockForkConfig)
 
 	candidateList := []*authority.Candidate{
 		{
@@ -529,7 +475,8 @@ func TestAuthorityCacheHandler_WithEmptyReceipts(t *testing.T) {
 
 	receipts := tx.Receipts{}
 
-	err := consensus.authorityCacheHandler(candidates, header, receipts)
+	cacher := &poaCacher{candidates, mockForkConfig}
+	_, err := cacher.Handle(header, receipts)
 	assert.NoError(t, err)
 }
 

--- a/consensus/pos_validator_test.go
+++ b/consensus/pos_validator_test.go
@@ -37,7 +37,7 @@ func TestConsensus_PosFork(t *testing.T) {
 
 	// mint block 2: chain should set the staker contract, still using PoA
 	best, parent, st := setup.mintBlock()
-	err := setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
+	_, err := setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "pos - block signer invalid")
 	_, err = setup.consensus.validateAuthorityProposer(best.Header, parent.Header, st)
 	assert.NoError(t, err)
@@ -47,7 +47,7 @@ func TestConsensus_PosFork(t *testing.T) {
 
 	// mint block 4: chain should switch to PoS
 	best, parent, st = setup.mintBlock()
-	err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
 	assert.NoError(t, err)
 
 	cache, err := simplelru.NewLRU(16, nil)
@@ -95,7 +95,7 @@ func TestConsensus_PosFork(t *testing.T) {
 		Beneficiary(parent.Header.Beneficiary()).
 		Build().Header()
 
-	err = setup.consensus.validateStakingProposer(best.Header, newParentHeader, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(best.Header, newParentHeader, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "pos - stake beneficiary mismatch")
 
 	newLeaders = make([]validation.Leader, 0, len(leaders))
@@ -126,13 +126,13 @@ func TestConsensus_PosFork(t *testing.T) {
 		Beneficiary(parent.Header.Beneficiary()).
 		Build().Header()
 
-	err = setup.consensus.validateStakingProposer(best.Header, newParentHeader, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(best.Header, newParentHeader, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "pos - block total score invalid")
 
 	slotLockedVET := thor.BytesToBytes32([]byte(("total-weighted-stake")))
 	st.SetRawStorage(builtin.Staker.Address, slotLockedVET, rlp.RawValue{0xFF})
 
-	err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "pos - cannot get total weight")
 
 	newParentHeader = new(block.Builder).
@@ -150,7 +150,7 @@ func TestConsensus_PosFork(t *testing.T) {
 	slot := thor.Blake2b(parentSig.Bytes(), slotValidation.Bytes())
 	st.SetRawStorage(builtin.Staker.Address, slot, rlp.RawValue{0xFF})
 
-	err = setup.consensus.validateStakingProposer(best.Header, newParentHeader, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(best.Header, newParentHeader, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "failed to get validator")
 }
 
@@ -160,7 +160,7 @@ func TestConsensus_CannotGetLeaderGroup(t *testing.T) {
 	setup.mintMbpBlock(1)
 
 	best, parent, st := setup.mintBlock()
-	err := setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
+	_, err := setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "pos - block signer invalid")
 	_, err = setup.consensus.validateAuthorityProposer(best.Header, parent.Header, st)
 	assert.NoError(t, err)
@@ -168,14 +168,14 @@ func TestConsensus_CannotGetLeaderGroup(t *testing.T) {
 	setup.mintAddValidatorBlock()
 
 	best, parent, st = setup.mintBlock()
-	err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
 	assert.NoError(t, err)
 
 	slotValidationsActiveHead := thor.BytesToBytes32([]byte("validations-active-head"))
 
 	st.SetRawStorage(builtin.Staker.Address, slotValidationsActiveHead, rlp.RawValue{0xFF})
 
-	err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(best.Header, parent.Header, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "pos - cannot get leader group")
 }
 
@@ -196,7 +196,7 @@ func TestConsensus_POS_MissedSlots(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, setup.chain.AddBlock(blk, stage, receipts))
 
-	err = setup.consensus.validateStakingProposer(blk.Header(), parent.Header, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(blk.Header(), parent.Header, builtin.Staker.Native(st))
 	assert.NoError(t, err)
 	staker := builtin.Staker.Native(st)
 	validator, err := staker.GetValidation(signer.Address)
@@ -220,7 +220,7 @@ func TestConsensus_POS_Unscheduled(t *testing.T) {
 	blk, _, _, err := flow.Pack(signer.PrivateKey, 0, false)
 	assert.NoError(t, err)
 
-	err = setup.consensus.validateStakingProposer(blk.Header(), parent.Header, builtin.Staker.Native(st))
+	_, err = setup.consensus.validateStakingProposer(blk.Header(), parent.Header, builtin.Staker.Native(st))
 	assert.ErrorContains(t, err, "block timestamp unscheduled")
 }
 
@@ -265,7 +265,7 @@ func TestValidateStakingProposer_LockedVETError(t *testing.T) {
 	blk = blk.WithSignature(validSignature)
 	header := blk.Header()
 
-	err := consensus.validateStakingProposer(header, parent, staker)
+	_, err := consensus.validateStakingProposer(header, parent, staker)
 	assert.ErrorContains(t, err, "pos - block signer invalid")
 }
 


### PR DESCRIPTION
# Description

- bug: consensus cache is not invalidated after beneficiary events.
- refactor: only write to cache within `Consensus.validate`. This prevents `NewRuntimeForReplay` from writing to cache

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
