### PR TITLE
chore: `GetMaxBlockProposers` extracted

### DIFF
--- a/bft/engine.go
+++ b/bft/engine.go
@@ -437,15 +437,7 @@ func (engine *Engine) getTotalWeight(sum *chain.BlockSummary) (uint64, error) {
 
 func (engine *Engine) getMaxBlockProposers(sum *chain.BlockSummary) (uint64, error) {
 	state := engine.stater.NewState(sum.Root())
-	params, err := builtin.Params.Native(state).Get(thor.KeyMaxBlockProposers)
-	if err != nil {
-		return 0, err
-	}
-	mbp := params.Uint64()
-	if mbp == 0 || mbp > thor.InitialMaxBlockProposers {
-		mbp = thor.InitialMaxBlockProposers
-	}
-	return mbp, nil
+	return thor.GetMaxBlockProposers(builtin.Params.Native(state), true)
 }
 
 func (engine *Engine) getQuality(id thor.Bytes32) (quality uint32, err error) {

--- a/builtin/staker/delegation/service.go
+++ b/builtin/staker/delegation/service.go
@@ -93,7 +93,7 @@ func (s *Service) newDelegationID() (*big.Int, error) {
 	if err != nil {
 		return nil, err
 	}
-	// fist seen will be a nil pointer
+	// first seen will be a nil pointer
 	if id == nil {
 		id = big.NewInt(0)
 	}

--- a/builtin/staker/doc.go
+++ b/builtin/staker/doc.go
@@ -5,7 +5,7 @@
 
 package staker
 
-// Package staker implements the buitlin staker contract.
+// Package staker implements the builtin staker contract.
 //
 // It contains the core logic for the staker contract, including the staker's
 // state, the staker's methods, and the staker's events.

--- a/builtin/staker/housekeep.go
+++ b/builtin/staker/housekeep.go
@@ -97,6 +97,19 @@ func (s *Staker) evictionCallback(currentBlock uint32, evictions *[]thor.Address
 	}
 }
 
+// getMaxBlockProposers returns the max block proposers from the params
+func (s *Staker) getMaxBlockProposers() (uint64, error) {
+	mbp, err := s.params.Get(thor.KeyMaxBlockProposers)
+	if err != nil {
+		return 0, err
+	}
+	maxBlockProposers := mbp.Uint64()
+	if maxBlockProposers == 0 {
+		maxBlockProposers = thor.InitialMaxBlockProposers
+	}
+	return maxBlockProposers, nil
+}
+
 // computeActivationCount calculates how many validators can be activated
 func (s *Staker) computeActivationCount(hasValidatorExited bool) (uint64, error) {
 	// Calculate how many validators can be activated
@@ -113,13 +126,9 @@ func (s *Staker) computeActivationCount(hasValidatorExited bool) (uint64, error)
 		leaderSize = leaderSize - 1
 	}
 
-	mbp, err := s.params.Get(thor.KeyMaxBlockProposers)
+	maxBlockProposers, err := s.getMaxBlockProposers()
 	if err != nil {
 		return 0, err
-	}
-	maxBlockProposers := mbp.Uint64()
-	if maxBlockProposers == 0 {
-		maxBlockProposers = thor.InitialMaxBlockProposers
 	}
 
 	// If full or nothing queued then no activations
@@ -197,13 +206,9 @@ func (s *Staker) applyEpochTransition(transition *EpochTransition) error {
 	}
 
 	// Apply activations using existing method
-	mbp, err := s.params.Get(thor.KeyMaxBlockProposers)
+	maxBlockProposers, err := s.getMaxBlockProposers()
 	if err != nil {
 		return err
-	}
-	maxBlockProposers := mbp.Uint64()
-	if maxBlockProposers == 0 {
-		maxBlockProposers = thor.InitialMaxBlockProposers
 	}
 
 	for range transition.ActivationCount {

--- a/builtin/staker/housekeep.go
+++ b/builtin/staker/housekeep.go
@@ -97,19 +97,6 @@ func (s *Staker) evictionCallback(currentBlock uint32, evictions *[]thor.Address
 	}
 }
 
-// GetMaxBlockProposers returns the max block proposers from the params
-func (s *Staker) GetMaxBlockProposers() (uint64, error) {
-	mbp, err := s.params.Get(thor.KeyMaxBlockProposers)
-	if err != nil {
-		return 0, err
-	}
-	maxBlockProposers := mbp.Uint64()
-	if maxBlockProposers == 0 {
-		maxBlockProposers = thor.InitialMaxBlockProposers
-	}
-	return maxBlockProposers, nil
-}
-
 // computeActivationCount calculates how many validators can be activated
 func (s *Staker) computeActivationCount(hasValidatorExited bool) (uint64, error) {
 	// Calculate how many validators can be activated
@@ -126,7 +113,7 @@ func (s *Staker) computeActivationCount(hasValidatorExited bool) (uint64, error)
 		leaderSize = leaderSize - 1
 	}
 
-	maxBlockProposers, err := s.GetMaxBlockProposers()
+	maxBlockProposers, err := thor.GetMaxBlockProposers(s.params, false)
 	if err != nil {
 		return 0, err
 	}
@@ -206,7 +193,7 @@ func (s *Staker) applyEpochTransition(transition *EpochTransition) error {
 	}
 
 	// Apply activations using existing method
-	maxBlockProposers, err := s.GetMaxBlockProposers()
+	maxBlockProposers, err := thor.GetMaxBlockProposers(s.params, false)
 	if err != nil {
 		return err
 	}

--- a/builtin/staker/housekeep.go
+++ b/builtin/staker/housekeep.go
@@ -97,8 +97,8 @@ func (s *Staker) evictionCallback(currentBlock uint32, evictions *[]thor.Address
 	}
 }
 
-// getMaxBlockProposers returns the max block proposers from the params
-func (s *Staker) getMaxBlockProposers() (uint64, error) {
+// GetMaxBlockProposers returns the max block proposers from the params
+func (s *Staker) GetMaxBlockProposers() (uint64, error) {
 	mbp, err := s.params.Get(thor.KeyMaxBlockProposers)
 	if err != nil {
 		return 0, err
@@ -126,7 +126,7 @@ func (s *Staker) computeActivationCount(hasValidatorExited bool) (uint64, error)
 		leaderSize = leaderSize - 1
 	}
 
-	maxBlockProposers, err := s.getMaxBlockProposers()
+	maxBlockProposers, err := s.GetMaxBlockProposers()
 	if err != nil {
 		return 0, err
 	}
@@ -206,7 +206,7 @@ func (s *Staker) applyEpochTransition(transition *EpochTransition) error {
 	}
 
 	// Apply activations using existing method
-	maxBlockProposers, err := s.getMaxBlockProposers()
+	maxBlockProposers, err := s.GetMaxBlockProposers()
 	if err != nil {
 		return err
 	}

--- a/builtin/staker/transition.go
+++ b/builtin/staker/transition.go
@@ -26,7 +26,7 @@ func (s *Staker) transition(currentBlock uint32) (bool, error) {
 		return false, nil
 	}
 
-	maxBlockProposers, err := s.GetMaxBlockProposers()
+	maxBlockProposers, err := thor.GetMaxBlockProposers(s.params, false)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/staker/transition.go
+++ b/builtin/staker/transition.go
@@ -26,14 +26,9 @@ func (s *Staker) transition(currentBlock uint32) (bool, error) {
 		return false, nil
 	}
 
-	mbp, err := s.params.Get(thor.KeyMaxBlockProposers)
+	maxBlockProposers, err := s.getMaxBlockProposers()
 	if err != nil {
 		return false, err
-	}
-
-	maxBlockProposers := mbp.Uint64()
-	if maxBlockProposers == 0 {
-		maxBlockProposers = thor.InitialMaxBlockProposers
 	}
 
 	queueSize, err := s.validationService.QueuedGroupSize()

--- a/builtin/staker/transition.go
+++ b/builtin/staker/transition.go
@@ -26,7 +26,7 @@ func (s *Staker) transition(currentBlock uint32) (bool, error) {
 		return false, nil
 	}
 
-	maxBlockProposers, err := s.getMaxBlockProposers()
+	maxBlockProposers, err := s.GetMaxBlockProposers()
 	if err != nil {
 		return false, err
 	}

--- a/builtin/staker/validation/validation.go
+++ b/builtin/staker/validation/validation.go
@@ -135,7 +135,7 @@ func (v *Validation) CurrentIteration(currentBlock uint32) (uint32, error) {
 
 	// Active
 	if currentBlock < v.StartBlock {
-		return 0, errors.New("curren block cannot be less than start block")
+		return 0, errors.New("current block cannot be less than start block")
 	}
 	if v.Period == 0 {
 		return 0, errors.New("period cannot be zero")

--- a/packer/poa_scheduler.go
+++ b/packer/poa_scheduler.go
@@ -21,14 +21,9 @@ func (p *Packer) schedulePOA(parent *chain.BlockSummary, nowTimestamp uint64, st
 	}
 	staker := builtin.Staker.Native(state)
 
-	mbp, err := builtin.Params.Native(state).Get(thor.KeyMaxBlockProposers)
+	maxBlockProposers, err := thor.GetMaxBlockProposers(builtin.Params.Native(state), true)
 	if err != nil {
 		return thor.Address{}, 0, 0, err
-	}
-
-	maxBlockProposers := mbp.Uint64()
-	if maxBlockProposers == 0 || maxBlockProposers > thor.InitialMaxBlockProposers {
-		maxBlockProposers = thor.InitialMaxBlockProposers
 	}
 
 	balanceCheck := staker.TransitionPeriodBalanceCheck(p.forkConfig, parent.Header.Number()+1, endorsement)

--- a/poa/candidates.go
+++ b/poa/candidates.go
@@ -54,13 +54,9 @@ func (c *Candidates) Copy() *Candidates {
 func (c *Candidates) Pick(state *state.State, checkBalance authority.BalanceChecker) ([]Proposer, error) {
 	satisfied := c.satisfied
 	if len(satisfied) == 0 {
-		mbp, err := builtin.Params.Native(state).Get(thor.KeyMaxBlockProposers)
+		maxBlockProposers, err := thor.GetMaxBlockProposers(builtin.Params.Native(state), true)
 		if err != nil {
 			return nil, err
-		}
-		maxBlockProposers := mbp.Uint64()
-		if maxBlockProposers == 0 || maxBlockProposers > thor.InitialMaxBlockProposers {
-			maxBlockProposers = thor.InitialMaxBlockProposers
 		}
 
 		satisfied = make([]int, 0, len(c.list))

--- a/thor/params.go
+++ b/thor/params.go
@@ -70,7 +70,8 @@ var (
 // If capToInitial is true, values greater than InitialMaxBlockProposers are also capped (PoA)
 func GetMaxBlockProposers(params interface {
 	Get(Bytes32) (*big.Int, error)
-}, capToInitial bool) (uint64, error) {
+}, capToInitial bool,
+) (uint64, error) {
 	mbp, err := params.Get(KeyMaxBlockProposers)
 	if err != nil {
 		return 0, err

--- a/thor/params.go
+++ b/thor/params.go
@@ -65,3 +65,20 @@ var (
 	EnergyGrowthRate      = big.NewInt(5000000000) // WEI THOR per token(VET) per second. about 0.000432 THOR per token per day.
 	NumberOfBlocksPerYear = big.NewInt(8640 * 365) // number of blocks per year, non leap (365 days)
 )
+
+// GetMaxBlockProposers retrieves the max block proposers parameter with fallback to initial value
+// If capToInitial is true, values greater than InitialMaxBlockProposers are also capped (PoA)
+func GetMaxBlockProposers(params interface {
+	Get(Bytes32) (*big.Int, error)
+}, capToInitial bool) (uint64, error) {
+	mbp, err := params.Get(KeyMaxBlockProposers)
+	if err != nil {
+		return 0, err
+	}
+
+	maxBlockProposers := mbp.Uint64()
+	if maxBlockProposers == 0 || (capToInitial && maxBlockProposers > InitialMaxBlockProposers) {
+		maxBlockProposers = InitialMaxBlockProposers
+	}
+	return maxBlockProposers, nil
+}


### PR DESCRIPTION
# Description

Extracted duplicated logic into a single method.

Difference with PoA taken into account for cases where `maxBlockProposers > thor.InitialMaxBlockProposers` (`capToInitial` = `true`)
