### PR TITLE
Paolo/sanity check/814 bis

### DIFF
--- a/builtin/solidity/context.go
+++ b/builtin/solidity/context.go
@@ -34,3 +34,7 @@ func (c *Context) UseGas(gas uint64) {
 		c.charger.Charge(gas)
 	}
 }
+
+func (c *Context) Address() thor.Address {
+	return c.address
+}

--- a/builtin/solidity/mapping.go
+++ b/builtin/solidity/mapping.go
@@ -153,3 +153,7 @@ func (m *Mapping[K, V]) set(key K, value V) (uint64, error) {
 
 	return size, nil
 }
+
+func (m *Mapping[K, V]) Context() *Context {
+	return m.context
+}

--- a/builtin/staker/aggregation/aggregation.go
+++ b/builtin/staker/aggregation/aggregation.go
@@ -59,17 +59,18 @@ func (a *Aggregation) renew() (*globalstats.Renewal, error) {
 	queuedDecrease := a.Pending.VET
 
 	// Move Pending => Locked
-	a.Locked.Add(a.Pending)
+	err := a.Locked.Add(a.Pending)
+	if err != nil {
+		return nil, err
+	}
 	a.Pending = &stakes.WeightedStake{}
 
 	// Remove ExitingVET from LockedVET
-	err := a.Locked.Sub(a.Exiting)
+	err = a.Locked.Sub(a.Exiting)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: No WithdrawableVET?
-	// Move ExitingVET to WithdrawableVET
 	a.Exiting = &stakes.WeightedStake{}
 
 	return &globalstats.Renewal{

--- a/builtin/staker/aggregation/service.go
+++ b/builtin/staker/aggregation/service.go
@@ -49,7 +49,10 @@ func (s *Service) AddPendingVET(validator thor.Address, stake *stakes.WeightedSt
 		return err
 	}
 
-	agg.Pending.Add(stake)
+	if err = agg.Pending.Add(stake); err != nil {
+		return err
+	}
+
 	return s.aggregationStorage.Upsert(validator, agg)
 }
 
@@ -117,7 +120,9 @@ func (s *Service) SignalExit(validator thor.Address, stake *stakes.WeightedStake
 
 	// Only move to exiting pools - don't subtract from locked yet
 	// The subtraction happens during renewal
-	agg.Exiting.Add(stake)
+	if err = agg.Exiting.Add(stake); err != nil {
+		return err
+	}
 
 	// storage slot is already touched
 	return s.aggregationStorage.Update(validator, agg)

--- a/builtin/staker/delegations_test.go
+++ b/builtin/staker/delegations_test.go
@@ -23,7 +23,7 @@ type testValidators struct {
 	*validation.Validation
 }
 
-func newDelegationStaker(t *testing.T) (*Staker, []*testValidators) {
+func newDelegationStaker(t *testing.T) (*testStaker, []*testValidators) {
 	staker, _ := newStaker(t, 75, 101, true)
 	validations := make([]*testValidators, 0)
 	err := staker.validationService.LeaderGroupIterator(func(validatorID thor.Address, validation *validation.Validation) error {

--- a/builtin/staker/globalstats/delta.go
+++ b/builtin/staker/globalstats/delta.go
@@ -5,7 +5,12 @@
 
 package globalstats
 
-import "github.com/vechain/thor/v2/builtin/staker/stakes"
+import (
+	"errors"
+
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/vechain/thor/v2/builtin/staker/stakes"
+)
 
 type Renewal struct {
 	LockedIncrease *stakes.WeightedStake
@@ -22,29 +27,27 @@ func NewRenewal() *Renewal {
 }
 
 // Add sets r to the sum of itself and other.
-func (r *Renewal) Add(other *Renewal) *Renewal {
+func (r *Renewal) Add(other *Renewal) (*Renewal, error) {
 	if other == nil {
-		return r
+		return r, nil
 	}
 
-	r.LockedIncrease.Add(other.LockedIncrease)
-	r.LockedDecrease.Add(other.LockedDecrease)
-	r.QueuedDecrease += other.QueuedDecrease
-	return r
+	if err := r.LockedIncrease.Add(other.LockedIncrease); err != nil {
+		return nil, err
+	}
+	if err := r.LockedDecrease.Add(other.LockedDecrease); err != nil {
+		return nil, err
+	}
+
+	var overflow bool
+	if r.QueuedDecrease, overflow = math.SafeAdd(r.QueuedDecrease, other.QueuedDecrease); overflow {
+		return nil, errors.New("queued decrease overflow occurred")
+	}
+
+	return r, nil
 }
 
 type Exit struct {
 	ExitedTVL      *stakes.WeightedStake
 	QueuedDecrease uint64 // stake/VET only
-}
-
-// Add sets e to the sum of itself and other.
-func (e *Exit) Add(other *Exit) *Exit {
-	if other == nil {
-		return e
-	}
-
-	e.ExitedTVL.Add(other.ExitedTVL)
-	e.QueuedDecrease += other.QueuedDecrease
-	return e
 }

--- a/builtin/staker/globalstats/delta.go
+++ b/builtin/staker/globalstats/delta.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common/math"
+
 	"github.com/vechain/thor/v2/builtin/staker/stakes"
 )
 

--- a/builtin/staker/globalstats/delta_test.go
+++ b/builtin/staker/globalstats/delta_test.go
@@ -32,7 +32,8 @@ func TestRenewal_Add(t *testing.T) {
 		QueuedDecrease: 1,
 	}
 
-	got := base.Add(inc)
+	got, err := base.Add(inc)
+	assert.NoError(t, err)
 	assert.Same(t, base, got)
 	assert.Equal(t, uint64(11), got.LockedIncrease.VET)
 	assert.Equal(t, uint64(22), got.LockedIncrease.Weight)
@@ -46,39 +47,11 @@ func TestRenewal_Add_Nil(t *testing.T) {
 		LockedIncrease: stakes.NewWeightedStake(5, 6),
 		LockedDecrease: stakes.NewWeightedStake(7, 8),
 	}
-	got := base.Add(nil)
+	got, err := base.Add(nil)
+	assert.NoError(t, err)
 	assert.Same(t, base, got)
 	assert.Equal(t, uint64(5), got.LockedIncrease.VET)
 	assert.Equal(t, uint64(6), got.LockedIncrease.Weight)
 	assert.Equal(t, uint64(7), got.LockedDecrease.VET)
 	assert.Equal(t, uint64(8), got.LockedDecrease.Weight)
-}
-
-func TestExit_Add(t *testing.T) {
-	base := &Exit{
-		ExitedTVL:      stakes.NewWeightedStake(100, 200),
-		QueuedDecrease: 300,
-	}
-	inc := &Exit{
-		ExitedTVL:      stakes.NewWeightedStake(1, 2),
-		QueuedDecrease: 3,
-	}
-
-	got := base.Add(inc)
-	assert.Same(t, base, got)
-	assert.Equal(t, uint64(101), got.ExitedTVL.VET)
-	assert.Equal(t, uint64(202), got.ExitedTVL.Weight)
-	assert.Equal(t, uint64(303), got.QueuedDecrease)
-}
-
-func TestExit_Add_Nil(t *testing.T) {
-	base := &Exit{
-		ExitedTVL:      stakes.NewWeightedStake(10, 20),
-		QueuedDecrease: 30,
-	}
-	got := base.Add(nil)
-	assert.Same(t, base, got)
-	assert.Equal(t, uint64(10), got.ExitedTVL.VET)
-	assert.Equal(t, uint64(20), got.ExitedTVL.Weight)
-	assert.Equal(t, uint64(30), got.QueuedDecrease)
 }

--- a/builtin/staker/globalstats/service.go
+++ b/builtin/staker/globalstats/service.go
@@ -85,7 +85,7 @@ func (s *Service) ApplyRenewal(renewal *Renewal) error {
 }
 
 func (s *Service) ApplyExit(validation *Exit, aggregation *Exit) error {
-	totalExited := stakes.NewWeightedStake(validation.ExitedTVL.VET, validation.ExitedTVL.Weight)
+	totalExited := validation.ExitedTVL.Clone()
 	if err := totalExited.Add(aggregation.ExitedTVL); err != nil {
 		return err
 	}

--- a/builtin/staker/globalstats/service.go
+++ b/builtin/staker/globalstats/service.go
@@ -58,26 +58,25 @@ func (s *Service) ApplyRenewal(renewal *Renewal) error {
 	if err != nil {
 		return err
 	}
-	queued, err := s.queued.Get()
-	if err != nil {
+
+	if err := locked.Add(renewal.LockedIncrease); err != nil {
 		return err
 	}
 
-	locked.Add(renewal.LockedIncrease)
 	if err := locked.Sub(renewal.LockedDecrease); err != nil {
 		return err
 	}
-	queued -= renewal.QueuedDecrease
 
 	// for the initial state, use upsert to handle correct gas cost
 	if err := s.locked.Upsert(locked); err != nil {
 		return err
 	}
 
-	// queued here is already touched by addQueued
-	if err := s.queued.Update(queued); err != nil {
+	if err := s.RemoveQueued(renewal.QueuedDecrease); err != nil {
 		return err
 	}
+
+	// move locked decrease to withdrawable, includes validation's pending unlock and delegation's exiting
 	if err := s.AddWithdrawable(renewal.LockedDecrease.VET); err != nil {
 		return err
 	}
@@ -85,39 +84,50 @@ func (s *Service) ApplyRenewal(renewal *Renewal) error {
 	return nil
 }
 
-func (s *Service) ApplyExit(valExitedTVL uint64, exit *Exit) error {
-	locked, err := s.getLocked()
-	if err != nil {
+func (s *Service) ApplyExit(validation *Exit, aggregation *Exit) error {
+	totalExited := stakes.NewWeightedStake(validation.ExitedTVL.VET, validation.ExitedTVL.Weight)
+	if err := totalExited.Add(aggregation.ExitedTVL); err != nil {
 		return err
 	}
 
-	queued, err := s.queued.Get()
-	if err != nil {
+	if err := s.RemoveLocked(totalExited); err != nil {
 		return err
 	}
 
-	if err := locked.Sub(exit.ExitedTVL); err != nil {
-		return err
-	}
-	queued -= exit.QueuedDecrease
-
-	if err := s.locked.Update(locked); err != nil {
+	if err := s.RemoveQueued(validation.QueuedDecrease + aggregation.QueuedDecrease); err != nil {
 		return err
 	}
 
-	if err := s.queued.Update(queued); err != nil {
-		return err
+	// move validation's exiting to cooldown
+	if validation.ExitedTVL.VET > 0 {
+		if err := s.AddCooldown(validation.ExitedTVL.VET); err != nil {
+			return err
+		}
 	}
-	if err := s.AddCooldown(valExitedTVL); err != nil {
-		return err
-	}
-	if exit.ExitedTVL.VET > valExitedTVL {
-		if err := s.AddWithdrawable(exit.ExitedTVL.VET - valExitedTVL); err != nil {
+
+	// move aggregation's exiting to withdrawable
+	if aggregation.ExitedTVL.VET > 0 {
+		if err := s.AddWithdrawable(aggregation.ExitedTVL.VET); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// RemovedLocked decreases locked totals when stake is removed from the locked.
+func (s *Service) RemoveLocked(weightedStake *stakes.WeightedStake) error {
+	locked, err := s.getLocked()
+	if err != nil {
+		return err
+	}
+
+	if err := locked.Sub(weightedStake); err != nil {
+		return err
+	}
+
+	// locked here is already touched by addLocked
+	return s.locked.Update(locked)
 }
 
 // AddQueued increases queued totals when new stake is added to the queue.

--- a/builtin/staker/globalstats/service_test.go
+++ b/builtin/staker/globalstats/service_test.go
@@ -85,16 +85,17 @@ func TestService_ApplyExit(t *testing.T) {
 
 	assert.NoError(t, svc.AddQueued(300)) // weight 600
 
-	exit := &Exit{
-		ExitedTVL:      stakes.NewWeightedStake(400, 800),
-		QueuedDecrease: 300,
-	}
-
 	valExit := &Exit{
 		ExitedTVL:      stakes.NewWeightedStake(200, 400),
 		QueuedDecrease: 0,
 	}
-	assert.NoError(t, svc.ApplyExit(valExit.ExitedTVL.VET, exit))
+
+	aggExit := &Exit{
+		ExitedTVL:      stakes.NewWeightedStake(200, 400),
+		QueuedDecrease: 300,
+	}
+
+	assert.NoError(t, svc.ApplyExit(valExit, aggExit))
 
 	lockedV, lockedW, err := svc.GetLockedStake()
 	assert.NoError(t, err)

--- a/builtin/staker/housekeep.go
+++ b/builtin/staker/housekeep.go
@@ -172,7 +172,7 @@ func (s *Staker) applyEpochTransition(transition *EpochTransition) error {
 		logger.Info("exiting validator", "validator", transition.ExitValidator)
 
 		// Now call ExitValidator to get the actual exit details and perform the exit
-		exit, err := s.validationService.ExitValidator(transition.ExitValidator)
+		valExit, err := s.validationService.ExitValidator(transition.ExitValidator)
 		if err != nil {
 			return err
 		}
@@ -182,8 +182,7 @@ func (s *Staker) applyEpochTransition(transition *EpochTransition) error {
 			return err
 		}
 
-		valExitedTVL := exit.ExitedTVL.VET
-		if err := s.globalStatsService.ApplyExit(valExitedTVL, exit.Add(aggExit)); err != nil {
+		if err := s.globalStatsService.ApplyExit(valExit, aggExit); err != nil {
 			return err
 		}
 	}
@@ -236,8 +235,13 @@ func (s *Staker) activateNextValidation(currentBlk uint32, maxLeaderGroupSize ui
 		return thor.Address{}, err
 	}
 
+	globalRenewal, err := validatorRenewal.Add(aggRenew)
+	if err != nil {
+		return thor.Address{}, err
+	}
+
 	// Update global stats with both validator and delegation renewals
-	if err = s.globalStatsService.ApplyRenewal(validatorRenewal.Add(aggRenew)); err != nil {
+	if err = s.globalStatsService.ApplyRenewal(globalRenewal); err != nil {
 		return thor.Address{}, err
 	}
 

--- a/builtin/staker/housekeep.go
+++ b/builtin/staker/housekeep.go
@@ -283,7 +283,15 @@ func (s *Staker) PerformSanityCheck() error {
 	}
 	total := lockedStake + queuedStake + withdrawableStake + cooldownStake
 	if balance.Uint64() != total {
-		return fmt.Errorf("sanity check failed: locked(%d) + queued(%d) + withdrawable(%d) = %d, but account balance is %d", lockedStake, queuedStake, withdrawableStake, total, balance.Uint64())
+		return fmt.Errorf(
+			"sanity check failed: locked(%d) + queued(%d) + withdrawable(%d) = %d, but account balance is %d, diff= %d",
+			lockedStake,
+			queuedStake,
+			withdrawableStake,
+			total,
+			balance.Uint64(),
+			balance.Uint64()-total,
+		)
 	}
 	return nil
 }

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -407,7 +407,7 @@ func (s *Staker) WithdrawStake(validator thor.Address, endorser thor.Address, cu
 		return 0, NewReverts("endorser required")
 	}
 
-	stake, queued, cooldown, err := s.validationService.WithdrawStake(validator, val, currentBlock)
+	withdrawable, queued, cooldown, err := s.validationService.WithdrawStake(validator, val, currentBlock)
 	if err != nil {
 		logger.Info("withdraw failed", "validator", validator, "error", err)
 		return 0, err
@@ -415,21 +415,19 @@ func (s *Staker) WithdrawStake(validator thor.Address, endorser thor.Address, cu
 
 	// remove validator QueuedVET if the validator is still queued or had a pending increase
 	if queued > 0 {
-		err = s.globalStatsService.RemoveQueued(queued)
-		if err != nil {
+		if err = s.globalStatsService.RemoveQueued(queued); err != nil {
 			return 0, err
 		}
 	}
 
 	if cooldown > 0 {
-		err = s.globalStatsService.RemoveCooldown(cooldown)
-		if err != nil {
+		if err = s.globalStatsService.RemoveCooldown(cooldown); err != nil {
 			return 0, err
 		}
 	}
 
 	logger.Info("withdrew validator staker", "validator", validator)
-	return stake, nil
+	return withdrawable, nil
 }
 
 func (s *Staker) SetOnline(validator thor.Address, blockNum uint32, online bool) error {

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -107,6 +107,18 @@ func (ts *TestSequence) AddValidation(
 	return ts
 }
 
+func (ts *TestSequence) UpdateContractBalance(amount uint64) *TestSequence {
+	addr := ts.staker.validationService.ContractAddress()
+	current, err := ts.staker.state.GetBalance(addr)
+	assert.NoError(ts.t, err, "failed to get contract balance")
+	if current == nil {
+		current = big.NewInt(0)
+	}
+	newBalance := new(big.Int).Add(current, big.NewInt(int64(amount)))
+	ts.staker.state.SetBalance(addr, newBalance)
+	return ts
+}
+
 func (ts *TestSequence) SignalExit(validator, endorser thor.Address, currentBlock uint32) *TestSequence {
 	err := ts.staker.SignalExit(validator, endorser, currentBlock)
 	assert.NoError(ts.t, err, "failed to signal exit for validator %s with endorser %s", validator.String(), endorser.String())

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -25,11 +25,11 @@ import (
 )
 
 type TestSequence struct {
-	staker *Staker
+	staker *testStaker
 	t      *testing.T
 }
 
-func newTestSequence(t *testing.T, staker *Staker) *TestSequence {
+func newTestSequence(t *testing.T, staker *testStaker) *TestSequence {
 	return &TestSequence{staker: staker, t: t}
 }
 
@@ -314,13 +314,13 @@ func (ts *TestSequence) IncreaseDelegatorsReward(node thor.Address, reward *big.
 }
 
 type ValidationAssertions struct {
-	staker    *Staker
+	staker    *testStaker
 	addr      thor.Address
 	validator *validation.Validation
 	t         *testing.T
 }
 
-func assertValidation(t *testing.T, staker *Staker, addr thor.Address) *ValidationAssertions {
+func assertValidation(t *testing.T, staker *testStaker, addr thor.Address) *ValidationAssertions {
 	validator, err := staker.GetValidation(addr)
 	require.NoError(t, err, "failed to get validator %s", addr.String())
 	return &ValidationAssertions{staker: staker, addr: addr, validator: validator, t: t}
@@ -393,7 +393,7 @@ type AggregationAssertions struct {
 	t            *testing.T
 }
 
-func assertAggregation(t *testing.T, staker *Staker, validationID thor.Address) *AggregationAssertions {
+func assertAggregation(t *testing.T, staker *testStaker, validationID thor.Address) *AggregationAssertions {
 	agg, err := staker.aggregationService.GetAggregation(validationID)
 	require.NoError(t, err, "failed to get aggregation for validator %s", validationID.String())
 	return &AggregationAssertions{validationID: validationID, aggregation: agg, t: t}
@@ -437,7 +437,7 @@ type DelegationAssertions struct {
 	currentBlock uint32
 }
 
-func assertDelegation(t *testing.T, staker *Staker, delegationID *big.Int) *DelegationAssertions {
+func assertDelegation(t *testing.T, staker *testStaker, delegationID *big.Int) *DelegationAssertions {
 	delegation, validation, err := staker.GetDelegation(delegationID)
 	require.NoError(t, err, "failed to get delegation %s", delegationID.String())
 	return &DelegationAssertions{delegationID: delegationID, t: t, delegation: delegation, validation: validation}

--- a/builtin/staker/stakes/stakes_test.go
+++ b/builtin/staker/stakes/stakes_test.go
@@ -5,6 +5,7 @@
 package stakes
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +41,13 @@ func TestNewWeightedStakeWithMultiplier_LargeValues(t *testing.T) {
 	want := uint64(1e15 * 25 / 100)
 	assert.Equal(t, vet, ws.VET)
 	assert.Equal(t, want, ws.Weight)
+}
+
+func TestOverFlow(t *testing.T) {
+	a := NewWeightedStake(1, 1)
+	b := NewWeightedStake(math.MaxUint64, 0)
+	assert.ErrorContains(t, a.Add(b), "VET add overflow occurred")
+
+	c := NewWeightedStake(0, math.MaxUint64)
+	assert.ErrorContains(t, a.Add(c), "weight add overflow occurred")
 }

--- a/builtin/staker/transition_test.go
+++ b/builtin/staker/transition_test.go
@@ -88,13 +88,13 @@ func TestStaker_TransitionPeriodBalanceCheck(t *testing.T) {
 	tests := []struct {
 		name         string
 		currentBlock uint32
-		preTestHook  func(staker *Staker)
+		preTestHook  func(staker *testStaker)
 		ok           bool
 	}{
 		{
 			name:         "before hayabusa, validator has greater than funds",
 			currentBlock: 5,
-			preTestHook: func(staker *Staker) {
+			preTestHook: func(staker *testStaker) {
 				assert.NoError(t, staker.state.SetBalance(endorser, big.NewInt(2000)))
 			},
 			ok: true,
@@ -102,7 +102,7 @@ func TestStaker_TransitionPeriodBalanceCheck(t *testing.T) {
 		{
 			name:         "before hayabusa, validator funds are too low",
 			currentBlock: 5,
-			preTestHook: func(staker *Staker) {
+			preTestHook: func(staker *testStaker) {
 				assert.NoError(t, staker.state.SetBalance(endorser, big.NewInt(500)))
 			},
 			ok: false,
@@ -110,7 +110,7 @@ func TestStaker_TransitionPeriodBalanceCheck(t *testing.T) {
 		{
 			name:         "before hayabusa, validator has exactly enough funds",
 			currentBlock: 5,
-			preTestHook: func(staker *Staker) {
+			preTestHook: func(staker *testStaker) {
 				assert.NoError(t, staker.state.SetBalance(endorser, big.NewInt(1000)))
 			},
 			ok: true,
@@ -118,7 +118,7 @@ func TestStaker_TransitionPeriodBalanceCheck(t *testing.T) {
 		{
 			name:         "during transition period, validator has not staked, has enough funds",
 			currentBlock: 15,
-			preTestHook: func(staker *Staker) {
+			preTestHook: func(staker *testStaker) {
 				assert.NoError(t, staker.state.SetBalance(endorser, big.NewInt(2000)))
 			},
 			ok: true,
@@ -126,7 +126,7 @@ func TestStaker_TransitionPeriodBalanceCheck(t *testing.T) {
 		{
 			name:         "during transition period, validator has not staked, has insufficient funds",
 			currentBlock: 15,
-			preTestHook: func(staker *Staker) {
+			preTestHook: func(staker *testStaker) {
 				assert.NoError(t, staker.state.SetBalance(endorser, big.NewInt(500)))
 			},
 			ok: false,
@@ -134,7 +134,7 @@ func TestStaker_TransitionPeriodBalanceCheck(t *testing.T) {
 		{
 			name:         "during transition period, validator has staked",
 			currentBlock: 15,
-			preTestHook: func(staker *Staker) {
+			preTestHook: func(staker *testStaker) {
 				stake := big.NewInt(0).Div(MinStake, bigE18).Uint64()
 				assert.NoError(t, staker.AddValidation(master, endorser, thor.MediumStakingPeriod(), stake))
 			},

--- a/builtin/staker/validation/repository.go
+++ b/builtin/staker/validation/repository.go
@@ -162,6 +162,10 @@ func (r *Repository) iterateActive(callback func(thor.Address, *Validation) erro
 	return r.activeList.Iterate(callback)
 }
 
+func (r *Repository) iterateQueued(callback func(thor.Address, *Validation) error) error {
+	return r.queuedList.Iterate(callback)
+}
+
 func (r *Repository) iterateRenewalList(callbacks ...func(thor.Address, *Validation) error) error {
 	return r.renewalList.Iterate(func(address thor.Address) error {
 		entry, err := r.getValidation(address)

--- a/builtin/staker/validation/service.go
+++ b/builtin/staker/validation/service.go
@@ -84,6 +84,17 @@ func (s *Service) LeaderGroupIterator(callbacks ...func(thor.Address, *Validatio
 	})
 }
 
+func (s *Service) QueuedGroupIterator(callbacks ...func(thor.Address, *Validation) error) error {
+	return s.repo.iterateQueued(func(address thor.Address, entry *Validation) error {
+		for _, callback := range callbacks {
+			if err := callback(address, entry); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // IsActive returns true if there are active validations.
 func (s *Service) IsActive() (bool, error) {
 	activeCount, err := s.repo.activeListSize()
@@ -470,4 +481,8 @@ func makeRewardKey(validator thor.Address, stakingPeriod uint32) thor.Bytes32 {
 	binary.BigEndian.PutUint32(key[:4], stakingPeriod)
 	copy(key[4:], validator.Bytes())
 	return key
+}
+
+func (s *Service) ContractAddress() thor.Address {
+	return s.repo.storage.validations.Context().Address()
 }

--- a/builtin/staker/validation/validation.go
+++ b/builtin/staker/validation/validation.go
@@ -8,6 +8,7 @@ package validation
 import (
 	"errors"
 
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/vechain/thor/v2/builtin/staker/aggregation"
 	"github.com/vechain/thor/v2/builtin/staker/globalstats"
 	"github.com/vechain/thor/v2/builtin/staker/stakes"
@@ -126,17 +127,16 @@ func (v *Validation) CurrentIteration(currentBlock uint32) (uint32, error) {
 		return 0, nil
 	}
 
-	// Active(signaled exit) or Exit
+	// Exited, from active or queued
+	if v.Status == StatusExit {
+		return v.CompletedPeriods, nil
+	}
+
+	// Active(signaled exit)
 	// Once signaled exit, complete iterations is set to the current
 	// iteration of the time that exit is signaled
 	if v.CompletedPeriods > 0 {
 		return v.CompletedPeriods, nil
-	}
-
-	// In case of a Queued -> Exit validation
-	// no periods were completed and it's status is exited
-	if v.Status == StatusExit && v.CompletedPeriods == 0 {
-		return 0, nil
 	}
 
 	// Active
@@ -180,29 +180,30 @@ func (v *Validation) renew(delegationWeight uint64) (*globalstats.Renewal, error
 	queuedDecrease := v.QueuedVET
 
 	var prev, after struct {
-		lockedVET  uint64
 		valWeight  uint64
 		multiplier uint8
 	}
-	prev.lockedVET = v.LockedVET
 	prev.valWeight = stakes.NewWeightedStakeWithMultiplier(v.LockedVET, v.multiplier()).Weight
+
+	lockedIncrease := stakes.NewWeightedStake(0, 0)
+	lockedDecrease := stakes.NewWeightedStake(0, 0)
+
+	lockedIncrease.VET = v.QueuedVET
+	lockedDecrease.VET = v.PendingUnlockVET
+
+	v.LockedVET += v.QueuedVET
+	var underflow bool
+	v.LockedVET, underflow = math.SafeSub(v.LockedVET, v.PendingUnlockVET)
+	if underflow {
+		return nil, errors.New("pending unlock VET exceeds total locked VET")
+	}
 
 	// in renew, the multiplier is based on the actual delegation weight
 	after.multiplier = Multiplier
 	if delegationWeight > 0 {
 		after.multiplier = MultiplierWithDelegations
 	}
-
-	after.lockedVET = v.LockedVET + v.QueuedVET
-	if v.PendingUnlockVET > after.lockedVET {
-		return nil, errors.New("pending unlock VET exceeds total locked VET")
-	}
-	after.lockedVET -= v.PendingUnlockVET
-	after.valWeight = stakes.NewWeightedStakeWithMultiplier(after.lockedVET, after.multiplier).Weight
-
-	lockedIncrease := stakes.NewWeightedStake(0, 0)
-	lockedDecrease := stakes.NewWeightedStake(0, 0)
-
+	after.valWeight = stakes.NewWeightedStakeWithMultiplier(v.LockedVET, after.multiplier).Weight
 	// calculate the locked stake change based on the validator's weight
 	if prev.valWeight < after.valWeight {
 		lockedIncrease.Weight = after.valWeight - prev.valWeight
@@ -210,13 +211,6 @@ func (v *Validation) renew(delegationWeight uint64) (*globalstats.Renewal, error
 		lockedDecrease.Weight = prev.valWeight - after.valWeight
 	}
 
-	if prev.lockedVET < after.lockedVET {
-		lockedIncrease.VET = after.lockedVET - prev.lockedVET
-	} else {
-		lockedDecrease.VET = prev.lockedVET - after.lockedVET
-	}
-
-	v.LockedVET = after.lockedVET
 	v.WithdrawableVET += v.PendingUnlockVET
 	v.Weight = after.valWeight + delegationWeight
 	v.QueuedVET = 0
@@ -254,12 +248,19 @@ func (v *Validation) exit() *globalstats.Exit {
 	}
 }
 
+// CooldownEnded returns true if validator has exited and the cooldown period has ended.
+func (v *Validation) CooldownEnded(currentBlock uint32) bool {
+	if v.ExitBlock != nil && *v.ExitBlock+thor.CooldownPeriod() <= currentBlock {
+		return true
+	}
+	return false
+}
+
 // CalculateWithdrawableVET returns the validator withdrawable amount for a given block + period
 func (v *Validation) CalculateWithdrawableVET(currentBlock uint32) uint64 {
 	withdrawAmount := v.WithdrawableVET
 
-	// validator has exited and waited for the cooldown period
-	if v.ExitBlock != nil && *v.ExitBlock+thor.CooldownPeriod() <= currentBlock {
+	if v.CooldownEnded(currentBlock) {
 		withdrawAmount += v.CooldownVET
 	}
 

--- a/builtin/staker/validation/validation.go
+++ b/builtin/staker/validation/validation.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 
 	"github.com/ethereum/go-ethereum/common/math"
+
 	"github.com/vechain/thor/v2/builtin/staker/aggregation"
 	"github.com/vechain/thor/v2/builtin/staker/globalstats"
 	"github.com/vechain/thor/v2/builtin/staker/stakes"

--- a/builtin/staker/validations_test.go
+++ b/builtin/staker/validations_test.go
@@ -115,7 +115,7 @@ func TestStaker_TotalStake(t *testing.T) {
 		require.NoError(t, err)
 
 		// Update global totals
-		err = staker.globalStatsService.ApplyExit(exit.ExitedTVL.VET, exit.Add(aggExit))
+		err = staker.globalStatsService.ApplyExit(exit, aggExit)
 		require.NoError(t, err)
 
 		totalStaked -= stake
@@ -163,7 +163,7 @@ func TestStaker_TotalStake_Withdrawal(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update global totals
-	err = staker.globalStatsService.ApplyExit(exit.ExitedTVL.VET, exit.Add(aggExit))
+	err = staker.globalStatsService.ApplyExit(exit, aggExit)
 	require.NoError(t, err)
 
 	lockedVET, lockedWeight, err = staker.LockedStake()
@@ -1224,8 +1224,7 @@ func TestStaker_RemoveValidator(t *testing.T) {
 	require.NoError(t, err)
 
 	// Update global totals
-	valExitedTVL := exit.ExitedTVL.VET
-	err = staker.globalStatsService.ApplyExit(valExitedTVL, exit.Add(aggExit))
+	err = staker.globalStatsService.ApplyExit(exit, aggExit)
 	require.NoError(t, err)
 
 	validator, err := staker.GetValidation(addr)

--- a/builtin/staker/validations_test.go
+++ b/builtin/staker/validations_test.go
@@ -7,7 +7,6 @@
 package staker
 
 import (
-	"fmt"
 	"math"
 	"math/big"
 	"math/rand/v2"
@@ -62,15 +61,127 @@ func createKeys(amount int) map[thor.Address]keySet {
 	return keys
 }
 
-func newStaker(t *testing.T, amount int, maxValidators int64, initialise bool) (*Staker, uint64) {
+type testStaker struct {
+	addr  thor.Address
+	state *state.State
+	*Staker
+}
+
+func (ts *testStaker) AddValidation(
+	validator thor.Address,
+	endorser thor.Address,
+	period uint32,
+	stake uint64,
+) error {
+	balance, err := ts.state.GetBalance(ts.addr)
+	if err != nil {
+		return err
+	}
+	newBalance := big.NewInt(0).Add(balance, big.NewInt(0).SetUint64(stake))
+	if ts.state.SetBalance(ts.addr, newBalance) != nil {
+		return err
+	}
+	err = ts.Staker.AddValidation(validator, endorser, period, stake)
+	if err != nil {
+		if ts.state.SetBalance(ts.addr, balance) != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func (ts *testStaker) IncreaseStake(validator thor.Address, endorser thor.Address, amount uint64) error {
+	balance, err := ts.state.GetBalance(ts.addr)
+	if err != nil {
+		return err
+	}
+	newBalance := big.NewInt(0).Add(balance, big.NewInt(0).SetUint64(amount))
+	if ts.state.SetBalance(ts.addr, newBalance) != nil {
+		return err
+	}
+	err = ts.Staker.IncreaseStake(validator, endorser, amount)
+	if err != nil {
+		if ts.state.SetBalance(ts.addr, balance) != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func (ts *testStaker) WithdrawStake(validator thor.Address, endorser thor.Address, currentBlock uint32) (uint64, error) {
+	amount, err := ts.Staker.WithdrawStake(validator, endorser, currentBlock)
+	if err != nil {
+		return 0, err
+	}
+	balance, err := ts.state.GetBalance(ts.addr)
+	if err != nil {
+		return 0, err
+	}
+	newBalance := big.NewInt(0).Sub(balance, big.NewInt(0).SetUint64(amount))
+	if ts.state.SetBalance(ts.addr, newBalance) != nil {
+		return 0, err
+	}
+	return amount, nil
+}
+
+func (ts *testStaker) AddDelegation(
+	validator thor.Address,
+	stake uint64,
+	multiplier uint8,
+	currentBlock uint32,
+) (*big.Int, error) {
+	balance, err := ts.state.GetBalance(ts.addr)
+	if err != nil {
+		return nil, err
+	}
+	newBalance := big.NewInt(0).Add(balance, big.NewInt(0).SetUint64(stake))
+	if ts.state.SetBalance(ts.addr, newBalance) != nil {
+		return nil, err
+	}
+	delegation, err := ts.Staker.AddDelegation(validator, stake, multiplier, currentBlock)
+	if err != nil {
+		if ts.state.SetBalance(ts.addr, balance) != nil {
+			return nil, err
+		}
+	}
+	return delegation, err
+}
+
+func (ts *testStaker) WithdrawDelegation(
+	delegationID *big.Int,
+	currentBlock uint32,
+) (uint64, error) {
+	amount, err := ts.Staker.WithdrawDelegation(delegationID, currentBlock)
+	if err != nil {
+		return amount, err
+	}
+	balance, err := ts.state.GetBalance(ts.addr)
+	if err != nil {
+		return 0, err
+	}
+	newBalance := big.NewInt(0).Sub(balance, big.NewInt(0).SetUint64(amount))
+	if ts.state.SetBalance(ts.addr, newBalance) != nil {
+		return 0, err
+	}
+	return amount, nil
+}
+
+func newStaker(t *testing.T, amount int, maxValidators int64, initialise bool) (*testStaker, uint64) {
 	db := muxdb.NewMem()
 	st := state.New(db, trie.Root{})
 
 	keys := createKeys(amount)
 	param := params.New(thor.BytesToAddress([]byte("params")), st)
+	stakerAddr := thor.BytesToAddress([]byte("stkr"))
 
 	assert.NoError(t, param.Set(thor.KeyMaxBlockProposers, big.NewInt(maxValidators)))
-	staker := New(thor.BytesToAddress([]byte("stkr")), st, param, nil)
+	stakerImpl := New(stakerAddr, st, param, nil)
+	staker := &testStaker{
+		addr:   stakerAddr,
+		state:  st,
+		Staker: stakerImpl,
+	}
+
 	totalStake := uint64(0)
 	if initialise {
 		for _, key := range keys {
@@ -84,7 +195,12 @@ func newStaker(t *testing.T, amount int, maxValidators int64, initialise bool) (
 		assert.NoError(t, err)
 		assert.True(t, transitioned)
 	}
-	return staker, totalStake
+
+	return &testStaker{
+		addr:   stakerAddr,
+		state:  st,
+		Staker: stakerImpl,
+	}, totalStake
 }
 
 func TestStaker_TotalStake(t *testing.T) {
@@ -339,58 +455,6 @@ func TestStaker_AddValidation(t *testing.T) {
 	assert.Nil(t, validator)
 }
 
-func updateContractBalance(staker *Staker, amount uint64, sign int64) error {
-	addr := staker.validationService.ContractAddress()
-	current, err := staker.state.GetBalance(addr)
-	if err != nil {
-		return err
-	}
-	if current == nil {
-		current = big.NewInt(0)
-	}
-	newBalance := new(big.Int).Add(current, big.NewInt(int64(amount)*sign))
-	staker.state.SetBalance(addr, newBalance)
-	return nil
-}
-
-func addValidatorAndIncreaseContractBalance(staker *Staker, validator thor.Address, endorser thor.Address, period uint32, stake uint64) error {
-	if err := staker.AddValidation(validator, endorser, period, stake); err != nil {
-		return err
-	}
-	return updateContractBalance(staker, stake, 1)
-}
-
-func increaseStakeAndContractBalance(staker *Staker, validator thor.Address, endorser thor.Address, amount uint64) error {
-	if err := staker.IncreaseStake(validator, endorser, amount); err != nil {
-		return err
-	}
-	return updateContractBalance(staker, amount, 1)
-}
-
-// TODO: This doesn't need the update contract balance, MUST INVESTIGATE
-func decreaseStakeAndContractBalance(staker *Staker, validator thor.Address, endorser thor.Address, amount uint64, decreaseImmediate bool) error {
-	if err := staker.DecreaseStake(validator, endorser, amount); err != nil {
-		return err
-	}
-	if decreaseImmediate {
-		return updateContractBalance(staker, amount, -1)
-	}
-	return nil
-}
-
-func withdrawStakeAndContractBalance(staker *Staker, validator thor.Address, endorser thor.Address, block uint32) (uint64, error) {
-	amount, err := staker.WithdrawStake(validator, endorser, block)
-	if err != nil {
-		return 0, err
-	}
-	fmt.Println("amount", amount)
-	// if err := updateContractBalance(staker, amount, -1); err != nil {
-	// 	return 0, err
-	// }
-
-	return amount, nil
-}
-
 func TestStaker_QueueUpValidators(t *testing.T) {
 	staker, _ := newStaker(t, 101, 101, false)
 
@@ -400,7 +464,8 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	addr4 := datagen.RandAddress()
 
 	stake := RandomStake()
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, uint32(360)*24*15, stake))
+	err := staker.AddValidation(addr1, addr1, uint32(360)*24*15, stake)
+	assert.NoError(t, err)
 
 	validator, err := staker.GetValidation(addr1)
 	assert.NoError(t, err)
@@ -416,7 +481,8 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	assert.Equal(t, stake, validator.LockedVET)
 	assert.Equal(t, validation.StatusActive, validator.Status)
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, uint32(360)*24*15, stake))
+	err = staker.AddValidation(addr2, addr2, uint32(360)*24*15, stake)
+	assert.NoError(t, err)
 
 	validator, err = staker.GetValidation(addr2)
 	assert.NoError(t, err)
@@ -424,7 +490,8 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr3, addr3, uint32(360)*24*30, stake))
+	err = staker.AddValidation(addr3, addr3, uint32(360)*24*30, stake)
+	assert.NoError(t, err)
 
 	validator, err = staker.GetValidation(addr3)
 	assert.NoError(t, err)
@@ -432,7 +499,8 @@ func TestStaker_QueueUpValidators(t *testing.T) {
 	assert.Equal(t, stake, validator.QueuedVET)
 	assert.Equal(t, validation.StatusQueued, validator.Status)
 
-	assert.Error(t, addValidatorAndIncreaseContractBalance(staker, addr4, addr4, uint32(360)*24*14, stake), "period is out of boundaries")
+	err = staker.AddValidation(addr4, addr4, uint32(360)*24*14, stake)
+	assert.Error(t, err, "period is out of boundaries")
 
 	validator, err = staker.GetValidation(addr4)
 	assert.NoError(t, err)
@@ -501,9 +569,12 @@ func TestStaker_Get_FullFlow_Renewal_Off(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// add the validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr, addr, period, stake))
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
+	err := staker.AddValidation(addr, addr, period, stake)
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
 
 	active, queued, err := staker.GetValidationsNum()
 	assert.NoError(t, err)
@@ -796,8 +867,9 @@ func TestStaker_IncreaseActive(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// add the validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr, addr, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr, addr, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 	validator, err := staker.GetValidation(addr)
 	assert.NoError(t, err)
@@ -807,7 +879,8 @@ func TestStaker_IncreaseActive(t *testing.T) {
 
 	// increase stake of an active validator
 	expectedStake := 1000 + stake
-	assert.NoError(t, increaseStakeAndContractBalance(staker, addr, addr, 1000))
+	err = staker.IncreaseStake(addr, addr, 1000)
+	assert.NoError(t, err)
 	validator, err = staker.GetValidation(addr)
 	assert.NoError(t, err)
 	newStake := validator.QueuedVET + validator.LockedVET
@@ -834,10 +907,12 @@ func TestStaker_ChangeStakeActiveValidatorWithQueued(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// add the validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr, addr, period, stake))
+	err := staker.AddValidation(addr, addr, period, stake)
+	assert.NoError(t, err)
 	// add a second validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 	validator, err := staker.GetValidation(addr)
 	assert.NoError(t, err)
@@ -855,7 +930,8 @@ func TestStaker_ChangeStakeActiveValidatorWithQueued(t *testing.T) {
 
 	// increase stake of an active validator
 	expectedStake := 1000 + stake
-	assert.NoError(t, increaseStakeAndContractBalance(staker, addr, addr, 1000))
+	err = staker.IncreaseStake(addr, addr, 1000)
+	assert.NoError(t, err)
 	validator, err = staker.GetValidation(addr)
 	assert.NoError(t, err)
 	newStake := validator.QueuedVET + validator.LockedVET
@@ -918,8 +994,9 @@ func TestStaker_DecreaseActive(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// add the validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr, addr, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr, addr, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 	validator, err := staker.GetValidation(addr)
 	assert.NoError(t, err)
@@ -933,7 +1010,8 @@ func TestStaker_DecreaseActive(t *testing.T) {
 	// decrease stake of an active validator
 	decrease := uint64(1000)
 	expectedStake := stake - decrease
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, addr, addr, decrease, false))
+	err = staker.DecreaseStake(addr, addr, decrease)
+	assert.NoError(t, err)
 	validator, err = staker.GetValidation(addr)
 	assert.NoError(t, err)
 	newStake := validator.QueuedVET + validator.LockedVET
@@ -962,8 +1040,9 @@ func TestStaker_DecreaseActiveThenExit(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// add the validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr, addr, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr, addr, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 	validator, err := staker.GetValidation(addr)
 	assert.NoError(t, err)
@@ -977,7 +1056,8 @@ func TestStaker_DecreaseActiveThenExit(t *testing.T) {
 	// decrease stake of an active validator
 	decrease := uint64(1000)
 	expectedStake := stake - decrease
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, addr, addr, decrease, false))
+	err = staker.DecreaseStake(addr, addr, decrease)
+	assert.NoError(t, err)
 	validator, err = staker.GetValidation(addr)
 	assert.NoError(t, err)
 	assert.Equal(t, stake, validator.LockedVET)
@@ -1021,9 +1101,12 @@ func TestStaker_Get_FullFlow(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// add the validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr, addr, period, stake))
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
+	err := staker.AddValidation(addr, addr, period, stake)
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
 
 	validator, err := staker.GetValidation(addr)
 	assert.NoError(t, err)
@@ -1122,9 +1205,12 @@ func TestStaker_Get_FullFlow_Renewal_On_Then_Off(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// add the validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr, addr, period, stake))
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
+	err := staker.AddValidation(addr, addr, period, stake)
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
 
 	validator, err := staker.GetValidation(addr)
 	assert.NoError(t, err)
@@ -1364,7 +1450,12 @@ func TestStaker_Initialise(t *testing.T) {
 	addr := datagen.RandAddress()
 
 	param := params.New(thor.BytesToAddress([]byte("params")), st)
-	staker := New(thor.BytesToAddress([]byte("stkr")), st, param, nil)
+	stakerImpl := New(thor.BytesToAddress([]byte("stkr")), st, param, nil)
+	staker := &testStaker{
+		Staker: stakerImpl,
+		addr:   thor.BytesToAddress([]byte("stkr")),
+		state:  st,
+	}
 	assert.NoError(t, param.Set(thor.KeyMaxBlockProposers, big.NewInt(3)))
 
 	for range 3 {
@@ -1426,7 +1517,8 @@ func TestStaker_Housekeep_ExitOne(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// Add first validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
+	err := staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
 
 	totalLocked, totalWeight, err := staker.LockedStake()
 	assert.NoError(t, err)
@@ -1447,7 +1539,8 @@ func TestStaker_Housekeep_ExitOne(t *testing.T) {
 	assert.Equal(t, stake, totalWeight)
 
 	// Add second validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
 	totalLocked, totalWeight, err = staker.LockedStake()
 	assert.NoError(t, err)
 	totalQueued, err = staker.QueuedStake()
@@ -1467,7 +1560,8 @@ func TestStaker_Housekeep_ExitOne(t *testing.T) {
 	assert.Equal(t, stake*2, totalWeight)
 
 	// Add third validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr3, addr3, period, stake))
+	err = staker.AddValidation(addr3, addr3, period, stake)
+	assert.NoError(t, err)
 	totalLocked, totalWeight, err = staker.LockedStake()
 	assert.NoError(t, err)
 	totalQueued, err = staker.QueuedStake()
@@ -1536,13 +1630,16 @@ func TestStaker_Housekeep_Cooldown(t *testing.T) {
 
 	stake := RandomStake()
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr1, addr1, period, stake)
 	assert.NoError(t, err)
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
 	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr3, addr3, period, stake))
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr3, addr3, period, stake)
+	assert.NoError(t, err)
 	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
@@ -1616,13 +1713,16 @@ func TestStaker_Housekeep_CooldownToExited(t *testing.T) {
 	stake := RandomStake()
 	period := uint32(360) * 24 * 15
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr1, addr1, period, stake)
 	assert.NoError(t, err)
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
 	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr3, addr3, period, stake))
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr3, addr3, period, stake)
+	assert.NoError(t, err)
 	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
@@ -1662,13 +1762,16 @@ func TestStaker_Housekeep_ExitOrder(t *testing.T) {
 	stake := RandomStake()
 	period := uint32(360) * 24 * 15
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr1, addr1, period, stake)
 	assert.NoError(t, err)
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
 	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr3, addr3, period, stake))
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr3, addr3, period, stake)
+	assert.NoError(t, err)
 	_, err = staker.activateNextValidation(period*2, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
@@ -1723,11 +1826,13 @@ func TestStaker_Housekeep_RecalculateIncrease(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// auto renew is turned on
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
-	assert.NoError(t, increaseStakeAndContractBalance(staker, addr1, addr1, 1))
+	err = staker.IncreaseStake(addr1, addr1, 1)
+	assert.NoError(t, err)
 
 	// housekeep half way through the period, validator's locked vet should not change
 	_, err = staker.Housekeep(period / 2)
@@ -1759,12 +1864,14 @@ func TestStaker_Housekeep_RecalculateDecrease(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// auto renew is turned on
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
 	decrease := uint64(1)
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, addr1, addr1, decrease, false))
+	err = staker.DecreaseStake(addr1, addr1, decrease)
+	assert.NoError(t, err)
 
 	block := uint32(360) * 24 * 13
 	_, err = staker.Housekeep(block)
@@ -1796,11 +1903,13 @@ func TestStaker_Housekeep_DecreaseThenWithdraw(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// auto renew is turned on
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, addr1, addr1, 1, false))
+	err = staker.DecreaseStake(addr1, addr1, 1)
+	assert.NoError(t, err)
 
 	block := uint32(360) * 24 * 13
 	_, err = staker.Housekeep(block)
@@ -1849,18 +1958,21 @@ func TestStaker_DecreaseActive_DecreaseMultipleTimes(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// auto renew is turned on
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, addr1, addr1, 1, false))
+	err = staker.DecreaseStake(addr1, addr1, 1)
+	assert.NoError(t, err)
 
 	validator, err := staker.GetValidation(addr1)
 	assert.NoError(t, err)
 	assert.Equal(t, stake, validator.LockedVET)
 	assert.Equal(t, uint64(1), validator.PendingUnlockVET)
 
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, addr1, addr1, 1, false))
+	err = staker.DecreaseStake(addr1, addr1, 1)
+	assert.NoError(t, err)
 
 	validator, err = staker.GetValidation(addr1)
 	assert.NoError(t, err)
@@ -1885,8 +1997,9 @@ func TestStaker_Housekeep_Cannot_Exit_If_It_Breaks_Finality(t *testing.T) {
 	stake := RandomStake()
 	period := uint32(360) * 24 * 15
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
 	// disable auto renew
@@ -1906,10 +2019,12 @@ func TestStaker_Housekeep_Cannot_Exit_If_It_Breaks_Finality(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, validation.StatusExit, validator.Status)
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
+	err = staker.AddValidation(addr2, addr2, period, stake) // false
+	assert.NoError(t, err)
 	_, err = staker.activateNextValidation(exitBlock+8640, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr3, addr3, period, stake))
+	err = staker.AddValidation(addr3, addr3, period, stake) // false
+	assert.NoError(t, err)
 	_, err = staker.activateNextValidation(exitBlock+8640, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
@@ -1931,10 +2046,8 @@ func TestStaker_Housekeep_Exit_Decrements_Leader_Group_Size(t *testing.T) {
 
 	newTestSequence(t, staker).
 		AddValidation(addr1, addr1, period, stake).
-		UpdateContractBalance(stake).
 		ActivateNext(0).
 		AddValidation(addr2, addr2, period, stake).
-		UpdateContractBalance(stake).
 		ActivateNext(0).
 		SignalExit(addr1, addr1, 10).
 		SignalExit(addr2, addr2, 10).
@@ -1962,7 +2075,6 @@ func TestStaker_Housekeep_Exit_Decrements_Leader_Group_Size(t *testing.T) {
 
 	newTestSequence(t, staker).
 		AddValidation(addr3, addr3, period, stake).
-		UpdateContractBalance(stake).
 		ActivateNext(block).
 		SignalExit(addr3, addr3, block+period-1).
 		AssertFirstActive(addr3).
@@ -1985,9 +2097,12 @@ func TestStaker_Housekeep_Adds_Queued_Validators_Up_To_Limit(t *testing.T) {
 	stake := RandomStake()
 	period := uint32(360) * 24 * 15
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr2, addr2, period, stake))
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr3, addr3, period, stake))
+	err := staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr2, addr2, period, stake)
+	assert.NoError(t, err)
+	err = staker.AddValidation(addr3, addr3, period, stake)
+	assert.NoError(t, err)
 
 	queuedValidators, err := staker.validationService.QueuedGroupSize()
 	assert.NoError(t, err)
@@ -2024,7 +2139,8 @@ func TestStaker_QueuedValidator_Withdraw(t *testing.T) {
 	stake := RandomStake()
 	period := uint32(360) * 24 * 15
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
+	err := staker.AddValidation(addr1, addr1, period, stake) // false
+	assert.NoError(t, err)
 
 	withdraw, err := staker.WithdrawStake(addr1, addr1, period)
 	assert.NoError(t, err)
@@ -2046,9 +2162,10 @@ func TestStaker_IncreaseStake_Withdraw(t *testing.T) {
 	stake := RandomStake()
 	period := uint32(360) * 24 * 15
 
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, addr1, addr1, period, stake))
+	err := staker.AddValidation(addr1, addr1, period, stake)
+	assert.NoError(t, err)
 
-	_, err := staker.Housekeep(period)
+	_, err = staker.Housekeep(period)
 	assert.NoError(t, err)
 
 	val, err := staker.GetValidation(addr1)
@@ -2056,7 +2173,7 @@ func TestStaker_IncreaseStake_Withdraw(t *testing.T) {
 	assert.Equal(t, validation.StatusActive, val.Status)
 	assert.Equal(t, stake, val.LockedVET)
 
-	assert.NoError(t, increaseStakeAndContractBalance(staker, addr1, addr1, 100))
+	assert.NoError(t, staker.IncreaseStake(addr1, addr1, 100))
 	withdrawAmount, err := staker.WithdrawStake(addr1, addr1, period+thor.CooldownPeriod())
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(100), withdrawAmount)
@@ -2143,13 +2260,14 @@ func TestStaker_MultipleUpdates_CorrectWithdraw(t *testing.T) {
 	period := uint32(360) * 24 * 15
 
 	// QUEUED
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, acc, acc, period, initialStake))
+	err := staker.AddValidation(acc, acc, period, initialStake)
+	assert.NoError(t, err)
 
 	increases += thousand
-	assert.NoError(t, increaseStakeAndContractBalance(staker, acc, acc, thousand))
+	assert.NoError(t, staker.IncreaseStake(acc, acc, thousand))
 	// 1st decrease
 	decreases += fiveHundred
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, acc, acc, fiveHundred, true))
+	assert.NoError(t, staker.DecreaseStake(acc, acc, fiveHundred))
 
 	validator, err := staker.GetValidation(acc)
 	assert.NoError(t, err)
@@ -2167,7 +2285,7 @@ func TestStaker_MultipleUpdates_CorrectWithdraw(t *testing.T) {
 	assert.Equal(t, expected, validator.LockedVET)
 
 	// See `1st decrease` -> validator should be able withdraw the decrease amount
-	withdraw, err := withdrawStakeAndContractBalance(staker, acc, acc, period+1)
+	withdraw, err := staker.WithdrawStake(acc, acc, period+1)
 	assert.NoError(t, err)
 	assert.Equal(t, withdraw, fiveHundred)
 	withdrawnTotal += withdraw
@@ -2177,13 +2295,12 @@ func TestStaker_MultipleUpdates_CorrectWithdraw(t *testing.T) {
 	validator, err = staker.GetValidation(acc)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedLocked, validator.LockedVET)
-	assert.Equal(t, validation.StatusActive, validator.Status)
 
 	// 2nd decrease
 	decreases += thousand
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, acc, acc, thousand, false))
+	assert.NoError(t, staker.DecreaseStake(acc, acc, thousand))
 	increases += fiveHundred
-	assert.NoError(t, increaseStakeAndContractBalance(staker, acc, acc, fiveHundred))
+	assert.NoError(t, staker.IncreaseStake(acc, acc, fiveHundred))
 
 	// 2nd STAKING PERIOD
 	_, err = staker.Housekeep(period * 2)
@@ -2193,7 +2310,7 @@ func TestStaker_MultipleUpdates_CorrectWithdraw(t *testing.T) {
 	assert.Equal(t, validation.StatusActive, validator.Status)
 
 	// See `2nd decrease` -> validator should be able withdraw the decrease amount
-	withdraw, err = withdrawStakeAndContractBalance(staker, acc, acc, period*2+thor.CooldownPeriod())
+	withdraw, err = staker.WithdrawStake(acc, acc, period*2+thor.CooldownPeriod())
 	assert.NoError(t, err)
 	assert.Equal(t, thousand, withdraw)
 	withdrawnTotal += withdraw
@@ -2213,7 +2330,7 @@ func TestStaker_MultipleUpdates_CorrectWithdraw(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedLocked, validator.CooldownVET)
 
-	withdraw, err = withdrawStakeAndContractBalance(staker, acc, acc, period*3+thor.CooldownPeriod())
+	withdraw, err = staker.WithdrawStake(acc, acc, period*3+thor.CooldownPeriod())
 	assert.NoError(t, err)
 	withdrawnTotal += withdraw
 	depositTotal := initialStake + increases
@@ -2227,9 +2344,7 @@ func Test_GetValidatorTotals_ValidatorExiting(t *testing.T) {
 
 	delegationID := new(big.Int)
 	dStake := stakes.NewWeightedStakeWithMultiplier(MinStakeVET, 255)
-	newTestSequence(t, staker).
-		AddDelegation(validator.ID, dStake.VET, 255, delegationID, 10).
-		UpdateContractBalance(dStake.VET)
+	newTestSequence(t, staker).AddDelegation(validator.ID, dStake.VET, 255, delegationID, 10)
 
 	_, err := staker.aggregationService.GetAggregation(validators[0].ID)
 	assert.NoError(t, err)
@@ -2332,13 +2447,14 @@ func Test_Validator_Decrease_Exit_Withdraw(t *testing.T) {
 	acc := datagen.RandAddress()
 
 	originalStake := uint64(3) * MinStakeVET
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, acc, acc, thor.LowStakingPeriod(), originalStake))
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	err := staker.AddValidation(acc, acc, thor.LowStakingPeriod(), originalStake)
+	assert.NoError(t, err)
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
 	// Decrease stake
 	decrease := uint64(2) * MinStakeVET
-	err = decreaseStakeAndContractBalance(staker, acc, acc, decrease, false)
+	err = staker.DecreaseStake(acc, acc, decrease)
 	assert.NoError(t, err)
 
 	// Turn off auto-renew  - can't decrease if auto-renew is false
@@ -2384,18 +2500,19 @@ func Test_Validator_IncreaseDecrease_Combinations(t *testing.T) {
 	acc := datagen.RandAddress()
 
 	// Add & activate validator
-	assert.NoError(t, addValidatorAndIncreaseContractBalance(staker, acc, acc, thor.LowStakingPeriod(), MinStakeVET))
+	err := staker.AddValidation(acc, acc, thor.LowStakingPeriod(), MinStakeVET)
+	assert.NoError(t, err)
 
 	// Increase and decrease - both should be okay since we're only dealing with QueuedVET
-	assert.NoError(t, increaseStakeAndContractBalance(staker, acc, acc, MinStakeVET))       // 25m + 25m = 50m
-	assert.NoError(t, decreaseStakeAndContractBalance(staker, acc, acc, MinStakeVET, true)) // 25m - 50m = 25m
+	assert.NoError(t, staker.IncreaseStake(acc, acc, MinStakeVET)) // 25m + 25m = 50m
+	assert.NoError(t, staker.DecreaseStake(acc, acc, MinStakeVET)) // 25m - 50m = 25m
 
 	// Activate the validator.
-	_, err := staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
+	_, err = staker.activateNextValidation(0, getTestMaxLeaderSize(staker.params))
 	assert.NoError(t, err)
 
 	// Withdraw the previous decrease amount
-	withdrawal, err := withdrawStakeAndContractBalance(staker, acc, acc, 0)
+	withdrawal, err := staker.WithdrawStake(acc, acc, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, MinStakeVET, withdrawal, "withdraw should be 0 since we are withdrawing from pending locked")
 
@@ -2406,12 +2523,12 @@ func Test_Validator_IncreaseDecrease_Combinations(t *testing.T) {
 	assert.Equal(t, MinStakeVET, val.LockedVET)
 
 	// Increase stake (ok): 25m + 25m = 50m
-	assert.NoError(t, increaseStakeAndContractBalance(staker, acc, acc, MinStakeVET))
+	assert.NoError(t, staker.IncreaseStake(acc, acc, MinStakeVET))
 	// Decrease stake (NOT ok): 25m - 25m = 0. The Previous increase is not applied since it is still currently withdrawable.
-	assert.ErrorContains(t, decreaseStakeAndContractBalance(staker, acc, acc, MinStakeVET, false), "next period stake is lower than minimum stake")
+	assert.ErrorContains(t, staker.DecreaseStake(acc, acc, MinStakeVET), "next period stake is lower than minimum stake")
 	// Instantly withdraw - This is bad, it pulls from the QueuedVET, which means total stake later will be 0.
 	// The decrease previously marked as okay since the current TVL + pending TVL was greater than the min stake.
-	withdraw1, err := withdrawStakeAndContractBalance(staker, acc, acc, 0)
+	withdraw1, err := staker.WithdrawStake(acc, acc, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, MinStakeVET, withdraw1, "withdraw should be 0 since we are withdrawing from pending locked")
 
@@ -2420,7 +2537,7 @@ func Test_Validator_IncreaseDecrease_Combinations(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Withdraw again
-	withdraw2, err := withdrawStakeAndContractBalance(staker, acc, acc, thor.LowStakingPeriod()+thor.CooldownPeriod())
+	withdraw2, err := staker.WithdrawStake(acc, acc, thor.LowStakingPeriod()+thor.CooldownPeriod())
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(0), withdraw2)
 
@@ -2475,7 +2592,6 @@ func TestStaker_HasDelegations(t *testing.T) {
 		AssertHasDelegations(validator, false).
 		// delegation added, housekeeping not performed, should be false
 		AddDelegation(validator, dStake, 200, delegationID, 10).
-		UpdateContractBalance(dStake).
 		AssertHasDelegations(validator, false).
 		AssertGlobalWithdrawable(0).
 		// housekeeping performed, should be true

--- a/consensus/validator.go
+++ b/consensus/validator.go
@@ -303,6 +303,9 @@ func (c *Consensus) verifyBlock(blk *block.Block, state *state.State, blockConfl
 
 	if posActive {
 		staker := builtin.Staker.Native(state)
+		if err := staker.PerformSanityCheck(); err != nil {
+			return nil, nil, fmt.Errorf("staker sanity check failed while verifying block: %w", err)
+		}
 		energy := builtin.Energy.Native(state, header.Timestamp())
 		if err := energy.DistributeRewards(blk.Header().Beneficiary(), signer, staker, header.Number()); err != nil {
 			return nil, nil, err


### PR DESCRIPTION
# Description

Ensure that locked + queued + withdrawable VET + cooldown VET equals the total VET in the staker account address when calling Housekeep and apply transactions.

[GithubIssue](https://github.com/vechain/protocol-board-repo/issues/814)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
