### PR TITLE
Pedro/eth eq nonce v2

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -390,7 +390,7 @@ func (rt *Runtime) PrepareClause(
 	txCtx *xenv.TransactionContext,
 ) (exec func() (output *Output, interrupted bool, err error), interrupt func()) {
 	var (
-		stateDB       = statedb.New(rt.state, txCtx.TxType)
+		stateDB       = statedb.New(rt.state, txCtx.Type)
 		evm           = rt.newEVM(stateDB, clauseIndex, txCtx)
 		data          []byte
 		leftOverGas   uint64
@@ -574,7 +574,7 @@ func (rt *Runtime) PrepareTransaction(trx *tx.Transaction) (*TransactionExecutor
 			// stateDB.SetNonce before the inner snapshot; that survived the tx.
 			// For CREATE txs that reverted, rt.state.RevertTo(checkpoint) undid the EVM's
 			// increment, so we must re-apply it here.
-			if trx.Type() == tx.TypeEthTyped1559 {
+			if trx.Type() == tx.TypeEthDynamicFee {
 				isCreate := resolvedTx.Clauses[0].IsCreatingContract()
 				if !isCreate || reverted {
 					nonce, err := rt.state.GetNonce(txCtx.Origin)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -390,7 +390,7 @@ func (rt *Runtime) PrepareClause(
 	txCtx *xenv.TransactionContext,
 ) (exec func() (output *Output, interrupted bool, err error), interrupt func()) {
 	var (
-		stateDB       = statedb.New(rt.state)
+		stateDB       = statedb.New(rt.state, txCtx.TxType)
 		evm           = rt.newEVM(stateDB, clauseIndex, txCtx)
 		data          []byte
 		leftOverGas   uint64
@@ -566,6 +566,25 @@ func (rt *Runtime) PrepareTransaction(trx *tx.Transaction) (*TransactionExecutor
 
 			if err := returnGas(leftOverGas); err != nil {
 				return nil, err
+			}
+
+			// EIP-2: nonce is always consumed for EthereumTx, even if the tx reverts.
+			// For CALL txs the EVM never touches the nonce, so we always increment here.
+			// For CREATE txs that succeeded the EVM already incremented the nonce via
+			// stateDB.SetNonce before the inner snapshot; that survived the tx.
+			// For CREATE txs that reverted, rt.state.RevertTo(checkpoint) undid the EVM's
+			// increment, so we must re-apply it here.
+			if trx.Type() == tx.TypeEthTyped1559 {
+				isCreate := resolvedTx.Clauses[0].IsCreatingContract()
+				if !isCreate || reverted {
+					nonce, err := rt.state.GetNonce(txCtx.Origin)
+					if err != nil {
+						return nil, err
+					}
+					if err := rt.state.SetNonce(txCtx.Origin, nonce+1); err != nil {
+						return nil, err
+					}
+				}
 			}
 
 			if !thor.IsForked(rt.ctx.Number, rt.forkConfig.GALACTICA) {

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1099,6 +1099,125 @@ func TestCreateAddressDerivation(t *testing.T) {
 	}
 }
 
+// TestEthTxNonce verifies the nonce increment in Finalize for all four EthereumTx paths
+// plus the VeChain isolation guard.
+//
+// The nonce source differs per path:
+//
+//	CALL success        → Finalize (!isCreate = true)
+//	CALL reverted       → Finalize (!isCreate || , EIP-2: nonce consumed evenreverted on revert)
+//	CREATE success      → EVM's create() before snapshot; Finalize condition is false and skips
+//	CREATE reverted     → rt.state.RevertTo undoes EVM's write; Finalize re-applies
+//	TypeLegacy CREATE   → txType guard in StateDB prevents any Ethereum nonce write
+func TestEthTxNonce(t *testing.T) {
+	db := muxdb.NewMem()
+	g, _ := genesis.NewDevnet()
+	stater := state.NewStater(db)
+	b0, _, _, err := g.Build(stater)
+	assert.Nil(t, err)
+	repo, _ := chain.NewRepository(db, b0)
+
+	ethChainID := thor.GetEthChainID(b0.Header().ID())
+	senderKey := genesis.DevAccounts()[0].PrivateKey
+	sender := genesis.DevAccounts()[0].Address
+
+	ethBlkCtx := &xenv.BlockContext{
+		BaseFee:  big.NewInt(thor.InitialBaseFee),
+		GasLimit: b0.Header().GasLimit(),
+	}
+
+	newRT := func(blkCtx *xenv.BlockContext) (*runtime.Runtime, *state.State) {
+		st := stater.NewState(trie.Root{Hash: b0.Header().StateRoot()})
+		return runtime.New(repo.NewChain(b0.Header().ID()), st, blkCtx, forkFromStart), st
+	}
+
+	buildEthTx := func(nonce uint64, to *thor.Address, data []byte) *tx.Transaction {
+		trx, err := tx.NewEthBuilder(tx.TypeEthTyped1559).
+			ChainID(ethChainID).
+			Nonce(nonce).
+			MaxFeePerGas(big.NewInt(2 * thor.InitialBaseFee)).
+			MaxPriorityFeePerGas(big.NewInt(thor.InitialBaseFee)).
+			GasLimit(300_000).
+			To(to).
+			Data(data).
+			Build(senderKey)
+		assert.Nil(t, err)
+		return trx
+	}
+
+	// PUSH1 0 PUSH1 0 RETURN — deploys an empty contract without reverting.
+	successInitcode := []byte{0x60, 0x00, 0x60, 0x00, 0xf3}
+	// PUSH1 0 PUSH1 0 REVERT — reverts whether used as initcode or as deployed code.
+	revertCode := []byte{0x60, 0x00, 0x60, 0x00, 0xfd}
+
+	t.Run("call success: Finalize always increments nonce", func(t *testing.T) {
+		rt, st := newRT(ethBlkCtx)
+		recipient := genesis.DevAccounts()[1].Address
+		receipt, err := rt.ExecuteTransaction(buildEthTx(0, &recipient, nil))
+		assert.Nil(t, err)
+		assert.False(t, receipt.Reverted)
+		nonce, err := st.GetNonce(sender)
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(1), nonce)
+	})
+
+	t.Run("call reverted: nonce consumed even on revert", func(t *testing.T) {
+		rt, st := newRT(ethBlkCtx)
+		// Pre-load a contract whose runtime code always reverts.
+		contractAddr := thor.BytesToAddress([]byte("reverter"))
+		assert.Nil(t, st.SetCode(contractAddr, revertCode))
+		receipt, err := rt.ExecuteTransaction(buildEthTx(0, &contractAddr, nil))
+		assert.Nil(t, err)
+		assert.True(t, receipt.Reverted)
+		nonce, err := st.GetNonce(sender)
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(1), nonce)
+	})
+
+	t.Run("create success: EVM increments nonce before snapshot; Finalize skips", func(t *testing.T) {
+		rt, st := newRT(ethBlkCtx)
+		receipt, err := rt.ExecuteTransaction(buildEthTx(0, nil, successInitcode))
+		assert.Nil(t, err)
+		assert.False(t, receipt.Reverted)
+		nonce, err := st.GetNonce(sender)
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(1), nonce)
+	})
+
+	t.Run("create reverted: rt.state.RevertTo undoes EVM's increment; Finalize re-applies", func(t *testing.T) {
+		rt, st := newRT(ethBlkCtx)
+		receipt, err := rt.ExecuteTransaction(buildEthTx(0, nil, revertCode))
+		assert.Nil(t, err)
+		assert.True(t, receipt.Reverted)
+		nonce, err := st.GetNonce(sender)
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(1), nonce)
+	})
+
+	t.Run("vechain legacy create: Ethereum nonce domain untouched", func(t *testing.T) {
+		// BaseFee=0 (not nil): avoids nil-deref in EffectivePriorityFeePerGas (GALACTICA
+		// reward path) while keeping effectiveGasPrice >= baseFee trivially true for TypeLegacy.
+		vcBlkCtx := &xenv.BlockContext{BaseFee: new(big.Int), GasLimit: b0.Header().GasLimit()}
+		rt, st := newRT(vcBlkCtx)
+		vcSender := genesis.DevAccounts()[1]
+		vcTx := tx.NewBuilder(tx.TypeLegacy).
+			ChainTag(repo.ChainTag()).
+			BlockRef(tx.NewBlockRef(0)).
+			Expiration(100).
+			GasPriceCoef(255).
+			Gas(300_000).
+			Clause(tx.NewClause(nil).WithData(successInitcode)).
+			Build()
+		vcTx = tx.MustSign(vcTx, vcSender.PrivateKey)
+		receipt, err := rt.ExecuteTransaction(vcTx)
+		assert.Nil(t, err)
+		assert.False(t, receipt.Reverted)
+		nonce, err := st.GetNonce(vcSender.Address)
+		assert.Nil(t, err)
+		assert.Equal(t, uint64(0), nonce)
+	})
+}
+
 func getMockTx(repo *chain.Repository, txType tx.Type, t *testing.T) *tx.Transaction {
 	blockRef := tx.NewBlockRef(0)
 	chainTag := repo.ChainTag()

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1117,7 +1117,7 @@ func TestEthTxNonce(t *testing.T) {
 	assert.Nil(t, err)
 	repo, _ := chain.NewRepository(db, b0)
 
-	ethChainID := thor.GetEthChainID(b0.Header().ID())
+	ethChainID := repo.ChainID()
 	senderKey := genesis.DevAccounts()[0].PrivateKey
 	sender := genesis.DevAccounts()[0].Address
 
@@ -1132,15 +1132,16 @@ func TestEthTxNonce(t *testing.T) {
 	}
 
 	buildEthTx := func(nonce uint64, to *thor.Address, data []byte) *tx.Transaction {
-		trx, err := tx.NewEthBuilder(tx.TypeEthTyped1559).
+		unsigned := tx.NewBuilder(tx.TypeEthDynamicFee).
 			ChainID(ethChainID).
 			Nonce(nonce).
 			MaxFeePerGas(big.NewInt(2 * thor.InitialBaseFee)).
 			MaxPriorityFeePerGas(big.NewInt(thor.InitialBaseFee)).
-			GasLimit(300_000).
+			Gas(300_000).
 			To(to).
 			Data(data).
-			Build(senderKey)
+			Build()
+		trx, err := tx.Sign(unsigned, senderKey)
 		assert.Nil(t, err)
 		return trx
 	}

--- a/runtime/statedb/statedb.go
+++ b/runtime/statedb/statedb.go
@@ -141,7 +141,7 @@ func (s *StateDB) AddBalance(addr common.Address, amount *big.Int) {
 // GetNonce returns the Ethereum nonce for the given address.
 // Returns 0 for VeChain-native transactions (nonce is not used).
 func (s *StateDB) GetNonce(addr common.Address) uint64 {
-	if s.txType != tx.TypeEthTyped1559 {
+	if s.txType != tx.TypeEthDynamicFee {
 		return 0
 	}
 	n, err := s.state.GetNonce(thor.Address(addr))
@@ -154,7 +154,7 @@ func (s *StateDB) GetNonce(addr common.Address) uint64 {
 // SetNonce sets the Ethereum nonce for the given address.
 // No-op for VeChain-native transactions.
 func (s *StateDB) SetNonce(addr common.Address, nonce uint64) {
-	if s.txType != tx.TypeEthTyped1559 {
+	if s.txType != tx.TypeEthDynamicFee {
 		return
 	}
 	if err := s.state.SetNonce(thor.Address(addr), nonce); err != nil {

--- a/runtime/statedb/statedb.go
+++ b/runtime/statedb/statedb.go
@@ -23,8 +23,9 @@ var codeSizeCache, _ = lru.New(32 * 1024)
 
 // StateDB implements evm.StateDB, only adapt to evm.
 type StateDB struct {
-	state *state.State
-	repo  *stackedmap.StackedMap
+	state  *state.State
+	repo   *stackedmap.StackedMap
+	txType tx.Type
 }
 
 type (
@@ -42,7 +43,7 @@ type (
 )
 
 // New create a statedb object.
-func New(state *state.State) *StateDB {
+func New(state *state.State, txType tx.Type) *StateDB {
 	getter := func(k any) (any, bool, error) {
 		switch k.(type) {
 		case suicideFlagKey:
@@ -59,8 +60,9 @@ func New(state *state.State) *StateDB {
 
 	repo := stackedmap.New(getter)
 	return &StateDB{
-		state,
-		repo,
+		state:  state,
+		repo:   repo,
+		txType: txType,
 	}
 }
 
@@ -136,11 +138,29 @@ func (s *StateDB) AddBalance(addr common.Address, amount *big.Int) {
 	}
 }
 
-// GetNonce stub.
-func (s *StateDB) GetNonce(_ common.Address) uint64 { return 0 }
+// GetNonce returns the Ethereum nonce for the given address.
+// Returns 0 for VeChain-native transactions (nonce is not used).
+func (s *StateDB) GetNonce(addr common.Address) uint64 {
+	if s.txType != tx.TypeEthTyped1559 {
+		return 0
+	}
+	n, err := s.state.GetNonce(thor.Address(addr))
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
 
-// SetNonce stub.
-func (s *StateDB) SetNonce(_ common.Address, _ uint64) {}
+// SetNonce sets the Ethereum nonce for the given address.
+// No-op for VeChain-native transactions.
+func (s *StateDB) SetNonce(addr common.Address, nonce uint64) {
+	if s.txType != tx.TypeEthTyped1559 {
+		return
+	}
+	if err := s.state.SetNonce(thor.Address(addr), nonce); err != nil {
+		panic(err)
+	}
+}
 
 // GetCodeHash stub.
 func (s *StateDB) GetCodeHash(addr common.Address) common.Hash {

--- a/runtime/statedb/statedb_test.go
+++ b/runtime/statedb/statedb_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vechain/thor/v2/muxdb"
 	State "github.com/vechain/thor/v2/state"
 	"github.com/vechain/thor/v2/trie"
+	"github.com/vechain/thor/v2/tx"
 )
 
 func TestSnapshotRandom(t *testing.T) {
@@ -188,7 +189,7 @@ func (test *snapshotTest) run() bool {
 	var (
 		db           = muxdb.NewMem()
 		state        = State.New(db, trie.Root{})
-		stateDB      = New(state)
+		stateDB      = New(state, tx.TypeLegacy)
 		snapshotRevs = make([]int, len(test.snapshots))
 		sindex       = 0
 	)
@@ -203,7 +204,7 @@ func (test *snapshotTest) run() bool {
 	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
 		state := State.New(db, trie.Root{})
-		checkStateDB := New(state)
+		checkStateDB := New(state, tx.TypeLegacy)
 		for _, action := range test.actions[:test.snapshots[sindex]] {
 			action.fn(action, checkStateDB)
 		}
@@ -257,7 +258,7 @@ func TestTransientState(t *testing.T) {
 	db := muxdb.NewMem()
 	state := State.NewStater(db).NewState(trie.Root{})
 
-	stateDB := New(state)
+	stateDB := New(state, tx.TypeLegacy)
 	val := stateDB.GetTransientState(addr, key)
 	assert.Equal(t, common.Hash{}, val)
 
@@ -281,7 +282,7 @@ func TestTransientState(t *testing.T) {
 
 func TestCreateContract(t *testing.T) {
 	addr := common.Address{0x1}
-	stateDB := New(State.New(muxdb.NewMem(), trie.Root{}))
+	stateDB := New(State.New(muxdb.NewMem(), trie.Root{}), tx.TypeLegacy)
 	assert.False(t, stateDB.IsNewContract(addr))
 	stateDB.CreateContract(addr)
 	assert.True(t, stateDB.IsNewContract(addr))

--- a/state/account.go
+++ b/state/account.go
@@ -31,6 +31,10 @@ type Account struct {
 	Master      []byte // master address
 	CodeHash    []byte // hash of code
 	StorageRoot []byte // merkle root of the storage trie
+	// Nonce is the Ethereum-compatible transaction counter for TypeEthTyped1559 senders.
+	// Stored as a single-element slice so rlp:"tail" gives backward-compatible encoding:
+	// zero nonce → nil slice → same 6-field RLP as pre-INTERSTELLAR accounts.
+	Nonce []uint64 `rlp:"tail"`
 }
 
 // IsEmpty returns if an account is empty.
@@ -39,7 +43,8 @@ func (a *Account) IsEmpty() bool {
 	return a.Balance.Sign() == 0 &&
 		a.Energy.Sign() == 0 &&
 		len(a.Master) == 0 &&
-		len(a.CodeHash) == 0
+		len(a.CodeHash) == 0 &&
+		len(a.Nonce) == 0
 }
 
 var bigE18 = big.NewInt(1e18)
@@ -100,6 +105,11 @@ func loadAccount(trie *muxdb.Trie, addr thor.Address) (*Account, *AccountMetadat
 	var a Account
 	if err := rlp.DecodeBytes(data, &a); err != nil {
 		return nil, nil, err
+	}
+	// rlp:"tail" decodes absent elements as an empty (non-nil) slice;
+	// normalize to nil so zero-nonce accounts compare equal to emptyAccount().
+	if len(a.Nonce) == 0 {
+		a.Nonce = nil
 	}
 
 	var am AccountMetadata

--- a/state/account_test.go
+++ b/state/account_test.go
@@ -78,12 +78,12 @@ func TestTrie(t *testing.T) {
 		"should load an empty account")
 
 	acc1 := Account{
-		big.NewInt(1),
-		big.NewInt(0),
-		0,
-		[]byte("master"),
-		[]byte("code hash"),
-		[]byte("storage root"),
+		Balance:     big.NewInt(1),
+		Energy:      big.NewInt(0),
+		BlockTime:   0,
+		Master:      []byte("master"),
+		CodeHash:    []byte("code hash"),
+		StorageRoot: []byte("storage root"),
 	}
 	meta1 := AccountMetadata{
 		StorageID:       []byte("sid"),

--- a/state/state.go
+++ b/state/state.go
@@ -219,6 +219,34 @@ func (s *State) SetMaster(addr thor.Address, master thor.Address) error {
 	return nil
 }
 
+// GetNonce returns the Ethereum nonce for the given address.
+// Returns 0 for addresses that have never sent an EthereumTx.
+func (s *State) GetNonce(addr thor.Address) (uint64, error) {
+	acc, err := s.getAccount(addr)
+	if err != nil {
+		return 0, &Error{err}
+	}
+	if len(acc.Nonce) > 0 {
+		return acc.Nonce[0], nil
+	}
+	return 0, nil
+}
+
+// SetNonce sets the Ethereum nonce for the given address.
+func (s *State) SetNonce(addr thor.Address, nonce uint64) error {
+	cpy, err := s.getAccountCopy(addr)
+	if err != nil {
+		return &Error{err}
+	}
+	if nonce == 0 {
+		cpy.Nonce = nil
+	} else {
+		cpy.Nonce = []uint64{nonce}
+	}
+	s.updateAccount(addr, &cpy)
+	return nil
+}
+
 // GetStorage returns storage value for the given address and key.
 func (s *State) GetStorage(addr thor.Address, key thor.Bytes32) (thor.Bytes32, error) {
 	raw, err := s.GetRawStorage(addr, key)

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -370,3 +370,33 @@ func TestRLPDecodeErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestNonce(t *testing.T) {
+	addr := thor.BytesToAddress([]byte("nonce-test"))
+
+	t.Run("default is zero", func(t *testing.T) {
+		st := New(muxdb.NewMem(), trie.Root{})
+		n, err := st.GetNonce(addr)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(0), n)
+	})
+
+	t.Run("set and get roundtrip", func(t *testing.T) {
+		st := New(muxdb.NewMem(), trie.Root{})
+		assert.NoError(t, st.SetNonce(addr, 42))
+		n, err := st.GetNonce(addr)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(42), n)
+	})
+
+	t.Run("zero is stored as nil in account", func(t *testing.T) {
+		st := New(muxdb.NewMem(), trie.Root{})
+		_ = st.SetNonce(addr, 5)
+		_ = st.SetNonce(addr, 0)
+		acc, err := st.getAccountCopy(addr)
+		assert.NoError(t, err)
+		// nonce=0 must encode as nil so zero-nonce accounts are indistinguishable
+		// from pre-INTERSTELLAR accounts and IsEmpty() remains correct.
+		assert.Nil(t, acc.Nonce)
+	})
+}

--- a/vm/instructions_test.go
+++ b/vm/instructions_test.go
@@ -614,7 +614,7 @@ func TestOpTstore(t *testing.T) {
 	var (
 		db          = muxdb.NewMem()
 		state       = state.New(db, trie.Root{Hash: thor.Bytes32{}})
-		stateDB     = statedb.New(state)
+		stateDB     = statedb.New(state, tx.TypeLegacy)
 		env         = NewEVM(Context{}, stateDB, &ChainConfig{ChainConfig: *params.TestChainConfig}, Config{})
 		stack       = newstack()
 		mem         = NewMemory()
@@ -746,7 +746,7 @@ func TestOpSuicide6780(t *testing.T) {
 	tests := []testcase{}
 
 	newEVMInstance := func(state *state.State) *EVM {
-		stateDB := statedb.New(state)
+		stateDB := statedb.New(state, tx.TypeLegacy)
 		evm := NewEVM(Context{
 			BlockNumber: big.NewInt(1),
 			GasPrice:    big.NewInt(1),


### PR DESCRIPTION
# Description

Adds Nonce handling for tracking TypeEthDynamicFee Tx's

To keep this simple used the `rlp:"tail"` to decode optional empty fields - we might use a proper `rlp:"optional"` but that will require updating the vendored deps.

Fixes # [(issue)](https://github.com/vechain/protocol-board-repo/issues/1116)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
