### PR TITLE
replace latest with master gosec action

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Run Gosec
         id: gosec-run
         continue-on-error: true
-        uses: securego/gosec@latest # zizmor: ignore[unpinned-uses]
+        uses: securego/gosec@master # zizmor: ignore[unpinned-uses]
         with:
           args: '-exclude=G104,G115,G304,G406,G507 -exclude-dir=builtin/gen ./...'
 


### PR DESCRIPTION
# Description

The gosec action was failing because of: 

> Error: Unable to resolve action `securego/gosec@latest`, unable to find version `latest`

https://github.com/vechain/thor/actions/runs/26443766511/job/77844648619

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
