### PR TITLE
Remove redundant gas consumption call

### DIFF
--- a/builtin/staker_native.go
+++ b/builtin/staker_native.go
@@ -186,8 +186,6 @@ func init() {
 			}
 
 			if !isPoSActive {
-				charger.Charge(thor.SloadGas) // a.getEntry(ValidatorMaster)
-
 				exists, endorser, _, _, err := Authority.Native(env.State()).Get(thor.Address(args.Validator))
 				if err != nil {
 					return nil, err

--- a/builtin/staker_native_gas_test.go
+++ b/builtin/staker_native_gas_test.go
@@ -106,7 +106,7 @@ func TestStakerNativeGasCosts(t *testing.T) {
 		},
 		{
 			function:    "native_addValidation",
-			expectedGas: 122000,
+			expectedGas: 121800,
 			args:        []any{account1, account1, thor.LowStakingPeriod(), staker.MinStake},
 			description: "Add a new validator (not implemented yet)",
 		},


### PR DESCRIPTION
# Description

Removing a redundant gas consumption call when PoS is not yet active since `Authority.Native(env.State()).Get(thor.Address(args.Validator))` is actually charging the same amount of gas for the same operation.

Fixes [GHIssue](https://github.com/vechain/protocol-board-repo/issues/858)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
