### PR TITLE
Paolo/txpool metrics

### DIFF
--- a/txpool/metrics.go
+++ b/txpool/metrics.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	metricTxPoolGauge            = metrics.LazyLoadGaugeVec("txpool_current_tx_count", []string{"source", "type"})
+	metricTxPoolGauge            = metrics.LazyLoadGaugeVec("txpool_current_tx_count", []string{"source", "type", "status"})
+	metricTxPoolWashedCounter    = metrics.LazyLoadCounterVec("txpool_washed_tx_count", []string{"source", "type"})
 	metricBadTxGauge             = metrics.LazyLoadGaugeVec("bad_tx_count", []string{"source"})
 	metricTxPoolExecutablesGauge = metrics.LazyLoadGauge("txpool_executable_tx_count")
 	metricTxPoolAllGauge         = metrics.LazyLoadGauge("txpool_all_tx_count")

--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -8,7 +8,6 @@ package txpool
 import (
 	"math/big"
 	"slices"
-	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -43,9 +42,7 @@ type TxObject struct {
 	// gets <reward-ratio>% of the tip, after GALACTICA it's the effective priority fee per gas and validator gets 100% of the tip
 	priorityGasPrice *big.Int
 
-	// executable is updated by the pool. Accessed concurrently from wash, Remove and
-	// metric helpers
-	executable atomic.Bool
+	executable bool // don't touch this value, will be updated by the pool
 }
 
 func ResolveTx(tx *tx.Transaction, localSubmitted bool) (*TxObject, error) {
@@ -147,7 +144,7 @@ func (o *TxObject) Executable(chain *chain.Chain, state *state.State, headBlock 
 	}
 
 	// non executable -> executable, update payer, cost and priority gas price
-	if !o.executable.Load() {
+	if !o.executable {
 		o.payer = &payer
 		o.cost = prepaid
 

--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -8,6 +8,7 @@ package txpool
 import (
 	"math/big"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -42,7 +43,9 @@ type TxObject struct {
 	// gets <reward-ratio>% of the tip, after GALACTICA it's the effective priority fee per gas and validator gets 100% of the tip
 	priorityGasPrice *big.Int
 
-	executable bool // don't touch this value, will be updated by the pool
+	// executable is updated by the pool. Accessed concurrently from wash, Remove and
+	// metric helpers
+	executable atomic.Bool
 }
 
 func ResolveTx(tx *tx.Transaction, localSubmitted bool) (*TxObject, error) {
@@ -144,7 +147,7 @@ func (o *TxObject) Executable(chain *chain.Chain, state *state.State, headBlock 
 	}
 
 	// non executable -> executable, update payer, cost and priority gas price
-	if !o.executable {
+	if !o.executable.Load() {
 		o.payer = &payer
 		o.cost = prepaid
 

--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -32,11 +32,10 @@ type TxObject struct {
 	*tx.Transaction
 	resolved *runtime.ResolvedTransaction
 
-	timeAdded      int64
-	localSubmitted bool          // tx is submitted locally on this node, or synced remotely from p2p.
-	source         txSource      // source used for txpool current-count metrics.
-	payer          *thor.Address // payer of the tx, either origin, delegator, or on-chain delegation payer
-	cost           *big.Int      // total tx cost the payer needs to pay before execution(gas price * gas)
+	timeAdded int64
+	source    txSource      // where the tx came from: local, remote or fill.
+	payer     *thor.Address // payer of the tx, either origin, delegator, or on-chain delegation payer
+	cost      *big.Int      // total tx cost the payer needs to pay before execution(gas price * gas)
 
 	// basic unit of tip price for the validator, before GALACTICA it's the overallGasPrice(provedWork included) and validator
 	// gets <reward-ratio>% of the tip, after GALACTICA it's the effective priority fee per gas and validator gets 100% of the tip
@@ -50,22 +49,25 @@ func ResolveTx(tx *tx.Transaction, localSubmitted bool) (*TxObject, error) {
 	if localSubmitted {
 		source = txSourceLocal
 	}
-	return resolveTxWithSource(tx, localSubmitted, source)
+	return resolveTxWithSource(tx, source)
 }
 
-func resolveTxWithSource(tx *tx.Transaction, localSubmitted bool, source txSource) (*TxObject, error) {
+func resolveTxWithSource(tx *tx.Transaction, source txSource) (*TxObject, error) {
 	resolved, err := runtime.ResolveTransaction(tx)
 	if err != nil {
 		return nil, err
 	}
 
 	return &TxObject{
-		Transaction:    tx,
-		resolved:       resolved,
-		timeAdded:      time.Now().UnixNano(),
-		localSubmitted: localSubmitted,
-		source:         source,
+		Transaction: tx,
+		resolved:    resolved,
+		timeAdded:   time.Now().UnixNano(),
+		source:      source,
 	}, nil
+}
+
+func (o *TxObject) localSubmitted() bool {
+	return o.source == txSourceLocal
 }
 
 func (o *TxObject) Origin() thor.Address {

--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -20,12 +20,21 @@ import (
 	"github.com/vechain/thor/v2/tx"
 )
 
+type txSource string
+
+const (
+	txSourceLocal  txSource = "local"
+	txSourceRemote txSource = "remote"
+	txSourceFill   txSource = "fill"
+)
+
 type TxObject struct {
 	*tx.Transaction
 	resolved *runtime.ResolvedTransaction
 
 	timeAdded      int64
 	localSubmitted bool          // tx is submitted locally on this node, or synced remotely from p2p.
+	source         txSource      // source used for txpool current-count metrics.
 	payer          *thor.Address // payer of the tx, either origin, delegator, or on-chain delegation payer
 	cost           *big.Int      // total tx cost the payer needs to pay before execution(gas price * gas)
 
@@ -37,6 +46,14 @@ type TxObject struct {
 }
 
 func ResolveTx(tx *tx.Transaction, localSubmitted bool) (*TxObject, error) {
+	source := txSourceRemote
+	if localSubmitted {
+		source = txSourceLocal
+	}
+	return resolveTxWithSource(tx, localSubmitted, source)
+}
+
+func resolveTxWithSource(tx *tx.Transaction, localSubmitted bool, source txSource) (*TxObject, error) {
 	resolved, err := runtime.ResolveTransaction(tx)
 	if err != nil {
 		return nil, err
@@ -47,6 +64,7 @@ func ResolveTx(tx *tx.Transaction, localSubmitted bool) (*TxObject, error) {
 		resolved:       resolved,
 		timeAdded:      time.Now().UnixNano(),
 		localSubmitted: localSubmitted,
+		source:         source,
 	}, nil
 }
 

--- a/txpool/tx_object_map.go
+++ b/txpool/tx_object_map.go
@@ -180,9 +180,11 @@ func (m *txObjectMap) ToTxs() tx.Transactions {
 	return txs
 }
 
-func (m *txObjectMap) Fill(txObjs []*TxObject) {
+func (m *txObjectMap) Fill(txObjs []*TxObject) []*TxObject {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+
+	inserted := make([]*TxObject, 0, len(txObjs))
 	for _, txObj := range txObjs {
 		if _, found := m.mapByHash[txObj.Hash()]; found {
 			continue
@@ -194,8 +196,10 @@ func (m *txObjectMap) Fill(txObjs []*TxObject) {
 		}
 		m.mapByHash[txObj.Hash()] = txObj
 		m.mapByID[txObj.ID()] = txObj
+		inserted = append(inserted, txObj)
 		// skip cost check and accumulation
 	}
+	return inserted
 }
 
 func (m *txObjectMap) Len() int {

--- a/txpool/tx_object_map_test.go
+++ b/txpool/tx_object_map_test.go
@@ -177,18 +177,18 @@ func TestPendingCost(t *testing.T) {
 	baseFee := galactica.CalcBaseFee(best.Header, forkConfig)
 	exec1, err := txObj1.Executable(chain, state, best.Header, forkConfig, baseFee)
 	assert.Nil(t, err)
-	txObj1.executable.Store(exec1)
-	assert.True(t, txObj1.executable.Load())
+	txObj1.executable = exec1
+	assert.True(t, txObj1.executable)
 
 	exec2, err := txObj2.Executable(chain, state, best.Header, forkConfig, baseFee)
 	assert.Nil(t, err)
-	txObj2.executable.Store(exec2)
-	assert.True(t, txObj2.executable.Load())
+	txObj2.executable = exec2
+	assert.True(t, txObj2.executable)
 
 	exec3, err := txObj3.Executable(chain, state, best.Header, forkConfig, baseFee)
 	assert.Nil(t, err)
-	txObj3.executable.Store(exec3)
-	assert.True(t, txObj3.executable.Load())
+	txObj3.executable = exec3
+	assert.True(t, txObj3.executable)
 
 	// Creating a new txObjectMap
 	m := newTxObjectMap()

--- a/txpool/tx_object_map_test.go
+++ b/txpool/tx_object_map_test.go
@@ -175,17 +175,20 @@ func TestPendingCost(t *testing.T) {
 	state := stater.NewState(best.Root())
 
 	baseFee := galactica.CalcBaseFee(best.Header, forkConfig)
-	txObj1.executable, err = txObj1.Executable(chain, state, best.Header, forkConfig, baseFee)
+	exec1, err := txObj1.Executable(chain, state, best.Header, forkConfig, baseFee)
 	assert.Nil(t, err)
-	assert.True(t, txObj1.executable)
+	txObj1.executable.Store(exec1)
+	assert.True(t, txObj1.executable.Load())
 
-	txObj2.executable, err = txObj2.Executable(chain, state, best.Header, forkConfig, baseFee)
+	exec2, err := txObj2.Executable(chain, state, best.Header, forkConfig, baseFee)
 	assert.Nil(t, err)
-	assert.True(t, txObj2.executable)
+	txObj2.executable.Store(exec2)
+	assert.True(t, txObj2.executable.Load())
 
-	txObj3.executable, err = txObj3.Executable(chain, state, best.Header, forkConfig, baseFee)
+	exec3, err := txObj3.Executable(chain, state, best.Header, forkConfig, baseFee)
 	assert.Nil(t, err)
-	assert.True(t, txObj3.executable)
+	txObj3.executable.Store(exec3)
+	assert.True(t, txObj3.executable.Load())
 
 	// Creating a new txObjectMap
 	m := newTxObjectMap()

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -138,12 +138,12 @@ func (p *TxPool) housekeeping() {
 				atomic.StoreUint32(&p.addedAfterWash, 0)
 
 				startTime := mclock.Now()
-				executables, removedLegacy, removedDynamicFee, err := p.wash(headSummary, headBlockChanged)
+				executables, removed, err := p.wash(headSummary, headBlockChanged)
 				elapsed := mclock.Now() - startTime
 
 				ctx := []any{
 					"len", poolLen,
-					"removed", removedLegacy + removedDynamicFee,
+					"removed", removed,
 					"elapsed", common.PrettyDuration(elapsed),
 				}
 				if err != nil {
@@ -355,7 +355,7 @@ func (p *TxPool) addWhenSynced(
 		}
 	}
 
-	txObj.executable = executable
+	txObj.executable.Store(executable)
 	if err := p.all.Add(txObj, p.options.LimitPerAccount, func(payer thor.Address, needs *big.Int) error {
 		// check payer's balance
 		balance, err := builtin.Energy.Native(state, headSummary.Header.Timestamp()+thor.BlockInterval()).Get(payer)
@@ -470,46 +470,40 @@ func (p *TxPool) Dump() tx.Transactions {
 }
 
 // wash to evict txs that are over limit, out of lifetime, out of energy, settled, expired or dep broken.
-// this method should only be called in housekeeping go routine
+// this method should only be called in housekeeping go routine.
+//
+// removed counts every tx evicted by this wash regardless of tx type. The
+// per-source/per-type breakdown lives on the txpool_washed_tx_count counter,
+// which is the source of truth for dashboards/alerts.
 func (p *TxPool) wash(
 	headSummary *chain.BlockSummary,
 	headBlockChanged bool,
 ) (
 	executables tx.Transactions,
-	removedLegacy int,
-	removedDynamicFee int,
+	removed int,
 	err error,
 ) {
 	all := p.all.ToTxObjects()
 	var toRemove []*TxObject
 	defer func() {
+		evict := func(txObj *TxObject) {
+			if p.all.RemoveByHash(txObj.Hash()) {
+				addTxPoolMetric(txObj, -1)
+				countWashedTx(txObj)
+				removed++
+			}
+		}
 		if err != nil {
 			// in case of error, simply cut pool size to limit
 			for i, txObj := range all {
 				if len(all)-i <= p.options.Limit {
 					break
 				}
-				if p.all.RemoveByHash(txObj.Hash()) {
-					addTxPoolMetric(txObj, -1)
-					countWashedTx(txObj)
-					if txObj.Type() == tx.TypeLegacy {
-						removedLegacy++
-					} else if txObj.Type() == tx.TypeDynamicFee {
-						removedDynamicFee++
-					}
-				}
+				evict(txObj)
 			}
 		} else {
 			for _, txObj := range toRemove {
-				if p.all.RemoveByHash(txObj.Hash()) {
-					addTxPoolMetric(txObj, -1)
-					countWashedTx(txObj)
-					if txObj.Type() == tx.TypeLegacy {
-						removedLegacy++
-					} else if txObj.Type() == tx.TypeDynamicFee {
-						removedDynamicFee++
-					}
-				}
+				evict(txObj)
 			}
 		}
 	}()
@@ -530,7 +524,7 @@ func (p *TxPool) wash(
 
 	legacyTxBaseGasPrice, err := builtin.Params.Native(newState()).Get(thor.KeyLegacyTxBaseGasPrice)
 	if err != nil {
-		return executables, removedLegacy, removedDynamicFee, err
+		return executables, removed, err
 	}
 	needPriorityGasPriceUpdate := func() bool {
 		if !headBlockChanged {
@@ -642,7 +636,7 @@ func (p *TxPool) wash(
 
 	for _, obj := range executableObjs {
 		// the tx was not executable previously: validate payer energy before promoting
-		if !obj.executable {
+		if !obj.executable.Load() {
 			payer := *obj.Payer()
 			needs := new(big.Int).Add(p.all.PendingCostOf(payer), obj.Cost())
 			energy, err := builtin.Energy.Native(newState(), headSummary.Header.Timestamp()+thor.BlockInterval()).Get(payer)
@@ -653,7 +647,7 @@ func (p *TxPool) wash(
 			}
 			// removes the non-executable tx from the pool
 			addTxPoolMetric(obj, -1)
-			obj.executable = true
+			obj.executable.Store(true)
 			// re-counts the same tx as executable
 			addTxPoolMetric(obj, 1)
 			p.all.UpdatePendingCost(obj)
@@ -671,7 +665,7 @@ func (p *TxPool) wash(
 			p.txFeed.Send(&TxEvent{tx, &executable})
 		}
 	})
-	return executables, 0, 0, nil
+	return executables, 0, nil
 }
 
 // Len returns the length of the `all` field
@@ -715,12 +709,8 @@ func txMetricType(trx *tx.Transaction) string {
 	}
 }
 
-func txMetricSource(txObj *TxObject) string {
-	return string(txObj.source)
-}
-
-func txMetricStatus(txObj *TxObject) string {
-	if txObj.executable {
+func txMetricStatus(executable bool) string {
+	if executable {
 		return "executable"
 	}
 	return "non_executable"
@@ -728,15 +718,15 @@ func txMetricStatus(txObj *TxObject) string {
 
 func addTxPoolMetric(txObj *TxObject, delta int64) {
 	metricTxPoolGauge().AddWithLabel(delta, map[string]string{
-		"source": txMetricSource(txObj),
+		"source": string(txObj.source),
 		"type":   txMetricType(txObj.Transaction),
-		"status": txMetricStatus(txObj),
+		"status": txMetricStatus(txObj.executable.Load()),
 	})
 }
 
 func countWashedTx(txObj *TxObject) {
 	metricTxPoolWashedCounter().AddWithLabel(1, map[string]string{
-		"source": txMetricSource(txObj),
+		"source": string(txObj.source),
 		"type":   txMetricType(txObj.Transaction),
 	})
 }

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -229,13 +229,13 @@ func (p *TxPool) SubscribeTxEvent(ch chan *TxEvent) event.Subscription {
 }
 
 func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmitted bool) (err error) {
-	source := "local"
-	if !localSubmitted {
-		source = "remote"
+	source := txSourceRemote
+	if localSubmitted {
+		source = txSourceLocal
 	}
 	defer func() {
 		if err != nil {
-			metricBadTxGauge().AddWithLabel(1, map[string]string{"source": source})
+			metricBadTxGauge().AddWithLabel(1, map[string]string{"source": string(source)})
 		}
 	}()
 
@@ -252,14 +252,14 @@ func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmi
 		return nil
 	}
 
-	txObj, err := ResolveTx(newTx, localSubmitted)
+	txObj, err := resolveTxWithSource(newTx, source)
 	if err != nil {
 		return badTxError{err.Error()}
 	}
 
 	headSummary := p.repo.BestBlockSummary()
 	if isChainSynced(uint64(time.Now().Unix()), headSummary.Header.Timestamp()) {
-		err = p.addWhenSynced(newTx, txObj, headSummary, rejectNonExecutable, localSubmitted)
+		err = p.addWhenSynced(newTx, txObj, headSummary, rejectNonExecutable)
 	} else {
 		err = p.addWhenNotSynced(newTx, txObj)
 	}
@@ -319,7 +319,6 @@ func (p *TxPool) addWhenSynced(
 	txObj *TxObject,
 	headSummary *chain.BlockSummary,
 	rejectNonExecutable bool,
-	localSubmitted bool,
 ) error {
 	state := p.stater.NewState(headSummary.Root())
 	executable, err := txObj.Executable(
@@ -334,7 +333,7 @@ func (p *TxPool) addWhenSynced(
 	}
 
 	// Check pool limits and priority for remote transactions
-	if !localSubmitted {
+	if !txObj.localSubmitted() {
 		if p.all.Len() >= p.options.Limit*15/10 {
 			return txRejectedError{"pool is full"}
 		} else if p.all.Len() >= p.options.Limit*12/10 {

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -154,7 +154,7 @@ func (p *TxPool) housekeeping() {
 					// from the same wash, so both reflect the consistent state
 					// that wash observed (not affected by concurrent Adds).
 					metricTxPoolExecutablesGauge().Set(int64(len(executables)))
-					metricTxPoolAllGauge().Set(int64(poolLen - removedLegacy - removedDynamicFee))
+					metricTxPoolAllGauge().Set(int64(poolLen - removed))
 				}
 
 				logger.Trace("wash done", ctx...)

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -157,12 +157,6 @@ func (p *TxPool) housekeeping() {
 					metricTxPoolAllGauge().Set(int64(poolLen - removedLegacy - removedDynamicFee))
 				}
 
-				if removedLegacy > 0 {
-					metricTxPoolGauge().AddWithLabel(0-int64(removedLegacy), map[string]string{"source": "washed", "type": "Legacy"})
-				}
-				if removedDynamicFee > 0 {
-					metricTxPoolGauge().AddWithLabel(0-int64(removedDynamicFee), map[string]string{"source": "washed", "type": "DynamicFee"})
-				}
 				logger.Trace("wash done", ctx...)
 			}
 		}
@@ -274,12 +268,7 @@ func (p *TxPool) add(newTx *tx.Transaction, rejectNonExecutable bool, localSubmi
 	}
 
 	atomic.AddUint32(&p.addedAfterWash, 1)
-
-	txTypeString := "Legacy"
-	if newTx.Type() == tx.TypeDynamicFee {
-		txTypeString = "DynamicFee"
-	}
-	metricTxPoolGauge().AddWithLabel(1, map[string]string{"source": source, "type": txTypeString})
+	addTxPoolMetric(txObj, 1)
 
 	return nil
 }
@@ -443,13 +432,7 @@ func (p *TxPool) Remove(txHash thor.Bytes32, txID thor.Bytes32) bool {
 		return false
 	}
 	if p.all.RemoveByHash(txHash) {
-		txTypeString := "Unknown"
-		if removedTransaction.Type() == tx.TypeLegacy {
-			txTypeString = "Legacy"
-		} else if removedTransaction.Type() == tx.TypeDynamicFee {
-			txTypeString = "DynamicFee"
-		}
-		metricTxPoolGauge().AddWithLabel(-1, map[string]string{"source": "n/a", "type": txTypeString})
+		addTxPoolMetric(removedTransaction, -1)
 		logger.Debug("tx removed", "id", txID)
 		return true
 	}
@@ -472,11 +455,13 @@ func (p *TxPool) Fill(txs tx.Transactions) {
 			continue
 		}
 		// here we ignore errors
-		if txObj, err := ResolveTx(tx, false); err == nil {
+		if txObj, err := resolveTxWithSource(tx, false, txSourceFill); err == nil {
 			txObjs = append(txObjs, txObj)
 		}
 	}
-	p.all.Fill(txObjs)
+	for _, txObj := range p.all.Fill(txObjs) {
+		addTxPoolMetric(txObj, 1)
+	}
 }
 
 // Dump dumps all txs in the pool.
@@ -504,20 +489,26 @@ func (p *TxPool) wash(
 				if len(all)-i <= p.options.Limit {
 					break
 				}
-				if txObj.Type() == tx.TypeLegacy {
-					removedLegacy++
-				} else if txObj.Type() == tx.TypeDynamicFee {
-					removedDynamicFee++
+				if p.all.RemoveByHash(txObj.Hash()) {
+					addTxPoolMetric(txObj, -1)
+					countWashedTx(txObj)
+					if txObj.Type() == tx.TypeLegacy {
+						removedLegacy++
+					} else if txObj.Type() == tx.TypeDynamicFee {
+						removedDynamicFee++
+					}
 				}
-				p.all.RemoveByHash(txObj.Hash())
 			}
 		} else {
 			for _, txObj := range toRemove {
-				p.all.RemoveByHash(txObj.Hash())
-				if txObj.Type() == tx.TypeLegacy {
-					removedLegacy++
-				} else if txObj.Type() == tx.TypeDynamicFee {
-					removedDynamicFee++
+				if p.all.RemoveByHash(txObj.Hash()) {
+					addTxPoolMetric(txObj, -1)
+					countWashedTx(txObj)
+					if txObj.Type() == tx.TypeLegacy {
+						removedLegacy++
+					} else if txObj.Type() == tx.TypeDynamicFee {
+						removedDynamicFee++
+					}
 				}
 			}
 		}
@@ -660,7 +651,11 @@ func (p *TxPool) wash(
 				logger.Trace("tx washed out", "id", obj.ID(), "err", "insufficient energy for overall pending cost")
 				continue
 			}
+			// removes the non-executable tx from the pool
+			addTxPoolMetric(obj, -1)
 			obj.executable = true
+			// re-counts the same tx as executable
+			addTxPoolMetric(obj, 1)
 			p.all.UpdatePendingCost(obj)
 			toBroadcast = append(toBroadcast, obj.Transaction)
 		} else if obj.localSubmitted {
@@ -707,4 +702,41 @@ func isChainSynced(nowTimestamp, blockTimestamp uint64) bool {
 		timeDiff = blockTimestamp - nowTimestamp
 	}
 	return timeDiff < thor.BlockInterval()*6
+}
+
+func txMetricType(trx *tx.Transaction) string {
+	switch trx.Type() {
+	case tx.TypeLegacy:
+		return "Legacy"
+	case tx.TypeDynamicFee:
+		return "DynamicFee"
+	default:
+		return "Unknown"
+	}
+}
+
+func txMetricSource(txObj *TxObject) string {
+	return string(txObj.source)
+}
+
+func txMetricStatus(txObj *TxObject) string {
+	if txObj.executable {
+		return "executable"
+	}
+	return "non_executable"
+}
+
+func addTxPoolMetric(txObj *TxObject, delta int64) {
+	metricTxPoolGauge().AddWithLabel(delta, map[string]string{
+		"source": txMetricSource(txObj),
+		"type":   txMetricType(txObj.Transaction),
+		"status": txMetricStatus(txObj),
+	})
+}
+
+func countWashedTx(txObj *TxObject) {
+	metricTxPoolWashedCounter().AddWithLabel(1, map[string]string{
+		"source": txMetricSource(txObj),
+		"type":   txMetricType(txObj.Transaction),
+	})
 }

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -455,7 +455,7 @@ func (p *TxPool) Fill(txs tx.Transactions) {
 			continue
 		}
 		// here we ignore errors
-		if txObj, err := resolveTxWithSource(tx, false, txSourceFill); err == nil {
+		if txObj, err := resolveTxWithSource(tx, txSourceFill); err == nil {
 			txObjs = append(txObjs, txObj)
 		}
 	}
@@ -558,7 +558,7 @@ func (p *TxPool) wash(
 		}
 
 		// out of lifetime
-		if !txObj.localSubmitted && now > txObj.timeAdded+int64(p.options.MaxLifetime) {
+		if !txObj.localSubmitted() && now > txObj.timeAdded+int64(p.options.MaxLifetime) {
 			toRemove = append(toRemove, txObj)
 			logger.Trace("tx washed out", "id", txObj.ID(), "err", "out of lifetime")
 			continue
@@ -584,13 +584,13 @@ func (p *TxPool) wash(
 		}
 
 		if executable {
-			if txObj.localSubmitted {
+			if txObj.localSubmitted() {
 				localExecutableObjs = append(localExecutableObjs, txObj)
 			} else {
 				executableObjs = append(executableObjs, txObj)
 			}
 		} else {
-			if !txObj.localSubmitted {
+			if !txObj.localSubmitted() {
 				nonExecutableObjs = append(nonExecutableObjs, txObj)
 			}
 		}
@@ -652,7 +652,7 @@ func (p *TxPool) wash(
 			addTxPoolMetric(obj, 1)
 			p.all.UpdatePendingCost(obj)
 			toBroadcast = append(toBroadcast, obj.Transaction)
-		} else if obj.localSubmitted {
+		} else if obj.localSubmitted() {
 			// broadcast local submitted even it's already executable
 			toBroadcast = append(toBroadcast, obj.Transaction)
 		}

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -355,7 +355,7 @@ func (p *TxPool) addWhenSynced(
 		}
 	}
 
-	txObj.executable.Store(executable)
+	txObj.executable = executable
 	if err := p.all.Add(txObj, p.options.LimitPerAccount, func(payer thor.Address, needs *big.Int) error {
 		// check payer's balance
 		balance, err := builtin.Energy.Native(state, headSummary.Header.Timestamp()+thor.BlockInterval()).Get(payer)
@@ -636,7 +636,7 @@ func (p *TxPool) wash(
 
 	for _, obj := range executableObjs {
 		// the tx was not executable previously: validate payer energy before promoting
-		if !obj.executable.Load() {
+		if !obj.executable {
 			payer := *obj.Payer()
 			needs := new(big.Int).Add(p.all.PendingCostOf(payer), obj.Cost())
 			energy, err := builtin.Energy.Native(newState(), headSummary.Header.Timestamp()+thor.BlockInterval()).Get(payer)
@@ -647,7 +647,7 @@ func (p *TxPool) wash(
 			}
 			// removes the non-executable tx from the pool
 			addTxPoolMetric(obj, -1)
-			obj.executable.Store(true)
+			obj.executable = true
 			// re-counts the same tx as executable
 			addTxPoolMetric(obj, 1)
 			p.all.UpdatePendingCost(obj)
@@ -720,7 +720,7 @@ func addTxPoolMetric(txObj *TxObject, delta int64) {
 	metricTxPoolGauge().AddWithLabel(delta, map[string]string{
 		"source": string(txObj.source),
 		"type":   txMetricType(txObj.Transaction),
-		"status": txMetricStatus(txObj.executable.Load()),
+		"status": txMetricStatus(txObj.executable),
 	})
 }
 

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -115,6 +115,87 @@ func newHTTPServer() *httptest.Server {
 	return server
 }
 
+func gatherMetricFamily(t *testing.T, name string) *dto.MetricFamily {
+	t.Helper()
+
+	gatherers := prometheus.Gatherers{prometheus.DefaultGatherer}
+	metricFamilies, err := gatherers.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range metricFamilies {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	return nil
+}
+
+func gaugeValueByLabels(mf *dto.MetricFamily, labels map[string]string) (float64, bool) {
+	for _, m := range mf.GetMetric() {
+		matched := true
+		for key, want := range labels {
+			found := false
+			for _, label := range m.GetLabel() {
+				if label.GetName() == key {
+					found = true
+					if label.GetValue() != want {
+						matched = false
+					}
+					break
+				}
+			}
+			if !found {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return m.GetGauge().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+func counterValueByLabels(mf *dto.MetricFamily, labels map[string]string) (float64, bool) {
+	if mf == nil {
+		return 0, false
+	}
+	for _, m := range mf.GetMetric() {
+		matched := true
+		for key, want := range labels {
+			found := false
+			for _, label := range m.GetLabel() {
+				if label.GetName() == key {
+					found = true
+					if label.GetValue() != want {
+						matched = false
+					}
+					break
+				}
+			}
+			if !found {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return m.GetCounter().GetValue(), true
+		}
+	}
+	return 0, false
+}
+
+func hasLabelValue(mf *dto.MetricFamily, name string, value string) bool {
+	for _, m := range mf.GetMetric() {
+		for _, label := range m.GetLabel() {
+			if label.GetName() == name && label.GetValue() == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestTxPoolMetrics(t *testing.T) {
 	metrics.InitializePrometheusMetrics()
 
@@ -133,24 +214,8 @@ func TestTxPoolMetrics(t *testing.T) {
 	err = pool.Add(tx3)
 	assert.Equal(t, "tx rejected: expired", err.Error())
 
-	gatherers := prometheus.Gatherers{prometheus.DefaultGatherer}
-	metricFamilies, err := gatherers.Gather()
-	require.NoError(t, err)
-
-	var txPoolMetric *dto.MetricFamily
-	var badTxMetric *dto.MetricFamily
-	for _, mf := range metricFamilies {
-		println("metric", mf.GetName())
-		if mf.GetName() == "thor_metrics_txpool_current_tx_count" {
-			txPoolMetric = mf
-			continue
-		}
-		if mf.GetName() == "thor_metrics_bad_tx_count" {
-			badTxMetric = mf
-			continue
-		}
-	}
-
+	txPoolMetric := gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
+	badTxMetric := gatherMetricFamily(t, "thor_metrics_bad_tx_count")
 	require.NotNil(t, txPoolMetric, "txpool_current_tx_count metric should exist")
 	require.NotNil(t, badTxMetric, "bad_tx_count metric should exist")
 
@@ -159,25 +224,13 @@ func TestTxPoolMetrics(t *testing.T) {
 	badTxMetrics := badTxMetric.GetMetric()
 	require.Greater(t, len(badTxMetrics), 0, "should have at least one metric entry")
 
-	foundLegacy := false
-	for _, m := range metrics {
-		labels := m.GetLabel()
-		source := ""
-		txType := ""
-		for _, label := range labels {
-			if label.GetName() == "source" {
-				source = label.GetValue()
-			}
-			if label.GetName() == "type" {
-				txType = label.GetValue()
-			}
-		}
-
-		if source == "remote" && txType == "Legacy" {
-			foundLegacy = true
-			assert.Equal(t, float64(1), m.GetGauge().GetValue())
-		}
-	}
+	value, foundLegacy := gaugeValueByLabels(txPoolMetric, map[string]string{
+		"source": "remote",
+		"type":   "Legacy",
+		"status": "executable",
+	})
+	require.True(t, foundLegacy, "should have metric entry for executable remote Legacy transaction")
+	assert.Equal(t, float64(1), value)
 
 	foundBad := false
 	for _, m := range badTxMetrics {
@@ -195,8 +248,64 @@ func TestTxPoolMetrics(t *testing.T) {
 		}
 	}
 
-	assert.True(t, foundLegacy, "should have metric entry for Legacy transaction")
 	assert.True(t, foundBad, "should have metric entry for bad Legacy transaction")
+	assert.False(t, hasLabelValue(txPoolMetric, "source", "washed"))
+	assert.False(t, hasLabelValue(txPoolMetric, "source", "n/a"))
+
+	removed := pool.Remove(tx1.Hash(), tx1.ID())
+	require.True(t, removed)
+
+	txPoolMetric = gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
+	value, foundLegacy = gaugeValueByLabels(txPoolMetric, map[string]string{
+		"source": "remote",
+		"type":   "Legacy",
+		"status": "executable",
+	})
+	require.True(t, foundLegacy, "removed tx metric entry should still exist after zeroing")
+	assert.Equal(t, float64(0), value)
+	assert.False(t, hasLabelValue(txPoolMetric, "source", "n/a"))
+
+	tx4 := newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[1])
+	require.NoError(t, pool.Add(tx4))
+	washCounterMetric := gatherMetricFamily(t, "thor_metrics_txpool_washed_tx_count")
+	beforeWashCount, _ := counterValueByLabels(washCounterMetric, map[string]string{
+		"source": "remote",
+		"type":   "Legacy",
+	})
+	pool.options.MaxLifetime = 0
+	_, washedLegacy, washedDynamicFee, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	require.NoError(t, err)
+	require.Equal(t, 1, washedLegacy+washedDynamicFee)
+
+	txPoolMetric = gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
+	value, foundLegacy = gaugeValueByLabels(txPoolMetric, map[string]string{
+		"source": "remote",
+		"type":   "Legacy",
+		"status": "executable",
+	})
+	require.True(t, foundLegacy, "washed tx metric entry should still exist after zeroing")
+	assert.Equal(t, float64(0), value)
+	assert.False(t, hasLabelValue(txPoolMetric, "source", "washed"))
+
+	washCounterMetric = gatherMetricFamily(t, "thor_metrics_txpool_washed_tx_count")
+	afterWashCount, foundWashed := counterValueByLabels(washCounterMetric, map[string]string{
+		"source": "remote",
+		"type":   "Legacy",
+	})
+	require.True(t, foundWashed, "should have washed tx counter for remote Legacy transaction")
+	assert.Equal(t, beforeWashCount+1, afterWashCount)
+
+	tx5 := newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[2])
+	pool.Fill(tx.Transactions{tx5})
+
+	txPoolMetric = gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
+	value, foundLegacy = gaugeValueByLabels(txPoolMetric, map[string]string{
+		"source": "fill",
+		"type":   "Legacy",
+		"status": "non_executable",
+	})
+	require.True(t, foundLegacy, "should have metric entry for filled Legacy transaction")
+	assert.Equal(t, float64(1), value)
 }
 
 func TestNewCloseWithServer(t *testing.T) {

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -272,7 +272,8 @@ func TestTxPoolMetrics(t *testing.T) {
 		"source": "remote",
 		"type":   "Legacy",
 	})
-	pool.options.MaxLifetime = 0
+	tx4Obj := pool.all.mapByID[tx4.ID()]
+	tx4Obj.timeAdded -= int64(pool.options.MaxLifetime) * 2
 	_, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
 	require.NoError(t, err)
 	require.Equal(t, 1, washed)

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -273,9 +273,9 @@ func TestTxPoolMetrics(t *testing.T) {
 		"type":   "Legacy",
 	})
 	pool.options.MaxLifetime = 0
-	_, washedLegacy, washedDynamicFee, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	_, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
 	require.NoError(t, err)
-	require.Equal(t, 1, washedLegacy+washedDynamicFee)
+	require.Equal(t, 1, washed)
 
 	txPoolMetric = gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
 	value, foundLegacy = gaugeValueByLabels(txPoolMetric, map[string]string{
@@ -602,7 +602,7 @@ func TestWashTxs(t *testing.T) {
 	pool := newPool(1, LIMIT_PER_ACCOUNT, &thor.NoFork)
 	defer pool.Close()
 
-	txs, _, _, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	txs, _, err := pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	assert.Zero(t, len(txs))
 	assert.Zero(t, len(pool.Executables()))
@@ -610,7 +610,7 @@ func TestWashTxs(t *testing.T) {
 	tx1 := newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[0])
 	assert.Nil(t, pool.AddLocal(tx1)) // this tx won't participate in the wash out.
 
-	txs, _, _, err = pool.wash(pool.repo.BestBlockSummary(), false)
+	txs, _, err = pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	assert.Equal(t, tx.Transactions{tx1}, txs)
 
@@ -626,7 +626,7 @@ func TestWashTxs(t *testing.T) {
 		Build()
 	pool.repo.AddBlock(b1, nil, 0, false)
 
-	txs, _, _, err = pool.wash(pool.repo.BestBlockSummary(), false)
+	txs, _, err = pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	assert.Equal(t, tx.Transactions{tx1}, txs)
 
@@ -638,10 +638,10 @@ func TestWashTxs(t *testing.T) {
 	txObj3, _ := ResolveTx(tx3, false)
 	assert.Nil(t, pool.all.Add(txObj3, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })) // this tx will participate in the wash out.
 
-	txs, removedLegacy, removedDynamicFee, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	txs, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(txs))
-	assert.Equal(t, 1, removedLegacy+removedDynamicFee)
+	assert.Equal(t, 1, washed)
 }
 
 func TestOrderTxsAfterGalacticaFork(t *testing.T) {
@@ -685,9 +685,9 @@ func TestOrderTxsAfterGalacticaFork(t *testing.T) {
 		assert.Nil(t, pool.Add(tx))
 	}
 
-	execTxs, removedLegacy, removedDynamicFee, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	execTxs, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
-	assert.Zero(t, removedLegacy+removedDynamicFee)
+	assert.Zero(t, washed)
 	assert.Equal(t, len(txs), len(execTxs))
 	assert.Equal(t, poolLimit-2, len(execTxs))
 	for i := 1; i < len(txs); i++ {
@@ -720,9 +720,9 @@ func TestOrderTxsAfterGalacticaFork(t *testing.T) {
 	assert.Nil(t, pool.Add(firstTx))
 	assert.Nil(t, pool.Add(lastTx))
 
-	execTxs, removedLegacy, removedDynamicFee, err = pool.wash(pool.repo.BestBlockSummary(), false)
+	execTxs, washed, err = pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
-	assert.Zero(t, removedLegacy+removedDynamicFee)
+	assert.Zero(t, washed)
 	assert.Equal(t, poolLimit, len(execTxs))
 	assert.Equal(t, execTxs[0].ID(), firstTx.ID())
 	assert.Equal(t, execTxs[len(execTxs)-1].ID(), lastTx.ID())
@@ -769,9 +769,9 @@ func TestOrderTxsAfterGalacticaForkSameValues(t *testing.T) {
 		assert.Nil(t, pool.Add(tx))
 	}
 
-	execTxs, removedLegacy, removedDynamicFee, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	execTxs, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
-	assert.Zero(t, removedLegacy+removedDynamicFee)
+	assert.Zero(t, washed)
 	assert.Equal(t, len(txs), len(execTxs))
 	assert.Equal(t, totalPoolTxs, len(execTxs))
 	for i := 1; i < len(txs); i++ {
@@ -828,7 +828,7 @@ func TestFillPool(t *testing.T) {
 	assert.Equal(t, len(txs), pool.all.Len(), "Number of transactions in the pool should match the number added")
 
 	// Test executables after wash
-	executables, _, _, _ := pool.wash(pool.repo.BestBlockSummary(), false)
+	executables, _, _ := pool.wash(pool.repo.BestBlockSummary(), false)
 	pool.executables.Store(executables)
 	assert.Equal(t, len(txs), len(pool.Executables()), "Number of transactions in the pool should match the number added")
 }
@@ -889,7 +889,7 @@ func TestFillPoolWithMixedTxs(t *testing.T) {
 	assert.Equal(t, len(txs), pool.all.Len(), "Number of transactions in the pool should match the number added")
 
 	// Test executables after wash
-	executables, _, _, _ := pool.wash(pool.repo.BestBlockSummary(), false)
+	executables, _, _ := pool.wash(pool.repo.BestBlockSummary(), false)
 	pool.executables.Store(executables)
 	assert.Equal(t, len(txs), len(pool.Executables()), "Number of transactions in the pool should match the number added")
 }
@@ -1134,7 +1134,7 @@ func TestNonExecutables(t *testing.T) {
 		)
 	}
 
-	executables, _, _, _ := pool.wash(pool.repo.BestBlockSummary(), false)
+	executables, _, _ := pool.wash(pool.repo.BestBlockSummary(), false)
 	pool.executables.Store(executables)
 
 	// add 1 non-executable
@@ -1155,23 +1155,23 @@ func TestExpiredTxs(t *testing.T) {
 		)
 	}
 
-	executables, _, _, _ := pool.wash(pool.repo.BestBlockSummary(), false)
+	executables, _, _ := pool.wash(pool.repo.BestBlockSummary(), false)
 	pool.executables.Store(executables)
 
 	// add 1 non-executable
 	assert.NoError(t, pool.Add(newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, &thor.Bytes32{1}, tx.Features(0), devAccounts[2])))
 
-	executables, washedLegacy, washedDynamicFee, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	executables, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	assert.Equal(t, 90, len(executables))
-	assert.Equal(t, 0, washedLegacy+washedDynamicFee)
+	assert.Equal(t, 0, washed)
 	assert.Equal(t, 91, pool.all.Len())
 
 	time.Sleep(3 * time.Second)
-	executables, washedLegacy, washedDynamicFee, err = pool.wash(pool.repo.BestBlockSummary(), false)
+	executables, washed, err = pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(executables))
-	assert.Equal(t, 91, washedLegacy+washedDynamicFee)
+	assert.Equal(t, 91, washed)
 	assert.Equal(t, 0, pool.all.Len())
 }
 
@@ -1437,7 +1437,7 @@ func TestWashPriorityGasPriceRecomputation(t *testing.T) {
 	err := pool.add(trx, false, false)
 	assert.Nil(t, err)
 
-	_, _, _, err = pool.wash(pool.repo.BestBlockSummary(), true)
+	_, _, err = pool.wash(pool.repo.BestBlockSummary(), true)
 	assert.Nil(t, err)
 
 	txObj := pool.all.GetByID(trx.ID())
@@ -1449,7 +1449,7 @@ func TestWashPriorityGasPriceRecomputation(t *testing.T) {
 	wrongPriorityGasPrice := new(big.Int).Mul(initialPriorityGasPrice, big.NewInt(999))
 	txObj.priorityGasPrice = wrongPriorityGasPrice
 
-	_, _, _, err = pool.wash(pool.repo.BestBlockSummary(), false)
+	_, _, err = pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	txObj = pool.all.GetByID(trx.ID())
 	assert.NotNil(t, txObj)
@@ -1480,7 +1480,7 @@ func TestWashPriorityGasPriceRecomputation(t *testing.T) {
 	}
 
 	// Test 3: Wash with new block that has different baseFee should recompute priorityGasPrice
-	_, _, _, err = pool.wash(pool.repo.BestBlockSummary(), true)
+	_, _, err = pool.wash(pool.repo.BestBlockSummary(), true)
 	assert.Nil(t, err)
 	txObj = pool.all.GetByID(trx.ID())
 	assert.NotNil(t, txObj)
@@ -1883,7 +1883,7 @@ func TestWashDeferredTxPendingCostEnforcement(t *testing.T) {
 		Build()
 	require.NoError(t, repo.AddBlock(b2, tx.Receipts{}, 0, true))
 
-	executables, _, _, err := pool.wash(repo.BestBlockSummary(), true)
+	executables, _, err := pool.wash(repo.BestBlockSummary(), true)
 	require.NoError(t, err)
 
 	promoted := 0
@@ -2077,10 +2077,133 @@ func TestTxPool_Local_IncreasingPriority(t *testing.T) {
 	// The wash method should keep the 10 highest priority transactions (6-15)
 	// and evict the 5 lowest priority ones (1-5).
 	pool.options.Limit = 10
-	executables, _, _, err := pool.wash(pool.repo.BestBlockSummary(), true)
+	executables, _, err := pool.wash(pool.repo.BestBlockSummary(), true)
 	assert.NoError(t, err)
 
 	for _, tx := range executables {
 		assert.Greater(t, tx.MaxPriorityFeePerGas().Int64(), int64(5*multiplier))
 	}
+}
+
+func TestWashMetricsOverLimit(t *testing.T) {
+	metrics.InitializePrometheusMetrics()
+
+	pool := newPool(LIMIT, LIMIT_PER_ACCOUNT, &thor.NoFork)
+	defer pool.Close()
+
+	// Snapshot all relevant metric values before mutating anything.
+	preGauge := gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
+	beforeExec, _ := gaugeValueByLabels(preGauge, map[string]string{
+		"source": "fill", "type": "Legacy", "status": "executable",
+	})
+	beforeNonExec, _ := gaugeValueByLabels(preGauge, map[string]string{
+		"source": "fill", "type": "Legacy", "status": "non_executable",
+	})
+	preCounter := gatherMetricFamily(t, "thor_metrics_txpool_washed_tx_count")
+	beforeWashed, _ := counterValueByLabels(preCounter, map[string]string{
+		"source": "fill", "type": "Legacy",
+	})
+
+	// Stage LIMIT+2 executable txs via Fill, which bypasses the remote
+	// pool-full check. Fill marks every tx with source="fill" and leaves
+	// executable=false; wash() then re-evaluates and they all land in
+	// executableObjs (not localExecutableObjs, since Fill sets
+	// localSubmitted=false), so they are subject to the limit branch.
+	const overflow = LIMIT + 2
+	fills := make(tx.Transactions, 0, overflow)
+	for i := range overflow {
+		fills = append(fills, newTx(
+			tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000,
+			tx.BlockRef{}, 100, nil, tx.Features(0),
+			devAccounts[i%len(devAccounts)],
+		))
+	}
+	pool.Fill(fills)
+	require.Equal(t, overflow, pool.all.Len())
+
+	_, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	require.NoError(t, err)
+	assert.Equal(t, overflow-LIMIT, washed)
+	assert.Equal(t, LIMIT, pool.all.Len())
+
+	postCounter := gatherMetricFamily(t, "thor_metrics_txpool_washed_tx_count")
+	afterWashed, ok := counterValueByLabels(postCounter, map[string]string{
+		"source": "fill", "type": "Legacy",
+	})
+	require.True(t, ok, "wash counter must exist for filled Legacy txs")
+	assert.Equal(t, float64(overflow-LIMIT), afterWashed-beforeWashed,
+		"wash counter must record one increment per evicted tx")
+
+	postGauge := gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
+	afterExec, ok := gaugeValueByLabels(postGauge, map[string]string{
+		"source": "fill", "type": "Legacy", "status": "executable",
+	})
+	require.True(t, ok)
+	assert.Equal(t, float64(LIMIT), afterExec-beforeExec,
+		"executable gauge must gain exactly LIMIT after over-limit wash")
+
+	afterNonExec, _ := gaugeValueByLabels(postGauge, map[string]string{
+		"source": "fill", "type": "Legacy", "status": "non_executable",
+	})
+	assert.Equal(t, float64(0), afterNonExec-beforeNonExec,
+		"non_executable gauge must net to zero (all fills promoted or evicted)")
+
+	// No washed/n/a labels should ever appear on the gauge.
+	assert.False(t, hasLabelValue(postGauge, "source", "washed"))
+	assert.False(t, hasLabelValue(postGauge, "source", "n/a"))
+}
+
+func TestWashMetricsNonExecutableLimit(t *testing.T) {
+	metrics.InitializePrometheusMetrics()
+
+	pool := newPool(LIMIT, LIMIT_PER_ACCOUNT, &thor.NoFork)
+	defer pool.Close()
+
+	preGauge := gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
+	beforeNonExec, _ := gaugeValueByLabels(preGauge, map[string]string{
+		"source": "fill", "type": "Legacy", "status": "non_executable",
+	})
+	preCounter := gatherMetricFamily(t, "thor_metrics_txpool_washed_tx_count")
+	beforeWashed, _ := counterValueByLabels(preCounter, map[string]string{
+		"source": "fill", "type": "Legacy",
+	})
+
+	// Non-executable cap = Limit*20%. Stage one extra to force the third
+	// wash branch (no over-limit, no mixed over-limit, just non-exec over cap).
+	nonExecCap := pool.options.Limit * 2 / 10
+	overflow := nonExecCap + 1
+
+	// Future block ref makes the tx valid but non-executable
+	// (Executable returns (false, nil) when BlockRef > nextBlockNum).
+	fills := make(tx.Transactions, 0, overflow)
+	for i := range overflow {
+		fills = append(fills, newTx(
+			tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000,
+			tx.NewBlockRef(2), 100, nil, tx.Features(0),
+			devAccounts[i%len(devAccounts)],
+		))
+	}
+	pool.Fill(fills)
+	require.Equal(t, overflow, pool.all.Len())
+
+	_, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
+	require.NoError(t, err)
+	assert.Equal(t, overflow-nonExecCap, washed,
+		"only the over-cap non-executable txs should be evicted")
+	assert.Equal(t, nonExecCap, pool.all.Len())
+
+	postCounter := gatherMetricFamily(t, "thor_metrics_txpool_washed_tx_count")
+	afterWashed, ok := counterValueByLabels(postCounter, map[string]string{
+		"source": "fill", "type": "Legacy",
+	})
+	require.True(t, ok)
+	assert.Equal(t, float64(overflow-nonExecCap), afterWashed-beforeWashed)
+
+	postGauge := gatherMetricFamily(t, "thor_metrics_txpool_current_tx_count")
+	afterNonExec, ok := gaugeValueByLabels(postGauge, map[string]string{
+		"source": "fill", "type": "Legacy", "status": "non_executable",
+	})
+	require.True(t, ok)
+	assert.Equal(t, float64(nonExecCap), afterNonExec-beforeNonExec,
+		"non_executable gauge delta must equal what stayed under the cap")
 }


### PR DESCRIPTION
## Description

This updates txpool metrics so `txpool_current_tx_count` represents the current pool contents by `source`, `type`, and `status`, instead of mixing add/remove deltas with synthetic sources like `washed` or `n/a`. 

Txs now track their source explicitly — `local`, `remote`, or `fill` — and their status (`executable` / `non_executable`) is reflected on the gauge label. 

Wash removals decrement the current-count gauge using the removed tx's real labels and also increment a separate `txpool_washed_tx_count{source,type}` counter. 

`TxObject.executable` is now `atomic.Bool` so the metric helper can read it safely from concurrent `Remove` and `wash` paths. 

The internal `wash()` return surface is collapsed to a single `removed int`; the per-type breakdown now lives only on the counter. 

## NOTE — Backward-incompatible changes

Dashboards / alerts:

- `txpool_current_tx_count` gains a new `status` label (`executable` | `non_executable`). Existing grafana queries that sums or groups the gauge must use `sum without(status)` to reproduce the old totals; otherwise series will double-count or appear as separate rows.
- `source="washed"` and `source="n/a"` are no longer emitted on `txpool_current_tx_count`. Any panel or alert filtering on those values will go silent. The per-source/per-type wash rate now lives on the new `txpool_washed_tx_count{source,type}` counter — switch wash dashboards to `rate(txpool_washed_tx_count[...])`.
- Filled (sync-replayed) txs now report `source="fill"` instead of `source="remote"`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
