### PR TITLE
FeeHistory rpc method support `reward percentiles` parameter

### DIFF
--- a/rpc/fees/handler.go
+++ b/rpc/fees/handler.go
@@ -7,7 +7,9 @@ package fees
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
+	"sort"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -61,9 +63,8 @@ func (h *Handler) ethFeeHistory(req jsonrpc.Request) jsonrpc.Response {
 		return jsonrpc.ErrResponse(req.ID, jsonrpc.CodeInvalidParams, err.Error())
 	}
 
-	// Reward percentiles are not yet supported.
-	if len(params.RewardPercentiles) > 0 {
-		return jsonrpc.ErrResponse(req.ID, jsonrpc.CodeServerError, "reward percentiles are not yet supported")
+	if err := validateRewardPercentiles(params.RewardPercentiles); err != nil {
+		return jsonrpc.ErrResponse(req.ID, jsonrpc.CodeInvalidParams, err.Error())
 	}
 
 	if params.BlockCount == 0 {
@@ -88,6 +89,10 @@ func (h *Handler) ethFeeHistory(req jsonrpc.Request) jsonrpc.Response {
 
 	baseFees := make([]*hexutil.Big, 0, params.BlockCount+1)
 	gasUsedRatios := make([]float64, 0, params.BlockCount)
+	var rewards [][]*hexutil.Big
+	if len(params.RewardPercentiles) > 0 {
+		rewards = make([][]*hexutil.Big, 0, params.BlockCount)
+	}
 
 	for n := oldestNum; n <= newestNum; n++ {
 		hdr, err := bestChain.GetBlockHeader(uint32(n))
@@ -101,16 +106,25 @@ func (h *Handler) ethFeeHistory(req jsonrpc.Request) jsonrpc.Response {
 			baseFees = append(baseFees, (*hexutil.Big)(new(big.Int).Set(bf)))
 		}
 
-		// gasUsedRatio counts only TypeEthDynamicFee gas so Ethereum tooling sees
-		// ETH-typed block utilisation, not VeChain legacy tx activity.
+		// gasUsedRatio and reward percentiles count only TypeEthDynamicFee gas so
+		// Ethereum tooling sees ETH-typed block utilisation and priority fees, not
+		// VeChain legacy tx activity.
 		receipts, err := h.repo.GetBlockReceipts(hdr.ID())
 		if err != nil {
 			return jsonrpc.ErrResponse(req.ID, jsonrpc.CodeInternalError, err.Error())
 		}
 		var ethGasUsed uint64
+		var rewardItems []rewardItem
 		for _, r := range receipts {
-			if r.Type == tx.TypeEthDynamicFee {
-				ethGasUsed += r.GasUsed
+			if r.Type != tx.TypeEthDynamicFee {
+				continue
+			}
+			ethGasUsed += r.GasUsed
+			if rewards != nil && r.GasUsed > 0 {
+				rewardItems = append(rewardItems, rewardItem{
+					reward:  new(big.Int).Div(r.Reward, new(big.Int).SetUint64(r.GasUsed)),
+					gasUsed: r.GasUsed,
+				})
 			}
 		}
 		ratio := 0.0
@@ -118,6 +132,10 @@ func (h *Handler) ethFeeHistory(req jsonrpc.Request) jsonrpc.Response {
 			ratio = float64(ethGasUsed) / float64(hdr.GasLimit())
 		}
 		gasUsedRatios = append(gasUsedRatios, ratio)
+
+		if rewards != nil {
+			rewards = append(rewards, calcRewardPercentiles(rewardItems, ethGasUsed, params.RewardPercentiles))
+		}
 	}
 
 	// Compute the true next-block baseFee using the consensus formula.
@@ -131,5 +149,62 @@ func (h *Handler) ethFeeHistory(req jsonrpc.Request) jsonrpc.Response {
 		OldestBlock:   hexutil.Uint64(oldestNum),
 		BaseFeePerGas: baseFees,
 		GasUsedRatio:  gasUsedRatios,
+		Reward:        rewards,
 	})
+}
+
+// maxRewardPercentiles caps the number of reward percentiles per request.
+const maxRewardPercentiles = 100
+
+// rewardItem is a single ETH-typed tx's effective priority fee per gas and its gas used.
+type rewardItem struct {
+	reward  *big.Int
+	gasUsed uint64
+}
+
+// validateRewardPercentiles enforces that percentiles are within [0, 100], in
+// ascending order, and no more than maxRewardPercentiles entries.
+func validateRewardPercentiles(percentiles []float64) error {
+	if len(percentiles) > maxRewardPercentiles {
+		return fmt.Errorf("there can be at most %d reward percentiles", maxRewardPercentiles)
+	}
+	for i, p := range percentiles {
+		if p < 0 || p > 100 {
+			return fmt.Errorf("reward percentile %f is invalid, must be between 0 and 100", p)
+		}
+		if i > 0 && p < percentiles[i-1] {
+			return fmt.Errorf("reward percentiles must be in ascending order, but %f is less than %f", p, percentiles[i-1])
+		}
+	}
+	return nil
+}
+
+// calcRewardPercentiles returns, for each requested percentile, the effective
+// priority fee per gas of the ETH-typed tx at that cumulative-gas threshold.
+// items must already be filtered to ETH-typed txs; totalGasUsed is their summed
+// gas. Blocks with no ETH-typed txs yield a zero for every percentile.
+func calcRewardPercentiles(items []rewardItem, totalGasUsed uint64, percentiles []float64) []*hexutil.Big {
+	rewards := make([]*hexutil.Big, len(percentiles))
+	if len(items) == 0 {
+		for i := range rewards {
+			rewards[i] = (*hexutil.Big)(new(big.Int))
+		}
+		return rewards
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].reward.Cmp(items[j].reward) < 0
+	})
+
+	txIndex := 0
+	cumulativeGasUsed := items[0].gasUsed
+	for i, p := range percentiles {
+		thresholdGasUsed := uint64(float64(totalGasUsed) * p / 100)
+		for cumulativeGasUsed < thresholdGasUsed && txIndex < len(items)-1 {
+			txIndex++
+			cumulativeGasUsed += items[txIndex].gasUsed
+		}
+		rewards[i] = (*hexutil.Big)(new(big.Int).Set(items[txIndex].reward))
+	}
+	return rewards
 }

