### PR TITLE
Use PackerEngine and ConsensusEngine interfaces in the node

### DIFF
--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -26,11 +26,13 @@ import (
 	"github.com/vechain/thor/v2/cmd/thor/node"
 	"github.com/vechain/thor/v2/cmd/thor/pruner"
 	"github.com/vechain/thor/v2/cmd/thor/solo"
+	"github.com/vechain/thor/v2/consensus"
 	"github.com/vechain/thor/v2/genesis"
 	"github.com/vechain/thor/v2/log"
 	"github.com/vechain/thor/v2/logdb"
 	"github.com/vechain/thor/v2/metrics"
 	"github.com/vechain/thor/v2/muxdb"
+	"github.com/vechain/thor/v2/packer"
 	"github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/txpool"
@@ -306,18 +308,20 @@ func defaultAction(ctx *cli.Context) error {
 		MinTxPriorityFee: minTxPriorityFee,
 		TargetGasLimit:   ctx.Uint64(targetGasLimitFlag.Name),
 	}
+	stater := state.NewStater(mainDB)
 
 	return node.New(
 		master,
 		repo,
 		bftEngine,
-		state.NewStater(mainDB),
 		logDB,
 		txPool,
 		filepath.Join(instanceDir, "tx.stash"),
 		p2pCommunicator.Communicator(),
 		forkConfig,
 		options,
+		consensus.New(repo, stater, forkConfig),
+		packer.New(repo, stater, master.Address(), master.Beneficiary, forkConfig, options.MinTxPriorityFee),
 	).Run(exitSignal)
 }
 


### PR DESCRIPTION
# Description

Small tweak for the node to use `PackerEngine` and `ConsensusEngine` interfaces in the node instead of structs.

Fixes # [(issue)](https://github.com/vechain/otherviews-workboard/issues/204)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
