### PR TITLE
fix: withdraw pending delegation

### DIFF
--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -676,7 +676,7 @@ func (s *Staker) WithdrawDelegation(
 
 	// start and finish values are sanitized: !started and finished is impossible
 	// delegation is still queued
-	if !started {
+	if !started && val.Status <= validation.StatusActive {
 		weightedStake := stakes.NewWeightedStakeWithMultiplier(withdrawableStake, del.Multiplier)
 		if err = s.aggregationService.SubPendingVet(del.Validation, weightedStake); err != nil {
 			return 0, err

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -676,7 +676,7 @@ func (s *Staker) WithdrawDelegation(
 
 	// start and finish values are sanitized: !started and finished is impossible
 	// delegation is still queued
-	if !started && val.Status <= validation.StatusActive {
+	if !started && val.Status != validation.StatusExit {
 		weightedStake := stakes.NewWeightedStakeWithMultiplier(withdrawableStake, del.Multiplier)
 		if err = s.aggregationService.SubPendingVet(del.Validation, weightedStake); err != nil {
 			return 0, err


### PR DESCRIPTION
# Description

underflow occurs if a delegation is added, then validator signals an exit and delegator calls to withdraw after

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
