### PR TITLE
Darren/fix/withdraw pending delegation v2

### DIFF
--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -436,6 +436,8 @@ func (s *Staker) WithdrawStake(validator thor.Address, endorser thor.Address, cu
 		return 0, err
 	}
 
+	// clean up aggregations, move all queued to withdrawable. Otherwise, delegation stakes remain in
+	// queued counter until they withdraw.
 	if isQueued {
 		exit, err := s.aggregationService.Exit(validator)
 		if err != nil {

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -442,10 +442,10 @@ func (s *Staker) WithdrawStake(validator thor.Address, endorser thor.Address, cu
 			return 0, err
 		}
 		if exit.QueuedDecrease > 0 {
-			if err := s.globalStatsService.AddWithdrawable(exit.QueuedDecrease); err != nil {
+			if err := s.globalStatsService.RemoveQueued(exit.QueuedDecrease); err != nil {
 				return 0, err
 			}
-			if err := s.globalStatsService.RemoveQueued(exit.QueuedDecrease); err != nil {
+			if err := s.globalStatsService.AddWithdrawable(exit.QueuedDecrease); err != nil {
 				return 0, err
 			}
 		}

--- a/builtin/staker/staker.go
+++ b/builtin/staker/staker.go
@@ -441,11 +441,13 @@ func (s *Staker) WithdrawStake(validator thor.Address, endorser thor.Address, cu
 		if err != nil {
 			return 0, err
 		}
-		if err := s.globalStatsService.AddWithdrawable(exit.QueuedDecrease); err != nil {
-			return 0, err
-		}
-		if err := s.globalStatsService.RemoveQueued(exit.QueuedDecrease); err != nil {
-			return 0, err
+		if exit.QueuedDecrease > 0 {
+			if err := s.globalStatsService.AddWithdrawable(exit.QueuedDecrease); err != nil {
+				return 0, err
+			}
+			if err := s.globalStatsService.RemoveQueued(exit.QueuedDecrease); err != nil {
+				return 0, err
+			}
 		}
 	}
 

--- a/builtin/staker_native_gas_test.go
+++ b/builtin/staker_native_gas_test.go
@@ -135,7 +135,7 @@ func TestStakerNativeGasCosts(t *testing.T) {
 		},
 		{
 			function:     "native_withdrawStake",
-			expectedGas:  12000,
+			expectedGas:  22600,
 			args:         []any{account1, account1},
 			description:  "Withdraw stake for a validator",
 			preTestHooks: []TestHook{preTestAddValidation(account1)},

--- a/builtin/staker_native_test.go
+++ b/builtin/staker_native_test.go
@@ -218,7 +218,7 @@ func (c *ccase) Assert(t *testing.T) *ccase {
 
 	if c.gas != 0 {
 		assert.Greater(t, inputGas, vmout.LeftOverGas)
-		assert.Equal(t, c.gas, inputGas-vmout.LeftOverGas)
+		assert.Equal(t, c.gas, inputGas-vmout.LeftOverGas, "expected = %d, got = %d", c.gas, inputGas-vmout.LeftOverGas)
 	}
 
 	c.output = nil
@@ -560,7 +560,7 @@ func TestStakerContract_PauseSwitches(t *testing.T) {
 	test.Case("addValidation", master, thor.LowStakingPeriod()).
 		Value(minStake).
 		Caller(endorser).
-		ShouldUseGas(117571).
+		ShouldUseGas(132571).
 		Assert(t)
 
 	test.Case("increaseStake", validator1).
@@ -599,7 +599,7 @@ func TestStakerContract_PauseSwitches(t *testing.T) {
 	// withdraw delegation2 on exited validator3
 	test.Case("withdrawDelegation", big.NewInt(2)).
 		Caller(delegator).
-		ShouldUseGas(34763).
+		ShouldUseGas(24563).
 		Assert(t)
 
 	// signal exit delegation1 on validator1


### PR DESCRIPTION
# Description

fix: allow delegation to withdraw if validator exits while the delegation is queued.
fix: move queued aggregation values to withdrawable if validator exits while queued.

Both issues are interlinked

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
