### PR TITLE
No delegations when exiting validator

### DIFF
--- a/builtin/staker/globalstats/service.go
+++ b/builtin/staker/globalstats/service.go
@@ -112,8 +112,8 @@ func (s *Service) ApplyExit(validation *Exit, aggregation *Exit) error {
 		}
 	}
 
-	// Both queued (val + del) stakes and exited validations are now withdrawable
-	// exited validations do not go on cooldown
+	// Both queued (val + del) stakes and exited delegations are now withdrawable
+	// exited delegations do not go on cooldown
 	withdrawableIncrease := queuedDecrease + aggregation.ExitedTVL.VET
 	if withdrawableIncrease > 0 {
 		if err := s.AddWithdrawable(withdrawableIncrease); err != nil {

--- a/builtin/staker/globalstats/service.go
+++ b/builtin/staker/globalstats/service.go
@@ -94,8 +94,15 @@ func (s *Service) ApplyExit(validation *Exit, aggregation *Exit) error {
 		return err
 	}
 
-	if err := s.RemoveQueued(validation.QueuedDecrease + aggregation.QueuedDecrease); err != nil {
-		return err
+	// all queued VET will be moved to withdrawable
+	// this pertains both validations and aggregations queued stake
+	if validation.QueuedDecrease+aggregation.QueuedDecrease > 0 {
+		if err := s.RemoveQueued(validation.QueuedDecrease + aggregation.QueuedDecrease); err != nil {
+			return err
+		}
+		if err := s.AddWithdrawable(validation.QueuedDecrease + aggregation.QueuedDecrease); err != nil {
+			return err
+		}
 	}
 
 	// move validation's exiting to cooldown

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -521,6 +521,11 @@ func (s *Staker) AddDelegation(
 		return nil, NewReverts("validation is not queued or active")
 	}
 
+	// delegations cannot be added to a validator that has signaled to exit
+	if val.ExitBlock != nil {
+		return nil, NewReverts("cannot add delegation to exiting validator")
+	}
+
 	// validate that new TVL is <= Max stake
 	if err = s.validateStakeIncrease(validator, val, stake); err != nil {
 		return nil, err

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -903,7 +903,7 @@ func Test_Increase_WhileValidatorExiting(t *testing.T) {
 
 	// add after validator signals exit, should fail
 	err = staker.IncreaseStake(first, val.Endorser, 10_000)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 
 	// housekeep should clean up the queued delegation
 	_, err = staker.Housekeep(val.Period)

--- a/builtin/staker/staker_test.go
+++ b/builtin/staker/staker_test.go
@@ -901,7 +901,7 @@ func Test_Increase_WhileValidatorExiting(t *testing.T) {
 
 	assert.NoError(t, staker.SignalExit(first, val.Endorser, 20))
 
-	// add before validator signals exit, should be okay
+	// add after validator signals exit, should fail
 	err = staker.IncreaseStake(first, val.Endorser, 10_000)
 	assert.NoError(t, err)
 

--- a/builtin/staker/validation/service.go
+++ b/builtin/staker/validation/service.go
@@ -318,6 +318,11 @@ func (s *Service) ExitValidator(validator thor.Address) (*globalstats.Exit, erro
 		return nil, err
 	}
 
+	// clean up in the renewal list, in case the validator inc/dec stake in the same period that signaled exit
+	if err = s.repo.renewalList.Remove(validator); err != nil {
+		return nil, err
+	}
+
 	return exit, nil
 }
 

--- a/builtin/staker_native_test.go
+++ b/builtin/staker_native_test.go
@@ -519,10 +519,6 @@ func TestStakerContract_PauseSwitches(t *testing.T) {
 		Caller(endorser).
 		Assert(t)
 
-	test.Case("signalExit", validator1).
-		Caller(endorser).
-		Assert(t)
-
 	// change switch to pause nothing
 	builtin.Params.Native(state).Set(thor.KeyStakerSwitches, big.NewInt(0b00))
 
@@ -531,6 +527,11 @@ func TestStakerContract_PauseSwitches(t *testing.T) {
 	test.Case("addDelegation", validator1, uint8(100)).
 		Value(minStake).
 		Caller(delegator).
+		Assert(t)
+
+	// cannot add delegation after the signal validation exit
+	test.Case("signalExit", validator1).
+		Caller(endorser).
 		Assert(t)
 
 	// withdraw delegation2 on exited validator3


### PR DESCRIPTION
# Description

Delegations are no longer allowed to validations that have signaled exit.

Fixes # (issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
