### PR TITLE
chore(staker): reduce housekeepnig logs"

### DIFF
--- a/builtin/staker/housekeep.go
+++ b/builtin/staker/housekeep.go
@@ -45,6 +45,8 @@ func (s *Staker) Housekeep(currentBlock uint32) (bool, error) {
 		return false, err
 	}
 
+	logger.Info("🏠housekeeping", "block", currentBlock, "updates", transition.HasUpdates())
+
 	if !transition.HasUpdates() {
 		return false, nil
 	}

--- a/builtin/staker/protocol.go
+++ b/builtin/staker/protocol.go
@@ -55,7 +55,6 @@ func (s *Staker) SyncPOS(forkConfig *thor.ForkConfig, current uint32) (Status, e
 		if err != nil {
 			return status, err
 		}
-		logger.Info("🏠housekeeping", "block", current, "updates", status.Updates)
 	}
 
 	return status, nil


### PR DESCRIPTION
# Description

Currently this gets logged on every block if staker logs are enabled. This changes the logic to only log if on an epoch block

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