--- a/rpc/fees/handler_test.go
+++ b/rpc/fees/handler_test.go
@@ -78,13 +78,90 @@ func TestFeesHandler(t *testing.T) {
 		assert.NotNil(t, rpcErr)
 	})
 
-	t.Run("eth_feeHistory_reward_percentiles_unsupported", func(t *testing.T) {
-		// Non-empty rewardPercentiles must return a server error rather than silently
-		// returning an empty reward array.
-		rpcErr := testutil.CallExpectError(t, ts, "eth_feeHistory", []any{1, "latest", []float64{25, 50, 75}})
-		assert.NotNil(t, rpcErr)
-		assert.Contains(t, rpcErr.Message, "reward percentiles are not yet supported")
+	t.Run("eth_feeHistory_reward_percentiles", func(t *testing.T) {
+		// Block 1 from the fixture is empty, so reward is present with one entry
+		// per block and one value per requested percentile, all zero.
+		result := testutil.Call(t, ts, "eth_feeHistory", []any{1, "latest", []float64{25, 50, 75}})
+		var fh map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(result, &fh))
+
+		var rewards [][]*hexutil.Big
+		require.NoError(t, json.Unmarshal(fh["reward"], &rewards))
+		require.Len(t, rewards, 1)
+		require.Len(t, rewards[0], 3)
+		for _, r := range rewards[0] {
+			assert.Equal(t, 0, r.ToInt().Sign())
+		}
 	})
+
+	t.Run("eth_feeHistory_no_reward_when_percentiles_empty", func(t *testing.T) {
+		// Omitting rewardPercentiles must omit the reward field entirely.
+		result := testutil.Call(t, ts, "eth_feeHistory", []any{1, "latest", []any{}})
+		var fh map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(result, &fh))
+		_, present := fh["reward"]
+		assert.False(t, present)
+	})
+
+	t.Run("eth_feeHistory_invalid_reward_percentiles", func(t *testing.T) {
+		// Descending percentiles are invalid.
+		rpcErr := testutil.CallExpectError(t, ts, "eth_feeHistory", []any{1, "latest", []float64{75, 25}})
+		assert.NotNil(t, rpcErr)
+	})
+}
+
+// TestFeeHistoryRewardPercentiles verifies that reward percentiles reflect the
+// effective priority fee per gas of ETH-typed txs in the block.
+func TestFeeHistoryRewardPercentiles(t *testing.T) {
+	c, err := testchain.NewDefault()
+	require.NoError(t, err)
+
+	sender := genesis.DevAccounts()[0]
+	recipient := genesis.DevAccounts()[1]
+
+	ethTx := testutil.BuildEthTx(t, c.Repo().ChainID(), sender, 0, &recipient.Address)
+	require.NoError(t, c.MintBlock(ethTx))
+
+	ts := testutil.NewTestServer(t, fees.New(c.Repo(), 100, &testchain.DefaultForkConfig))
+
+	result := testutil.Call(t, ts, "eth_feeHistory", []any{1, "latest", []float64{50}})
+	var fh map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result, &fh))
+
+	var rewards [][]*hexutil.Big
+	require.NoError(t, json.Unmarshal(fh["reward"], &rewards))
+	require.Len(t, rewards, 1)
+	require.Len(t, rewards[0], 1)
+	assert.True(t, rewards[0][0].ToInt().Sign() > 0,
+		"ETH-typed tx priority fee must be reflected in reward")
+}
+
+// TestFeeHistoryRewardEthOnly verifies that reward percentiles, like gasUsedRatio,
+// count only TypeEthDynamicFee gas and ignore VeChain legacy tx priority fees.
+func TestFeeHistoryRewardEthOnly(t *testing.T) {
+	c, err := testchain.NewDefault()
+	require.NoError(t, err)
+
+	sender := genesis.DevAccounts()[0]
+	recipient := genesis.DevAccounts()[1]
+
+	// Mint a block containing only a VeChain legacy tx. It pays a priority fee at
+	// the block level but is not ETH-typed, so it must not affect reward.
+	vcTx := testutil.BuildVcTx(t, c, sender, &recipient.Address)
+	require.NoError(t, c.MintBlock(vcTx))
+
+	ts := testutil.NewTestServer(t, fees.New(c.Repo(), 100, &testchain.DefaultForkConfig))
+
+	result := testutil.Call(t, ts, "eth_feeHistory", []any{1, "latest", []float64{50}})
+	var fh map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(result, &fh))
+
+	var rewards [][]*hexutil.Big
+	require.NoError(t, json.Unmarshal(fh["reward"], &rewards))
+	require.Len(t, rewards, 1)
+	require.Len(t, rewards[0], 1)
+	assert.Equal(t, 0, rewards[0][0].ToInt().Sign(),
+		"VeChain legacy tx priority fee must not contribute to reward")
 }
 
 // TestFeeHistoryGasUsedRatioEthOnly verifies that gasUsedRatio counts only

--- a/rpc/fees_types.go
+++ b/rpc/fees_types.go
@@ -51,8 +51,10 @@ func (p *FeeHistoryParams) UnmarshalJSON(data []byte) error {
 }
 
 // FeeHistoryResult is the response type for eth_feeHistory.
+// Reward is omitted when no reward percentiles were requested.
 type FeeHistoryResult struct {
-	OldestBlock   hexutil.Uint64 `json:"oldestBlock"`
-	BaseFeePerGas []*hexutil.Big `json:"baseFeePerGas"`
-	GasUsedRatio  []float64      `json:"gasUsedRatio"`
+	OldestBlock   hexutil.Uint64   `json:"oldestBlock"`
+	BaseFeePerGas []*hexutil.Big   `json:"baseFeePerGas"`
+	GasUsedRatio  []float64        `json:"gasUsedRatio"`
+	Reward        [][]*hexutil.Big `json:"reward,omitempty"`
 }


### PR DESCRIPTION
# Description

FeeHistory rpc method support `reward percentiles` parameter

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
