### PR TITLE
chore: small optimization when encoding hex to string

### DIFF
--- a/tracers/logger/logger.go
+++ b/tracers/logger/logger.go
@@ -475,14 +475,14 @@ func formatLogs(logs []StructLog) []StructLogRes {
 		if trace.Memory != nil {
 			memory := make([]string, 0, (len(trace.Memory)+31)/32)
 			for i := 0; i+32 <= len(trace.Memory); i += 32 {
-				memory = append(memory, fmt.Sprintf("%x", trace.Memory[i:i+32]))
+				memory = append(memory, hex.EncodeToString(trace.Memory[i:i+32]))
 			}
 			formatted[index].Memory = &memory
 		}
 		if trace.Storage != nil {
 			storage := make(map[string]string)
 			for i, storageValue := range trace.Storage {
-				storage[fmt.Sprintf("%x", i)] = fmt.Sprintf("%x", storageValue)
+				storage[hex.EncodeToString(i[:])] = hex.EncodeToString(storageValue[:])
 			}
 			formatted[index].Storage = &storage
 		}

--- a/tracers/logger/logger_test.go
+++ b/tracers/logger/logger_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/holiman/uint256"
@@ -126,14 +127,107 @@ func TestStructLogMarshalingOmitEmpty(t *testing.T) {
 	}
 }
 
