### PR TITLE
introduce wsc check

### DIFF
--- a/api/admin/health/health_api_test.go
+++ b/api/admin/health/health_api_test.go
@@ -55,7 +55,7 @@ func initAPIServer(t *testing.T) {
 	masterNode, _ := masterNode()
 	router := mux.NewRouter()
 	NewAPI(
-		New(thorChain.Repo(), comm.New(thorChain.Repo(), txpool.New(thorChain.Repo(), nil, txpool.Options{}, &thor.NoFork))), masterNode,
+		New(thorChain.Repo(), comm.New(thorChain.Repo(), txpool.New(thorChain.Repo(), nil, txpool.Options{}, &thor.NoFork), nil)), masterNode,
 	).Mount(router, "/health")
 
 	ts = httptest.NewServer(router)

--- a/api/node/node_test.go
+++ b/api/node/node_test.go
@@ -78,6 +78,7 @@ func initCommServer(t *testing.T) {
 			LimitPerAccount: 128,
 			MaxLifetime:     10 * time.Minute,
 		}, &thor.NoFork),
+		nil,
 	)
 
 	router := mux.NewRouter()

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -180,6 +180,10 @@ var (
 		Value: "localhost:2113",
 		Usage: "admin service listening address",
 	}
+	wscProviderURLFlag = cli.StringFlag{
+		Name:  "wsc-provider-url",
+		Usage: "URL of the weak subjectivity checkpoint provider",
+	}
 	txPoolLimitPerAccountFlag = cli.Uint64Flag{
 		Name:  "txpool-limit-per-account",
 		Value: 128,

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -482,7 +482,13 @@ func loadNodeMaster(ctx *cli.Context) (*node.Master, error) {
 	return master, nil
 }
 
-func newP2PCommunicator(ctx *cli.Context, repo *chain.Repository, txPool *txpool.TxPool, instanceDir string) (*p2p.P2P, error) {
+func newP2PCommunicator(
+	ctx *cli.Context,
+	repo *chain.Repository,
+	txPool *txpool.TxPool,
+	wspChecker *comm.WeakSubjectivityChecker,
+	instanceDir string,
+) (*p2p.P2P, error) {
 	// known peers will be loaded/stored from/in this file
 	peersCachePath := filepath.Join(instanceDir, "peers.cache")
 
@@ -522,7 +528,7 @@ func newP2PCommunicator(ctx *cli.Context, repo *chain.Repository, txPool *txpool
 	}
 
 	return p2p.New(
-		comm.New(repo, txPool),
+		comm.New(repo, txPool, wspChecker),
 		key,
 		instanceDir,
 		userNAT,

--- a/comm/retry.go
+++ b/comm/retry.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package comm
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+// retryWithBackoff retries fn up to maxAttempts with exponential backoff.
+// The delay starts at initialDelay and doubles each time up to maxDelay.
+// A small jitter (±10%) is added to spread retries.
+// The function is cancellable via ctx.
+func retryWithBackoff(ctx context.Context, maxRetry int, initialDelay, maxDelay time.Duration, fn func(context.Context) error) error {
+	if maxRetry <= 0 {
+		return fn(ctx)
+	}
+
+	// Create a per-call RNG for jitter
+	rng := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec G404
+
+	delay := initialDelay
+	var lastErr error
+	for attempt := 1; attempt <= maxRetry; attempt++ {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		if err := fn(ctx); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+
+		if attempt == maxRetry {
+			break
+		}
+
+		// jitter in [0.9, 1.1]
+		jitter := 0.9 + 0.2*rng.Float64()
+		sleepFor := min(time.Duration(float64(delay)*jitter), maxDelay)
+
+		timer := time.NewTimer(sleepFor)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+
+		// Exponential backoff with cap
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+	}
+	return lastErr
+}

--- a/comm/retry_test.go
+++ b/comm/retry_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package comm
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryWithBackoff_SucceedsImmediate(t *testing.T) {
+	t.Parallel()
+	var attempts int
+	err := retryWithBackoff(context.Background(), 5, 10*time.Millisecond, 50*time.Millisecond, func(ctx context.Context) error {
+		attempts++
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, attempts, "should not retry when first attempt succeeds")
+}
+
+func TestRetryWithBackoff_SucceedsAfterRetries(t *testing.T) {
+	t.Parallel()
+	var attempts int
+	failFirst := 2
+	err := retryWithBackoff(context.Background(), 5, 10*time.Millisecond, 50*time.Millisecond, func(ctx context.Context) error {
+		attempts++
+		if attempts <= failFirst {
+			return errors.New("transient error")
+		}
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, failFirst+1, attempts, "should retry until success")
+}
+
+func TestRetryWithBackoff_ExhaustsAttempts(t *testing.T) {
+	t.Parallel()
+	var attempts int
+	maxAttempts := 3
+	start := time.Now()
+	err := retryWithBackoff(context.Background(), maxAttempts, 10*time.Millisecond, 40*time.Millisecond, func(ctx context.Context) error {
+		attempts++
+		return errors.New("always fails")
+	})
+	elapsed := time.Since(start)
+	assert.Error(t, err)
+	assert.Equal(t, maxAttempts, attempts)
+	// Expect at least (maxAttempts-1) sleeps with jitter; allow generous lower bound
+	assert.GreaterOrEqual(t, elapsed, 10*time.Millisecond)
+}
+
+func TestRetryWithBackoff_ContextCancelledBeforeStart(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var attempts int
+	err := retryWithBackoff(ctx, 5, 10*time.Millisecond, 50*time.Millisecond, func(ctx context.Context) error {
+		attempts++
+		return nil
+	})
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Equal(t, 0, attempts, "fn should not be called when context already cancelled")
+}
+
+func TestRetryWithBackoff_ContextCancelledDuringSleep(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var attempts int
+	done := make(chan struct{})
+	go func() {
+		// Cancel during the first backoff
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+		close(done)
+	}()
+
+	start := time.Now()
+	err := retryWithBackoff(ctx, 5, 200*time.Millisecond, 200*time.Millisecond, func(ctx context.Context) error {
+		attempts++
+		return errors.New("transient")
+	})
+	<-done
+	elapsed := time.Since(start)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Equal(t, 1, attempts, "should cancel during first sleep, so only one attempt")
+	assert.Less(t, elapsed, 200*time.Millisecond, "should return before completing first sleep")
+}
+
+func TestRetryWithBackoff_InitialDelayZero(t *testing.T) {
+	t.Parallel()
+	var attempts int
+	maxAttempts := 3
+	start := time.Now()
+	err := retryWithBackoff(context.Background(), maxAttempts, 0, 0, func(ctx context.Context) error {
+		attempts++
+		return errors.New("boom")
+	})
+	elapsed := time.Since(start)
+	assert.Error(t, err)
+	assert.Equal(t, maxAttempts, attempts)
+	assert.Less(t, elapsed, 50*time.Millisecond)
+}
+
+func TestRetryWithBackoff_MaxDelayCap(t *testing.T) {
+	t.Parallel()
+	var attempts int
+	successAt := 4 // will perform 3 sleeps before succeeding
+	start := time.Now()
+	err := retryWithBackoff(context.Background(), successAt, 20*time.Millisecond, 30*time.Millisecond, func(ctx context.Context) error {
+		attempts++
+		if attempts < successAt {
+			return errors.New("retry")
+		}
+		return nil
+	})
+	elapsed := time.Since(start)
+	assert.NoError(t, err)
+	assert.Equal(t, successAt, attempts)
+	// Expect at least ~20 + 30 + 30 ms minus jitter; allow generous lower bound
+	assert.GreaterOrEqual(t, elapsed, 50*time.Millisecond)
+}

--- a/comm/weak_subjectivity.go
+++ b/comm/weak_subjectivity.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2025 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package comm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/math"
+
+	"github.com/vechain/thor/v2/bft"
+	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/chain"
+	"github.com/vechain/thor/v2/thor"
+)
+
+type WeakSubjectivityCheckpoint struct {
+	ID           thor.Bytes32 `json:"id"`
+	Number       uint32       `json:"number"`
+	TxsRoot      thor.Bytes32 `json:"txsRoot"`
+	StateRoot    thor.Bytes32 `json:"stateRoot"`
+	ReceiptsRoot thor.Bytes32 `json:"receiptsRoot"`
+}
+
+type wspBlockSummary struct {
+	Number        uint32                `json:"number"`
+	ID            thor.Bytes32          `json:"id"`
+	Size          uint32                `json:"size"`
+	ParentID      thor.Bytes32          `json:"parentID"`
+	Timestamp     uint64                `json:"timestamp"`
+	GasLimit      uint64                `json:"gasLimit"`
+	Beneficiary   thor.Address          `json:"beneficiary"`
+	GasUsed       uint64                `json:"gasUsed"`
+	TotalScore    uint64                `json:"totalScore"`
+	TxsRoot       thor.Bytes32          `json:"txsRoot"`
+	TxsFeatures   uint32                `json:"txsFeatures"`
+	StateRoot     thor.Bytes32          `json:"stateRoot"`
+	ReceiptsRoot  thor.Bytes32          `json:"receiptsRoot"`
+	COM           bool                  `json:"com"`
+	Signer        thor.Address          `json:"signer"`
+	IsTrunk       bool                  `json:"isTrunk"`
+	IsFinalized   bool                  `json:"isFinalized"`
+	BaseFeePerGas *math.HexOrDecimal256 `json:"baseFeePerGas,omitempty"`
+}
+
+type wspResponse struct {
+	wspBlockSummary
+	Transactions []thor.Bytes32 `json:"transactions"`
+}
+
+type WeakSubjectivityChecker struct {
+	repo           *chain.Repository
+	bft            bft.Committer
+	client         *http.Client
+	wspProviderURL string
+}
+
+func NewWeakSubjectivityChecker(repo *chain.Repository, bft bft.Committer, wscURL string) *WeakSubjectivityChecker {
+	return &WeakSubjectivityChecker{
+		repo:           repo,
+		bft:            bft,
+		client:         &http.Client{},
+		wspProviderURL: wscURL,
+	}
+}
+
+func ValidateWeakSubjectivityCheckpoint(blk *block.Block, checkpoint *WeakSubjectivityCheckpoint) (bool, error) {
+	now := uint64(time.Now().Unix())
+	checkpointTimestamp := blk.Header().Timestamp()
+
+	if now <= checkpointTimestamp {
+		return false, fmt.Errorf("checkpoint is in the future")
+	}
+
+	if blk.Header().ID() != checkpoint.ID {
+		return false, fmt.Errorf("block id mismatch")
+	}
+
+	if blk.Header().Number() != checkpoint.Number {
+		return false, fmt.Errorf("number mismatch")
+	}
+
+	if blk.Header().TxsRoot() != checkpoint.TxsRoot {
+		return false, fmt.Errorf("txs root mismatch")
+	}
+
+	if blk.Header().StateRoot() != checkpoint.StateRoot {
+		return false, fmt.Errorf("state root mismatch")
+	}
+
+	if blk.Header().ReceiptsRoot() != checkpoint.ReceiptsRoot {
+		return false, fmt.Errorf("receipts root mismatch")
+	}
+
+	return true, nil
+}
+
+func (w *WeakSubjectivityChecker) LatestFinalizedBlock() (*block.Block, error) {
+	if w.bft == nil {
+		return nil, fmt.Errorf("bft engine is not set")
+	}
+	finalizedID := w.bft.Finalized()
+	blk, err := w.repo.GetBlock(finalizedID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get finalized block: %w", err)
+	}
+	return blk, nil
+}
+
+func (w *WeakSubjectivityChecker) PerformCheck(ctx context.Context) error {
+	// Retry fetch with exponential backoff (3 attempts, starting at 1s up to 8s)
+	fetchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	var checkpoint *WeakSubjectivityCheckpoint
+	if err := retryWithBackoff(fetchCtx, 3, time.Second, 8*time.Second, func(ctx context.Context) error {
+		callCtx, callCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer callCancel()
+		cp, err := w.fetchWeakSubjectivityCheckpoint(callCtx, w.wspProviderURL)
+		if err != nil {
+			return err
+		}
+		checkpoint = cp
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// We compare the internal latest finalized block, provided by the bft engine
+	// with the received checkpoint.
+	internalFinalizedBlk, err := w.LatestFinalizedBlock()
+	if err != nil {
+		return err
+	}
+
+	if err := w.checkFinalizedAndCheckpoint(internalFinalizedBlk, checkpoint); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *WeakSubjectivityChecker) checkFinalizedAndCheckpoint(finalizedBlk *block.Block, checkpoint *WeakSubjectivityCheckpoint) error {
+	header := finalizedBlk.Header()
+	if header.ID() != checkpoint.ID {
+		return fmt.Errorf("finalized block ID does not match checkpoint")
+	}
+	if header.Number() != checkpoint.Number {
+		return fmt.Errorf("finalized block number does not match checkpoint")
+	}
+	if header.TxsRoot() != checkpoint.TxsRoot {
+		return fmt.Errorf("finalized block TxsRoot does not match checkpoint")
+	}
+	if header.StateRoot() != checkpoint.StateRoot {
+		return fmt.Errorf("finalized block StateRoot does not match checkpoint")
+	}
+	if header.ReceiptsRoot() != checkpoint.ReceiptsRoot {
+		return fmt.Errorf("finalized block ReceiptsRoot does not match checkpoint")
+	}
+	return nil
+}
+
+func (w *WeakSubjectivityChecker) fetchWeakSubjectivityCheckpoint(ctx context.Context, url string) (*WeakSubjectivityCheckpoint, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	defer io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %v", resp.Status)
+	}
+
+	var r wspResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return nil, fmt.Errorf("decode wsp response: %w", err)
+	}
+
+	if !r.IsFinalized {
+		return nil, fmt.Errorf("checkpoint is not finalized")
+	}
+
+	return &WeakSubjectivityCheckpoint{
+		ID:           r.ID,
+		Number:       r.Number,
+		TxsRoot:      r.TxsRoot,
+		StateRoot:    r.StateRoot,
+		ReceiptsRoot: r.ReceiptsRoot,
+	}, nil
+}

--- a/comm/weak_subjectivity_test.go
+++ b/comm/weak_subjectivity_test.go
@@ -1,0 +1,261 @@
+// Copyright (c) 2025 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package comm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/chain"
+	"github.com/vechain/thor/v2/genesis"
+	"github.com/vechain/thor/v2/muxdb"
+	"github.com/vechain/thor/v2/state"
+	"github.com/vechain/thor/v2/thor"
+)
+
+func TestValidateWeakSubjectivityCheckpoint(t *testing.T) {
+	blk := new(block.Builder).Build()
+	checkpoint := &WeakSubjectivityCheckpoint{
+		ID:           blk.Header().ID(),
+		Number:       blk.Header().Number(),
+		TxsRoot:      blk.Header().TxsRoot(),
+		StateRoot:    blk.Header().StateRoot(),
+		ReceiptsRoot: blk.Header().ReceiptsRoot(),
+	}
+	valid, err := ValidateWeakSubjectivityCheckpoint(blk, checkpoint)
+	assert.True(t, valid)
+	assert.NoError(t, err)
+}
+
+func TestFetchWeakSubjectivityCheckpoint_Success(t *testing.T) {
+	id := thor.MustParseBytes32("0x" + strings.Repeat("11", 32))
+	txsRoot := thor.MustParseBytes32("0x" + strings.Repeat("22", 32))
+	stateRoot := thor.MustParseBytes32("0x" + strings.Repeat("33", 32))
+	receiptsRoot := thor.MustParseBytes32("0x" + strings.Repeat("44", 32))
+	num := uint32(12345)
+
+	body := fmt.Sprintf(`{
+		"number": %d,
+		"id": %q,
+		"txsRoot": %q,
+		"stateRoot": %q,
+		"receiptsRoot": %q,
+		"isFinalized": true,
+		"transactions": []
+	}`, num, id.String(), txsRoot.String(), stateRoot.String(), receiptsRoot.String())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	wsc := &WeakSubjectivityChecker{client: &http.Client{}}
+	got, err := wsc.fetchWeakSubjectivityCheckpoint(context.Background(), srv.URL)
+	assert.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.Equal(t, id, got.ID)
+	assert.Equal(t, num, got.Number)
+	assert.Equal(t, txsRoot, got.TxsRoot)
+	assert.Equal(t, stateRoot, got.StateRoot)
+	assert.Equal(t, receiptsRoot, got.ReceiptsRoot)
+}
+
+func TestFetchWeakSubjectivityCheckpoint_NotFinalized(t *testing.T) {
+	id := thor.MustParseBytes32("0x" + strings.Repeat("aa", 32))
+
+	body := fmt.Sprintf(`{
+		"number": %d,
+		"id": %q,
+		"isFinalized": false
+	}`, 100, id.String())
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	wsc := &WeakSubjectivityChecker{client: &http.Client{}}
+	got, err := wsc.fetchWeakSubjectivityCheckpoint(context.Background(), srv.URL)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "checkpoint is not finalized")
+}
+
+func TestFetchWeakSubjectivityCheckpoint_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	wsc := &WeakSubjectivityChecker{client: &http.Client{}}
+	got, err := wsc.fetchWeakSubjectivityCheckpoint(context.Background(), srv.URL)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "status 500 Internal Server Error")
+}
+
+func TestFetchWeakSubjectivityCheckpoint_InvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{not-json}"))
+	}))
+	defer srv.Close()
+
+	wsc := &WeakSubjectivityChecker{client: &http.Client{}}
+	got, err := wsc.fetchWeakSubjectivityCheckpoint(context.Background(), srv.URL)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decode wsp response")
+}
+
+func TestFetchWeakSubjectivityCheckpoint_InvalidID(t *testing.T) {
+	body := `{
+		"number": 77,
+		"id": "0x1234",
+		"isFinalized": true,
+		"txsRoot": "0x` + strings.Repeat("55", 32) + `",
+		"stateRoot": "0x` + strings.Repeat("66", 32) + `",
+		"receiptsRoot": "0x` + strings.Repeat("77", 32) + `"
+	}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	wsc := &WeakSubjectivityChecker{client: &http.Client{}}
+	got, err := wsc.fetchWeakSubjectivityCheckpoint(context.Background(), srv.URL)
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "decode wsp response")
+}
+
+func TestCheckFinalizedAndCheckpoint_Positive(t *testing.T) {
+	blk := new(block.Builder).Build()
+	checkpoint := &WeakSubjectivityCheckpoint{
+		ID:           blk.Header().ID(),
+		Number:       blk.Header().Number(),
+		TxsRoot:      blk.Header().TxsRoot(),
+		StateRoot:    blk.Header().StateRoot(),
+		ReceiptsRoot: blk.Header().ReceiptsRoot(),
+	}
+	wsc := &WeakSubjectivityChecker{}
+	require.NotPanics(t, func() {
+		wsc.checkFinalizedAndCheckpoint(blk, checkpoint)
+	})
+}
+
+func TestCheckFinalizedAndCheckpoint_Negative(t *testing.T) {
+	blk := new(block.Builder).Build()
+	base := &WeakSubjectivityCheckpoint{
+		ID:           blk.Header().ID(),
+		Number:       blk.Header().Number(),
+		TxsRoot:      blk.Header().TxsRoot(),
+		StateRoot:    blk.Header().StateRoot(),
+		ReceiptsRoot: blk.Header().ReceiptsRoot(),
+	}
+	wsc := &WeakSubjectivityChecker{}
+
+	cases := []struct {
+		name   string
+		mutate func(*WeakSubjectivityCheckpoint)
+		errMsg string
+	}{
+		{
+			"ID mismatch",
+			func(cp *WeakSubjectivityCheckpoint) { cp.ID[0] ^= 0xFF },
+			"finalized block ID does not match checkpoint",
+		},
+		{
+			"Number mismatch",
+			func(cp *WeakSubjectivityCheckpoint) { cp.Number++ },
+			"finalized block number does not match checkpoint",
+		},
+		{
+			"TxsRoot mismatch",
+			func(cp *WeakSubjectivityCheckpoint) { cp.TxsRoot[0] ^= 0xFF },
+			"finalized block TxsRoot does not match checkpoint",
+		},
+		{
+			"StateRoot mismatch",
+			func(cp *WeakSubjectivityCheckpoint) { cp.StateRoot[0] ^= 0xFF },
+			"finalized block StateRoot does not match checkpoint",
+		},
+		{
+			"ReceiptsRoot mismatch",
+			func(cp *WeakSubjectivityCheckpoint) { cp.ReceiptsRoot[0] ^= 0xFF },
+			"finalized block ReceiptsRoot does not match checkpoint",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			cp := *base // copy
+			c.mutate(&cp)
+			err := wsc.checkFinalizedAndCheckpoint(blk, &cp)
+			require.Error(t, err)
+			assert.EqualError(t, err, c.errMsg)
+		})
+	}
+}
+
+func TestLatestFinalizedBlock_Positive(t *testing.T) {
+	memDB := muxdb.NewMem()
+	g := genesis.NewDevnet()
+	genesis, _, _, _ := g.Build(state.NewStater(memDB))
+
+	repo, err := chain.NewRepository(memDB, genesis)
+	require.NoError(t, err)
+
+	testParentID := genesis.Header().ID()
+	testBlk := new(block.Builder).ParentID(testParentID).Build()
+	repo.AddBlock(testBlk, nil, 0, false)
+
+	bft := &mockBFT{finalized: testBlk.Header().ID()}
+	wsc := &WeakSubjectivityChecker{repo: repo, bft: bft}
+	got, err := wsc.LatestFinalizedBlock()
+	assert.NoError(t, err)
+	assert.Equal(t, testBlk.Header().ID(), got.Header().ID())
+}
+
+func TestLatestFinalizedBlock_Negative(t *testing.T) {
+	wsc := &WeakSubjectivityChecker{}
+	got, err := wsc.LatestFinalizedBlock()
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bft engine is not set")
+
+	memDB := muxdb.NewMem()
+	g := genesis.NewDevnet()
+	genesis, _, _, _ := g.Build(state.NewStater(memDB))
+
+	repo, err := chain.NewRepository(memDB, genesis)
+	require.NoError(t, err)
+	bft := &mockBFT{finalized: thor.MustParseBytes32("0x" + strings.Repeat("22", 32))}
+	wsc = &WeakSubjectivityChecker{repo: repo, bft: bft}
+	got, err = wsc.LatestFinalizedBlock()
+	assert.Nil(t, got)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get finalized block")
+}
+
+type mockBFT struct {
+	finalized thor.Bytes32
+}
+
+func (m *mockBFT) Finalized() thor.Bytes32          { return m.finalized }
+func (m *mockBFT) Justified() (thor.Bytes32, error) { return thor.Bytes32{}, nil }


### PR DESCRIPTION
# Description

Introducing the first implementation of the weak subjectivity logic when a node is booted up. 

## **Weak Subjectivity Check (WSC) Flow**

### 1. **User Specifies the WSC URL**
- The user starts the Thor node with the CLI flag:
  ```
  --wsc-provider-url <URL>
  ```
- This URL points to a trusted Weak Subjectivity Checkpoint provider (e.g., a REST endpoint).

---

### 2. **Node Startup and Dependency Wiring**
- The CLI parses the flag and passes the URL to the main application.
- The main function creates a `WeakSubjectivityChecker` instance, wiring it with:
  - The chain repository
  - The BFT engine (for finalized block info)
  - The WSC provider URL

---

### 3. **Communicator Initialization**
- The `Communicator` is constructed with the `WeakSubjectivityChecker` as a dependency.
- The communicator is responsible for node synchronization and peer communication.

---

### 4. **Node Synchronization Begins**
- The node starts syncing blocks as usual.
- When the node believes it is "synced" (i.e., caught up with the network), the communicator triggers the WSC.

---

### 5. **Performing the Weak Subjectivity Check**
- The communicator calls `wspChecker.PerformCheck(ctx)`:
  1. **Fetch Checkpoint:**
     - The checker fetches the latest finalized checkpoint from the WSC provider URL (with retries and backoff).
     - The checkpoint includes block ID, number, txs root, state root, receipts root.
  2. **Get Local Finalized Block:**
     - The checker queries the BFT engine for the node’s latest finalized block.
  3. **Compare Checkpoint and Last Local Finalized Block:**
     - The checker compares all fields (ID, number, roots) of the local finalized block with the checkpoint.

---

### 6. **Decision: Canonical or Malicious Chain?**
- **If all fields match:**
  - The node is considered to be on the canonical chain.
  - Sync proceeds as normal.
- **If any field does not match:**
  - The node is on a fork or a malicious chain.
  - The communicator panics and stops the node with an error:
    ```
    weak subjectivity check failed: <reason>
    ```
  - This prevents the node from operating on a potentially malicious fork.

---

## **Summary Table**

| Step | Action | Component |
|------|--------|-----------|
| 1 | User sets `--wsc-provider-url` | CLI |
| 2 | Main wires up checker | Main/CLI |
| 3 | Communicator gets checker | Communicator |
| 4 | Node syncs | Node/Communicator |
| 5 | WSC fetches checkpoint, gets local finalized block, compares | WeakSubjectivityChecker |
| 6 | If match: continue; if not: panic | Communicator/WSC |

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
