### PR TITLE
add weak subjectivity logic

### DIFF
--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -256,6 +256,12 @@ var (
 		Sources: envVar("MIN_EFFECTIVE_PRIORITY_FEE"),
 	}
 
+	wscProviderURLFlag = &cli.StringFlag{
+		Name:    "wsc-provider-url",
+		Usage:   "URL to fetch weak subjectivity checkpoint",
+		Sources: envVar("WSC_PROVIDER_URL"),
+	}
+
 	// solo mode only flags
 	onDemandFlag = &cli.BoolFlag{
 		Name:    "on-demand",

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -127,6 +127,7 @@ func main() {
 			txPoolLimitPerAccountFlag,
 			allowedTracersFlag,
 			minEffectivePriorityFeeFlag,
+			wscProviderURLFlag,
 		},
 		Action: defaultAction,
 		Commands: []*cli.Command{
@@ -333,6 +334,7 @@ func defaultAction(_ context.Context, ctx *cli.Command) error {
 		SkipLogs:         skipLogs,
 		MinTxPriorityFee: minTxPriorityFee,
 		TargetGasLimit:   ctx.Uint64(targetGasLimitFlag.Name),
+		WSCProviderURL:   ctx.String(wscProviderURLFlag.Name),
 	}
 	stater := state.NewStater(mainDB)
 

--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -112,7 +112,7 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 	n.maxBlockNum = maxBlockNum
 
-	wscRequired, err := n.prepareWeakSubjectivity()
+	wscRequired, err := n.shouldCheckWeakSubjectivityCheckpoint()
 	if err != nil {
 		return err
 	}

--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -43,6 +43,7 @@ type Options struct {
 	TargetGasLimit   uint64
 	SkipLogs         bool
 	MinTxPriorityFee uint64
+	WSCProviderURL   string
 }
 
 type Node struct {
@@ -61,6 +62,7 @@ type Node struct {
 
 	logDBFailed       bool
 	initialSynced     bool // true if the initial synchronization process is done
+	wscRequired       bool
 	bandwidth         bandwidth.Bandwidth
 	maxBlockNum       uint32
 	processLock       sync.Mutex
@@ -109,6 +111,12 @@ func (n *Node) Run(ctx context.Context) error {
 		return err
 	}
 	n.maxBlockNum = maxBlockNum
+
+	wscRequired, err := n.prepareWeakSubjectivity()
+	if err != nil {
+		return err
+	}
+	n.wscRequired = wscRequired
 
 	db, err := leveldb.OpenFile(n.txStashPath, nil)
 	if err != nil {

--- a/cmd/thor/node/node.go
+++ b/cmd/thor/node/node.go
@@ -62,7 +62,7 @@ type Node struct {
 
 	logDBFailed       bool
 	initialSynced     bool // true if the initial synchronization process is done
-	wscRequired       bool
+	wscEnabled        bool
 	bandwidth         bandwidth.Bandwidth
 	maxBlockNum       uint32
 	processLock       sync.Mutex
@@ -112,11 +112,11 @@ func (n *Node) Run(ctx context.Context) error {
 	}
 	n.maxBlockNum = maxBlockNum
 
-	wscRequired, err := n.shouldCheckWeakSubjectivityCheckpoint()
+	wscEnabled, err := n.shouldCheckWeakSubjectivityCheckpoint()
 	if err != nil {
 		return err
 	}
-	n.wscRequired = wscRequired
+	n.wscEnabled = wscEnabled
 
 	db, err := leveldb.OpenFile(n.txStashPath, nil)
 	if err != nil {

--- a/cmd/thor/node/packer_loop.go
+++ b/cmd/thor/node/packer_loop.go
@@ -31,7 +31,7 @@ func (n *Node) packerLoop(ctx context.Context) {
 		return
 	case <-n.comm.Synced():
 	}
-	if n.wscRequired {
+	if n.wscEnabled {
 		logger.Info("verifying weak subjectivity checkpoint")
 		if err := n.verifyWeakSubjectivityCheckpoint(ctx); err != nil {
 			logger.Error("weak subjectivity checkpoint failed", "err", err)

--- a/cmd/thor/node/packer_loop.go
+++ b/cmd/thor/node/packer_loop.go
@@ -31,6 +31,13 @@ func (n *Node) packerLoop(ctx context.Context) {
 		return
 	case <-n.comm.Synced():
 	}
+	if n.wscRequired {
+		logger.Info("verifying weak subjectivity checkpoint")
+		if err := n.verifyWeakSubjectivity(ctx); err != nil {
+			logger.Error("weak subjectivity checkpoint failed", "err", err)
+			panic(err)
+		}
+	}
 	n.initialSynced = true
 	logger.Info("synchronization process done")
 

--- a/cmd/thor/node/packer_loop.go
+++ b/cmd/thor/node/packer_loop.go
@@ -33,7 +33,7 @@ func (n *Node) packerLoop(ctx context.Context) {
 	}
 	if n.wscRequired {
 		logger.Info("verifying weak subjectivity checkpoint")
-		if err := n.verifyWeakSubjectivity(ctx); err != nil {
+		if err := n.verifyWeakSubjectivityCheckpoint(ctx); err != nil {
 			logger.Error("weak subjectivity checkpoint failed", "err", err)
 			panic(err)
 		}

--- a/cmd/thor/node/wsc.go
+++ b/cmd/thor/node/wsc.go
@@ -22,8 +22,13 @@ const (
 	wscMaxBodySize  = 16 * 1024 * 1024
 )
 
-// prepareWeakSubjectivity decides if WSC must run after synchronization, based on finalized age and URL presence.
+// prepareWeakSubjectivity only enables WSC when a provider URL is configured.
 func (n *Node) prepareWeakSubjectivity() (bool, error) {
+	if n.options.WSCProviderURL == "" {
+		logger.Debug("weak subjectivity checkpoint disabled: provider url not set")
+		return false, nil
+	}
+
 	summary, err := n.finalizedSummary()
 	if err != nil {
 		return false, err
@@ -37,11 +42,6 @@ func (n *Node) prepareWeakSubjectivity() (bool, error) {
 	}
 	if safe {
 		logger.Info("weak subjectivity checkpoint skipped", "finalized", shortID(finalizedID), "age", age)
-		return false, nil
-	}
-
-	if n.options.WSCProviderURL == "" {
-		logger.Warn("weak subjectivity checkpoint required but provider url not set; continuing without check", "finalized", shortID(finalizedID), "age", age)
 		return false, nil
 	}
 

--- a/cmd/thor/node/wsc.go
+++ b/cmd/thor/node/wsc.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/vechain/thor/v2/chain"
+	"github.com/vechain/thor/v2/thor"
+)
+
+const (
+	wscSafeRange    = time.Hour
+	wscFetchTimeout = 15 * time.Second
+	wscMaxBodySize  = 16 * 1024 * 1024
+)
+
+// prepareWeakSubjectivity decides if WSC must run after synchronization, based on finalized age and URL presence.
+func (n *Node) prepareWeakSubjectivity() (bool, error) {
+	summary, err := n.finalizedSummary()
+	if err != nil {
+		return false, err
+	}
+
+	now := time.Now()
+	finalizedID := summary.Header.ID()
+	safe, age, err := finalizedInSafeRange(now, summary)
+	if err != nil {
+		return false, err
+	}
+	if safe {
+		logger.Info("weak subjectivity checkpoint skipped", "finalized", shortID(finalizedID), "age", age)
+		return false, nil
+	}
+
+	if n.options.WSCProviderURL == "" {
+		logger.Warn("weak subjectivity checkpoint required but provider url not set; continuing without check", "finalized", shortID(finalizedID), "age", age)
+		return false, nil
+	}
+
+	logger.Info("weak subjectivity checkpoint required", "finalized", shortID(finalizedID), "age", age, "provider", n.options.WSCProviderURL)
+	return true, nil
+}
+
+// verifyWeakSubjectivity fetches the checkpoint and enforces both the safe-range and ID match.
+func (n *Node) verifyWeakSubjectivity(ctx context.Context) error {
+	checkpoint, err := fetchWSCCheckpoint(ctx, n.options.WSCProviderURL)
+	if err != nil {
+		return err
+	}
+
+	summary, err := n.finalizedSummary()
+	if err != nil {
+		return err
+	}
+
+	safe, age, err := finalizedInSafeRange(time.Now(), summary)
+	if err != nil {
+		return err
+	}
+	if !safe {
+		return fmt.Errorf("finalized block outside safe range (age %s)", age)
+	}
+
+	finalizedID := summary.Header.ID()
+	if checkpoint != finalizedID {
+		return fmt.Errorf("checkpoint mismatch: checkpoint=%s finalized=%s", checkpoint, finalizedID)
+	}
+
+	logger.Info("weak subjectivity checkpoint verified", "finalized", shortID(finalizedID))
+	return nil
+}
+
+func (n *Node) finalizedSummary() (*chain.BlockSummary, error) {
+	return n.repo.GetBlockSummary(n.bft.Finalized())
+}
+
+// finalizedInSafeRange returns false (with error) if the finalized timestamp is ahead of local time.
+func finalizedInSafeRange(now time.Time, summary *chain.BlockSummary) (bool, time.Duration, error) {
+	age, err := finalizedAge(now, summary)
+	if err != nil {
+		return false, 0, err
+	}
+	return age <= wscSafeRange, age, nil
+}
+
+// finalizedAge fails if the finalized timestamp is ahead of local time.
+func finalizedAge(now time.Time, summary *chain.BlockSummary) (time.Duration, error) {
+	blockTime := time.Unix(int64(summary.Header.Timestamp()), 0)
+	if blockTime.After(now) {
+		return 0, fmt.Errorf("finalized block timestamp %s is in the future", blockTime)
+	}
+	return now.Sub(blockTime), nil
+}
+
+// fetchWSCCheckpoint performs a bounded HTTP GET and expects a JSON payload with an id field.
+func fetchWSCCheckpoint(ctx context.Context, url string) (thor.Bytes32, error) {
+	if url == "" {
+		return thor.Bytes32{}, fmt.Errorf("missing checkpoint url")
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, wscFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return thor.Bytes32{}, err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return thor.Bytes32{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return thor.Bytes32{}, fmt.Errorf("unexpected response status %s", resp.Status)
+	}
+
+	var payload struct {
+		ID *thor.Bytes32 `json:"id"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(resp.Body, wscMaxBodySize))
+	if err := decoder.Decode(&payload); err != nil {
+		return thor.Bytes32{}, fmt.Errorf("decode checkpoint response: %w", err)
+	}
+	if payload.ID == nil {
+		return thor.Bytes32{}, fmt.Errorf("checkpoint response missing id")
+	}
+	return *payload.ID, nil
+}

--- a/cmd/thor/node/wsc.go
+++ b/cmd/thor/node/wsc.go
@@ -23,14 +23,14 @@ const (
 )
 
 // finalizedStatus loads the finalized block and computes its safe-range status.
-func (n *Node) finalizedStatus() (id thor.Bytes32, safe bool, age time.Duration, err error) {
+func (n *Node) finalizedStatus() (thor.Bytes32, bool, time.Duration, error) {
 	summary, err := n.repo.GetBlockSummary(n.bft.Finalized())
 	if err != nil {
 		return thor.Bytes32{}, false, 0, err
 	}
-	id = summary.Header.ID()
-	safe, age, err = finalizedInSafeRange(time.Now(), summary)
-	return
+	id := summary.Header.ID()
+	safe, age, err := finalizedInSafeRange(time.Now(), summary)
+	return id, safe, age, err
 }
 
 // shouldCheckWeakSubjectivityCheckpoint only enables WSC when a provider URL is configured

--- a/cmd/thor/node/wsc_test.go
+++ b/cmd/thor/node/wsc_test.go
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/chain"
+	"github.com/vechain/thor/v2/genesis"
+	"github.com/vechain/thor/v2/test/testchain"
+	"github.com/vechain/thor/v2/thor"
+)
+
+func summaryWithTimestamp(ts time.Time) *chain.BlockSummary {
+	blk := (&block.Builder{}).Timestamp(uint64(ts.Unix())).Build()
+	return &chain.BlockSummary{Header: blk.Header()}
+}
+
+func newCheckpointServer(status int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func newTestNode(t *testing.T, launchTime uint64, wscURL string) *Node {
+	t.Helper()
+	forkConfig := thor.SoloFork
+	chain, err := testchain.NewIntegrationTestChain(genesis.DevConfig{
+		ForkConfig: &forkConfig,
+		LaunchTime: launchTime,
+	}, 180)
+	require.NoError(t, err)
+
+	return &Node{
+		repo:    chain.Repo(),
+		bft:     chain.Engine(),
+		options: Options{WSCProviderURL: wscURL},
+	}
+}
+
+func TestFinalizedInSafeRange(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	cases := []struct {
+		name      string
+		timestamp time.Time
+		expected  bool
+		wantErr   bool
+	}{
+		{"future timestamp", now.Add(10 * time.Second), false, true},
+		{"exactly safe range", now.Add(-wscSafeRange), true, false},
+		{"just outside safe range", now.Add(-wscSafeRange - time.Second), false, false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := summaryWithTimestamp(tt.timestamp)
+			safe, age, err := finalizedInSafeRange(now, summary)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, safe)
+			if tt.expected {
+				require.LessOrEqual(t, age, wscSafeRange)
+			}
+		})
+	}
+}
+
+func TestFinalizedAge(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	future := summaryWithTimestamp(now.Add(15 * time.Second))
+	_, err := finalizedAge(now, future)
+	require.Error(t, err)
+
+	past := summaryWithTimestamp(now.Add(-2 * time.Minute))
+	age, err := finalizedAge(now, past)
+	require.NoError(t, err)
+	require.Equal(t, 2*time.Minute, age)
+}
+
+func TestFetchWSCCheckpoint(t *testing.T) {
+	id := thor.MustParseBytes32("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
+
+	t.Run("success", func(t *testing.T) {
+		body := fmt.Sprintf(`{"id":"%s"}`, id.String())
+		server := newCheckpointServer(http.StatusOK, body)
+		defer server.Close()
+
+		got, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		require.NoError(t, err)
+		require.Equal(t, id, got)
+	})
+
+	t.Run("missing url", func(t *testing.T) {
+		_, err := fetchWSCCheckpoint(context.Background(), "")
+		require.Error(t, err)
+	})
+
+	t.Run("non-2xx status", func(t *testing.T) {
+		server := newCheckpointServer(http.StatusInternalServerError, `{"id":"0x00"}`)
+		defer server.Close()
+
+		_, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		require.ErrorContains(t, err, "unexpected response status")
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		server := newCheckpointServer(http.StatusOK, "not-json")
+		defer server.Close()
+
+		_, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		require.ErrorContains(t, err, "decode checkpoint response")
+	})
+
+	t.Run("missing id", func(t *testing.T) {
+		server := newCheckpointServer(http.StatusOK, `{}`)
+		defer server.Close()
+
+		_, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		require.ErrorContains(t, err, "missing id")
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		server := newCheckpointServer(http.StatusOK, `{"id":"0x1234"}`)
+		defer server.Close()
+
+		_, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		require.ErrorContains(t, err, "decode checkpoint response")
+	})
+}
+
+func TestPrepareWeakSubjectivity(t *testing.T) {
+	now := time.Now()
+
+	t.Run("safe range", func(t *testing.T) {
+		node := newTestNode(t, uint64(now.Add(-10*time.Second).Unix()), "http://example.test")
+		required, err := node.prepareWeakSubjectivity()
+		require.NoError(t, err)
+		require.False(t, required)
+	})
+
+	t.Run("out of range without url", func(t *testing.T) {
+		node := newTestNode(t, uint64(now.Add(-2*time.Hour).Unix()), "")
+		required, err := node.prepareWeakSubjectivity()
+		require.NoError(t, err)
+		require.False(t, required)
+	})
+
+	t.Run("out of range with url", func(t *testing.T) {
+		node := newTestNode(t, uint64(now.Add(-2*time.Hour).Unix()), "http://example.test")
+		required, err := node.prepareWeakSubjectivity()
+		require.NoError(t, err)
+		require.True(t, required)
+	})
+}
+
+func TestVerifyWeakSubjectivity(t *testing.T) {
+	now := time.Now()
+
+	t.Run("match", func(t *testing.T) {
+		node := newTestNode(t, uint64(now.Add(-10*time.Second).Unix()), "")
+		finalizedID := node.bft.Finalized()
+		server := newCheckpointServer(http.StatusOK, fmt.Sprintf(`{"id":"%s"}`, finalizedID.String()))
+		defer server.Close()
+
+		node.options.WSCProviderURL = server.URL
+		require.NoError(t, node.verifyWeakSubjectivity(context.Background()))
+	})
+
+	t.Run("mismatch", func(t *testing.T) {
+		node := newTestNode(t, uint64(now.Add(-10*time.Second).Unix()), "")
+		finalizedID := node.bft.Finalized()
+		badID := finalizedID
+		badID[31] ^= 0xff
+		server := newCheckpointServer(http.StatusOK, fmt.Sprintf(`{"id":"%s"}`, badID.String()))
+		defer server.Close()
+
+		node.options.WSCProviderURL = server.URL
+		err := node.verifyWeakSubjectivity(context.Background())
+		require.ErrorContains(t, err, "checkpoint mismatch")
+	})
+
+	t.Run("outside safe range", func(t *testing.T) {
+		node := newTestNode(t, uint64(now.Add(-2*time.Hour).Unix()), "")
+		finalizedID := node.bft.Finalized()
+		server := newCheckpointServer(http.StatusOK, fmt.Sprintf(`{"id":"%s"}`, finalizedID.String()))
+		defer server.Close()
+
+		node.options.WSCProviderURL = server.URL
+		err := node.verifyWeakSubjectivity(context.Background())
+		require.ErrorContains(t, err, "outside safe range")
+	})
+}

--- a/cmd/thor/node/wsc_test.go
+++ b/cmd/thor/node/wsc_test.go
@@ -162,6 +162,13 @@ func TestPrepareWeakSubjectivity(t *testing.T) {
 		require.False(t, required)
 	})
 
+	t.Run("future timestamp without url", func(t *testing.T) {
+		node := newTestNode(t, uint64(now.Add(2*time.Hour).Unix()), "")
+		required, err := node.prepareWeakSubjectivity()
+		require.NoError(t, err)
+		require.False(t, required)
+	})
+
 	t.Run("out of range with url", func(t *testing.T) {
 		node := newTestNode(t, uint64(now.Add(-2*time.Hour).Unix()), "http://example.test")
 		required, err := node.prepareWeakSubjectivity()

--- a/cmd/thor/node/wsc_test.go
+++ b/cmd/thor/node/wsc_test.go
@@ -94,7 +94,7 @@ func TestFinalizedAge(t *testing.T) {
 	require.Equal(t, 2*time.Minute, age)
 }
 
-func TestFetchWSCCheckpoint(t *testing.T) {
+func TestFetchWSCheckpoint(t *testing.T) {
 	id := thor.MustParseBytes32("0x0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20")
 
 	t.Run("success", func(t *testing.T) {
@@ -102,13 +102,13 @@ func TestFetchWSCCheckpoint(t *testing.T) {
 		server := newCheckpointServer(http.StatusOK, body)
 		defer server.Close()
 
-		got, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		got, err := fetchWSCheckpoint(context.Background(), server.URL)
 		require.NoError(t, err)
 		require.Equal(t, id, got)
 	})
 
 	t.Run("missing url", func(t *testing.T) {
-		_, err := fetchWSCCheckpoint(context.Background(), "")
+		_, err := fetchWSCheckpoint(context.Background(), "")
 		require.Error(t, err)
 	})
 
@@ -116,7 +116,7 @@ func TestFetchWSCCheckpoint(t *testing.T) {
 		server := newCheckpointServer(http.StatusInternalServerError, `{"id":"0x00"}`)
 		defer server.Close()
 
-		_, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		_, err := fetchWSCheckpoint(context.Background(), server.URL)
 		require.ErrorContains(t, err, "unexpected response status")
 	})
 
@@ -124,7 +124,7 @@ func TestFetchWSCCheckpoint(t *testing.T) {
 		server := newCheckpointServer(http.StatusOK, "not-json")
 		defer server.Close()
 
-		_, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		_, err := fetchWSCheckpoint(context.Background(), server.URL)
 		require.ErrorContains(t, err, "decode checkpoint response")
 	})
 
@@ -132,7 +132,7 @@ func TestFetchWSCCheckpoint(t *testing.T) {
 		server := newCheckpointServer(http.StatusOK, `{}`)
 		defer server.Close()
 
-		_, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		_, err := fetchWSCheckpoint(context.Background(), server.URL)
 		require.ErrorContains(t, err, "missing id")
 	})
 
@@ -140,7 +140,7 @@ func TestFetchWSCCheckpoint(t *testing.T) {
 		server := newCheckpointServer(http.StatusOK, `{"id":"0x1234"}`)
 		defer server.Close()
 
-		_, err := fetchWSCCheckpoint(context.Background(), server.URL)
+		_, err := fetchWSCheckpoint(context.Background(), server.URL)
 		require.ErrorContains(t, err, "decode checkpoint response")
 	})
 }
@@ -150,28 +150,28 @@ func TestPrepareWeakSubjectivity(t *testing.T) {
 
 	t.Run("safe range", func(t *testing.T) {
 		node := newTestNode(t, uint64(now.Add(-10*time.Second).Unix()), "http://example.test")
-		required, err := node.prepareWeakSubjectivity()
+		required, err := node.shouldCheckWeakSubjectivityCheckpoint()
 		require.NoError(t, err)
 		require.False(t, required)
 	})
 
 	t.Run("out of range without url", func(t *testing.T) {
 		node := newTestNode(t, uint64(now.Add(-2*time.Hour).Unix()), "")
-		required, err := node.prepareWeakSubjectivity()
+		required, err := node.shouldCheckWeakSubjectivityCheckpoint()
 		require.NoError(t, err)
 		require.False(t, required)
 	})
 
 	t.Run("future timestamp without url", func(t *testing.T) {
 		node := newTestNode(t, uint64(now.Add(2*time.Hour).Unix()), "")
-		required, err := node.prepareWeakSubjectivity()
+		required, err := node.shouldCheckWeakSubjectivityCheckpoint()
 		require.NoError(t, err)
 		require.False(t, required)
 	})
 
 	t.Run("out of range with url", func(t *testing.T) {
 		node := newTestNode(t, uint64(now.Add(-2*time.Hour).Unix()), "http://example.test")
-		required, err := node.prepareWeakSubjectivity()
+		required, err := node.shouldCheckWeakSubjectivityCheckpoint()
 		require.NoError(t, err)
 		require.True(t, required)
 	})
@@ -187,7 +187,7 @@ func TestVerifyWeakSubjectivity(t *testing.T) {
 		defer server.Close()
 
 		node.options.WSCProviderURL = server.URL
-		require.NoError(t, node.verifyWeakSubjectivity(context.Background()))
+		require.NoError(t, node.verifyWeakSubjectivityCheckpoint(context.Background()))
 	})
 
 	t.Run("mismatch", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestVerifyWeakSubjectivity(t *testing.T) {
 		defer server.Close()
 
 		node.options.WSCProviderURL = server.URL
-		err := node.verifyWeakSubjectivity(context.Background())
+		err := node.verifyWeakSubjectivityCheckpoint(context.Background())
 		require.ErrorContains(t, err, "checkpoint mismatch")
 	})
 
@@ -210,7 +210,7 @@ func TestVerifyWeakSubjectivity(t *testing.T) {
 		defer server.Close()
 
 		node.options.WSCProviderURL = server.URL
-		err := node.verifyWeakSubjectivity(context.Background())
+		err := node.verifyWeakSubjectivityCheckpoint(context.Background())
 		require.ErrorContains(t, err, "outside safe range")
 	})
 }


### PR DESCRIPTION
# Description

This PR introduces an optional flag `--wsc-provider-url` to allow the client to check against a week subjectivity checkpoint if the local synched chain is the canonical.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