-func TestFormatLogs(t *testing.T) {
+func TestFormatLogs(t *testing.T) {d
+	testMemory := []byte("test data for memory that is long enough to be processed as 32-byte chunks")
+	testStack := []uint256.Int{*uint256.NewInt(42), *uint256.NewInt(123)}
+	testStorage := map[common.Hash]common.Hash{
+		common.BytesToHash([]byte("key1")): common.BytesToHash([]byte("val1")),
+		common.BytesToHash([]byte("key2")): common.BytesToHash([]byte("val2")),
+	}
+	testReturnData := []byte("return data")
+
 	logs := []StructLog{
-		{Pc: 1, Op: vm.PUSH1, Gas: 100, GasCost: 2, Depth: 1, Memory: []byte("test"), Stack: []uint256.Int{*uint256.NewInt(1)}},
+		{
+			Pc:         1,
+			Op:         vm.PUSH1,
+			Gas:        100,
+			GasCost:    2,
+			Depth:      1,
+			Memory:     testMemory,
+			Stack:      testStack,
+			Storage:    testStorage,
+			ReturnData: testReturnData,
+		},
 	}
 
 	formattedLogs := formatLogs(logs)
+
+	// Test length
 	if len(formattedLogs) != len(logs) {
 		t.Errorf("Expected %d formatted logs, got %d", len(logs), len(formattedLogs))
+		return
+	}
+
+	formatted := formattedLogs[0]
+
+	// Test basic fields
+	if formatted.Pc != 1 {
+		t.Errorf("Expected Pc=1, got %d", formatted.Pc)
+	}
+	if formatted.Op != "PUSH1" {
+		t.Errorf("Expected Op='PUSH1', got '%s'", formatted.Op)
+	}
+	if formatted.Gas != 100 {
+		t.Errorf("Expected Gas=100, got %d", formatted.Gas)
+	}
+	if formatted.GasCost != 2 {
+		t.Errorf("Expected GasCost=2, got %d", formatted.GasCost)
+	}
+	if formatted.Depth != 1 {
+		t.Errorf("Expected Depth=1, got %d", formatted.Depth)
+	}
+
+	// Test memory formatting
+	if formatted.Memory == nil {
+		t.Error("Expected Memory to be formatted, got nil")
+	} else {
+		// Memory is processed in 32-byte chunks, so we expect at least 2 chunks for our test data
+		if len(*formatted.Memory) < 2 {
+			t.Errorf("Expected at least 2 memory chunks, got %d", len(*formatted.Memory))
+		}
+		// Test first memory chunk (should be hex encoded)
+		if len(*formatted.Memory) > 0 {
+			firstChunk := (*formatted.Memory)[0]
+			if len(firstChunk) != 64 { // 32 bytes = 64 hex chars
+				t.Errorf("Expected memory chunk to be 64 hex chars, got %d", len(firstChunk))
+			}
+		}
+	}
+
+	// Test stack formatting
+	if formatted.Stack == nil {
+		t.Error("Expected Stack to be formatted, got nil")
+	} else {
+		if len(*formatted.Stack) != len(testStack) {
+			t.Errorf("Expected %d stack items, got %d", len(testStack), len(*formatted.Stack))
+		}
+		// Test first stack item (should be hex encoded)
+		if len(*formatted.Stack) > 0 {
+			firstStack := (*formatted.Stack)[0]
+			if firstStack != "0x2a" { // 42 in hex
+				t.Errorf("Expected first stack item to be '0x2a', got '%s'", firstStack)
+			}
+		}
+	}
+
+	// Test storage formatting
+	if formatted.Storage == nil {
+		t.Error("Expected Storage to be formatted, got nil")
+	} else {
+		if len(*formatted.Storage) != len(testStorage) {
+			t.Errorf("Expected %d storage items, got %d", len(testStorage), len(*formatted.Storage))
+		}
+		// Test storage key-value formatting
+		for key, value := range *formatted.Storage {
+			if len(key) != 64 || len(value) != 64 { // 32 bytes = 64 hex chars
+				t.Errorf("Expected storage key/value to be 64 hex chars, got key=%d, value=%d", len(key), len(value))
+			}
+		}
+	}
+
+	// Test return data formatting
+	if formatted.ReturnData != hexutil.Bytes(testReturnData).String() {
+		t.Errorf("Expected ReturnData to be hex encoded, got '%s'", formatted.ReturnData)
 	}
 }
 

--- a/tracers/logger/logger_test.go
+++ b/tracers/logger/logger_test.go
@@ -194,9 +194,7 @@ func TestFormatLogs(t *testing.T) {
 		// Verify first memory chunk
 		if len(*formatted.Memory) > 0 {
 			firstChunk := (*formatted.Memory)[0]
-			if len(firstChunk) != 64 {
-				t.Errorf("Expected first memory chunk to be 64 hex chars, got %d", len(firstChunk))
-			} else if firstChunk != expectedFirstChunk {
+			if firstChunk != expectedFirstChunk {
 				t.Errorf("Expected first memory chunk to be '%s', got '%s'", expectedFirstChunk, firstChunk)
 			}
 		}
@@ -204,9 +202,7 @@ func TestFormatLogs(t *testing.T) {
 		// Verify second memory chunk
 		if len(*formatted.Memory) > 1 {
 			secondChunk := (*formatted.Memory)[1]
-			if len(secondChunk) != 64 {
-				t.Errorf("Expected second memory chunk to be 64 hex chars, got %d", len(secondChunk))
-			} else if secondChunk != expectedSecondChunk {
+			if secondChunk != expectedSecondChunk {
 				t.Errorf("Expected second memory chunk to be '%s', got '%s'", expectedSecondChunk, secondChunk)
 			}
 		}
@@ -263,15 +259,6 @@ func TestFormatLogs(t *testing.T) {
 			t.Errorf("Expected storage value for key '%s' to be '%s', got '%s'", expectedKey2, expectedValue2, value2)
 		}
 
-		// Test that all keys and values are 64 hex characters (32 bytes)
-		for key, value := range *formatted.Storage {
-			if len(key) != 64 {
-				t.Errorf("Expected storage key to be 64 hex chars, got %d: '%s'", len(key), key)
-			}
-			if len(value) != 64 {
-				t.Errorf("Expected storage value to be 64 hex chars, got %d: '%s'", len(value), value)
-			}
-		}
 	}
 
 	// Test return data formatting

--- a/tracers/logger/logger_test.go
+++ b/tracers/logger/logger_test.go
@@ -186,11 +186,35 @@ func TestFormatLogs(t *testing.T) {
 		if len(*formatted.Memory) < 2 {
 			t.Errorf("Expected at least 2 memory chunks, got %d", len(*formatted.Memory))
 		}
-		// Test first memory chunk (should be hex encoded)
+
+		// Test specific memory chunks with exact values
+		expectedFirstChunk := hex.EncodeToString(testMemory[0:32])
+		expectedSecondChunk := hex.EncodeToString(testMemory[32:64])
+
+		// Verify first memory chunk
 		if len(*formatted.Memory) > 0 {
 			firstChunk := (*formatted.Memory)[0]
-			if len(firstChunk) != 64 { // 32 bytes = 64 hex chars
-				t.Errorf("Expected memory chunk to be 64 hex chars, got %d", len(firstChunk))
+			if len(firstChunk) != 64 {
+				t.Errorf("Expected first memory chunk to be 64 hex chars, got %d", len(firstChunk))
+			} else if firstChunk != expectedFirstChunk {
+				t.Errorf("Expected first memory chunk to be '%s', got '%s'", expectedFirstChunk, firstChunk)
+			}
+		}
+
+		// Verify second memory chunk
+		if len(*formatted.Memory) > 1 {
+			secondChunk := (*formatted.Memory)[1]
+			if len(secondChunk) != 64 {
+				t.Errorf("Expected second memory chunk to be 64 hex chars, got %d", len(secondChunk))
+			} else if secondChunk != expectedSecondChunk {
+				t.Errorf("Expected second memory chunk to be '%s', got '%s'", expectedSecondChunk, secondChunk)
+			}
+		}
+
+		// Test that all memory chunks are 64 hex characters (32 bytes)
+		for i, chunk := range *formatted.Memory {
+			if len(chunk) != 64 {
+				t.Errorf("Expected memory chunk %d to be 64 hex chars, got %d: '%s'", i, len(chunk), chunk)
 			}
 		}
 	}

--- a/tracers/logger/logger_test.go
+++ b/tracers/logger/logger_test.go
@@ -258,7 +258,6 @@ func TestFormatLogs(t *testing.T) {
 		} else if value2 != expectedValue2 {
 			t.Errorf("Expected storage value for key '%s' to be '%s', got '%s'", expectedKey2, expectedValue2, value2)
 		}
-
 	}
 
 	// Test return data formatting

--- a/tracers/logger/logger_test.go
+++ b/tracers/logger/logger_test.go
@@ -18,6 +18,7 @@ package logger
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -217,10 +218,34 @@ func TestFormatLogs(t *testing.T) {
 		if len(*formatted.Storage) != len(testStorage) {
 			t.Errorf("Expected %d storage items, got %d", len(testStorage), len(*formatted.Storage))
 		}
-		// Test storage key-value formatting
+
+		// Test specific storage key-value pairs
+		expectedKey1 := hex.EncodeToString(common.BytesToHash([]byte("key1")).Bytes())
+		expectedValue1 := hex.EncodeToString(common.BytesToHash([]byte("val1")).Bytes())
+		expectedKey2 := hex.EncodeToString(common.BytesToHash([]byte("key2")).Bytes())
+		expectedValue2 := hex.EncodeToString(common.BytesToHash([]byte("val2")).Bytes())
+
+		// Verify first key-value pair
+		if value1, exists := (*formatted.Storage)[expectedKey1]; !exists {
+			t.Errorf("Expected storage key '%s' not found", expectedKey1)
+		} else if value1 != expectedValue1 {
+			t.Errorf("Expected storage value for key '%s' to be '%s', got '%s'", expectedKey1, expectedValue1, value1)
+		}
+
+		// Verify second key-value pair
+		if value2, exists := (*formatted.Storage)[expectedKey2]; !exists {
+			t.Errorf("Expected storage key '%s' not found", expectedKey2)
+		} else if value2 != expectedValue2 {
+			t.Errorf("Expected storage value for key '%s' to be '%s', got '%s'", expectedKey2, expectedValue2, value2)
+		}
+
+		// Test that all keys and values are 64 hex characters (32 bytes)
 		for key, value := range *formatted.Storage {
-			if len(key) != 64 || len(value) != 64 { // 32 bytes = 64 hex chars
-				t.Errorf("Expected storage key/value to be 64 hex chars, got key=%d, value=%d", len(key), len(value))
+			if len(key) != 64 {
+				t.Errorf("Expected storage key to be 64 hex chars, got %d: '%s'", len(key), key)
+			}
+			if len(value) != 64 {
+				t.Errorf("Expected storage value to be 64 hex chars, got %d: '%s'", len(value), value)
 			}
 		}
 	}

--- a/tracers/logger/logger_test.go
+++ b/tracers/logger/logger_test.go
@@ -127,7 +127,7 @@ func TestStructLogMarshalingOmitEmpty(t *testing.T) {
 	}
 }
 
-func TestFormatLogs(t *testing.T) {d
+func TestFormatLogs(t *testing.T) {
 	testMemory := []byte("test data for memory that is long enough to be processed as 32-byte chunks")
 	testStack := []uint256.Int{*uint256.NewInt(42), *uint256.NewInt(123)}
 	testStorage := map[common.Hash]common.Hash{


### PR DESCRIPTION
# Description

Using `hex.EncodeToString` instead
