### PR TITLE
txpool: improve tx pricing logic and simplify re-pricing logic

### DIFF
--- a/cmd/thor/solo/core.go
+++ b/cmd/thor/solo/core.go
@@ -164,5 +164,6 @@ func (c *Core) IsExecutable(trx *tx.Transaction) (bool, error) {
 		return false, errors.WithMessage(err, "resolve transaction")
 	}
 
-	return txObject.Executable(chain, state, best.Header, c.forkConfig, baseFee)
+	executable, _, err := txObject.Evaluate(chain, state, best.Header, c.forkConfig, baseFee, false)
+	return executable, err
 }

--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -8,6 +8,7 @@ package txpool
 import (
 	"math/big"
 	"slices"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -28,20 +29,27 @@ const (
 	txSourceFill   txSource = "fill"
 )
 
+type txPricing struct {
+	payer *thor.Address // payer of the tx, either origin, delegator, or on-chain delegation payer
+	cost  *big.Int      // total tx cost the payer needs to pay before execution(gas price * gas)
+
+	// basic unit of tip price for the validator, before GALACTICA it's the overallGasPrice(provedWork included) and validator
+	// gets <reward-ratio>% of the tip, after GALACTICA it's the effective priority fee per gas and validator gets 100% of the tip
+	priorityGasPrice *big.Int
+}
+
 type TxObject struct {
 	*tx.Transaction
 	resolved *runtime.ResolvedTransaction
 
 	timeAdded int64
-	source    txSource      // where the tx came from: local, remote or fill.
-	payer     *thor.Address // payer of the tx, either origin, delegator, or on-chain delegation payer
-	cost      *big.Int      // total tx cost the payer needs to pay before execution(gas price * gas)
+	source    txSource // where the tx came from: local, remote or fill.
 
-	// basic unit of tip price for the validator, before GALACTICA it's the overallGasPrice(provedWork included) and validator
-	// gets <reward-ratio>% of the tip, after GALACTICA it's the effective priority fee per gas and validator gets 100% of the tip
-	priorityGasPrice *big.Int
+	// pricing is published lock-free via an atomic snapshot, so payer/cost/priorityGasPrice
+	// always move together.
+	pricing atomic.Pointer[txPricing]
 
-	executable bool // don't touch this value, will be updated by the pool
+	executable bool // written ONLY under txObjectMap.lock; serves as the accounting gate
 }
 
 func ResolveTx(tx *tx.Transaction, localSubmitted bool) (*TxObject, error) {
@@ -79,29 +87,49 @@ func (o *TxObject) Delegator() *thor.Address {
 }
 
 func (o *TxObject) Cost() *big.Int {
-	return o.cost
+	if p := o.pricing.Load(); p != nil {
+		return p.cost
+	}
+	return nil
 }
 
 func (o *TxObject) Payer() *thor.Address {
-	return o.payer
+	if p := o.pricing.Load(); p != nil {
+		return p.payer
+	}
+	return nil
 }
 
-func (o *TxObject) Executable(chain *chain.Chain, state *state.State, headBlock *block.Header, forkConfig *thor.ForkConfig, baseFee *big.Int) (bool, error) {
+func (o *TxObject) priorityGasPrice() *big.Int {
+	if p := o.pricing.Load(); p != nil {
+		return p.priorityGasPrice
+	}
+	return nil
+}
+
+func (o *TxObject) setPricing(p *txPricing) { o.pricing.Store(p) }
+
+// Evaluate performs a side-effect-free evaluation; it never mutates o. When the tx is
+// executable and was not alreadyExecutable, it returns a non-nil pricing snapshot for the
+// caller to publish via setPricing; otherwise pricing is nil.
+func (o *TxObject) Evaluate(
+	chain *chain.Chain, state *state.State, headBlock *block.Header, forkConfig *thor.ForkConfig, baseFee *big.Int, alreadyExecutable bool,
+) (bool, *txPricing, error) {
 	// evaluate the tx on the next block as head block is already history
 	nextBlockNum := headBlock.Number() + 1
 	nextBlockTime := headBlock.Timestamp() + thor.BlockInterval()
 
 	switch {
 	case o.Gas() > headBlock.GasLimit():
-		return false, errors.New("tx gas exceeds block gas limit")
-	case o.IsExpired(nextBlockNum): // Check tx expiration on top of next block
-		return false, errors.New("expired")
+		return false, nil, errors.New("tx gas exceeds block gas limit")
+	case o.IsExpired(nextBlockNum):
+		return false, nil, errors.New("expired")
 	case o.BlockRef().Number() > nextBlockNum+uint32(5*60/thor.BlockInterval()):
 		// reject deferred tx which will be applied after 5mins
-		return false, errors.New("block ref out of schedule")
+		return false, nil, errors.New("block ref out of schedule")
 	case nextBlockNum < forkConfig.GALACTICA && o.Type() != tx.TypeLegacy:
 		// reject non legacy tx before GALACTICA
-		return false, tx.ErrTxTypeNotSupported
+		return false, nil, tx.ErrTxTypeNotSupported
 	}
 
 	// test features on next block
@@ -110,31 +138,31 @@ func (o *TxObject) Executable(chain *chain.Chain, state *state.State, headBlock 
 		features.SetDelegated(true)
 	}
 	if err := o.TestFeatures(features); err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	if has, err := chain.HasTransaction(o.ID(), o.BlockRef().Number()); err != nil {
-		return false, err
+		return false, nil, err
 	} else if has {
-		return false, errors.New("known tx")
+		return false, nil, errors.New("known tx")
 	}
 
 	if dep := o.DependsOn(); dep != nil {
 		txMeta, err := chain.GetTransactionMeta(*dep)
 		if err != nil {
 			if chain.IsNotFound(err) {
-				return false, nil
+				return false, nil, nil
 			}
-			return false, err
+			return false, nil, err
 		}
 		if txMeta.Reverted {
-			return false, errors.New("dep reverted")
+			return false, nil, errors.New("dep reverted")
 		}
 	}
 
 	// Tx is considered executable when the BlockRef has passed in reference to the next block.
 	if o.BlockRef().Number() > nextBlockNum {
-		return false, nil
+		return false, nil, nil
 	}
 
 	checkpoint := state.NewCheckpoint()
@@ -142,32 +170,34 @@ func (o *TxObject) Executable(chain *chain.Chain, state *state.State, headBlock 
 
 	legacyTxBaseGasPrice, _, payer, prepaid, _, err := o.resolved.BuyGas(state, nextBlockTime, baseFee)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
-	// non executable -> executable, update payer, cost and priority gas price
-	if !o.executable {
-		o.payer = &payer
-		o.cost = prepaid
-
-		// calculate the priority gas price
-		provedWork, err := o.ProvedWork(nextBlockNum, chain.GetBlockID)
-		if err != nil {
-			return false, err
-		}
-		// normalize the base fee here, set to 0 to make the func EffectivePriorityFeePerGas return overallGasPrice for before GALACTICA txs
-		// before GALACTICA, the baseFeeCache.Get will return nil just like the Header.BaseFee
-		if baseFee == nil {
-			baseFee = big.NewInt(0)
-		}
-		o.priorityGasPrice = o.EffectivePriorityFeePerGas(baseFee, legacyTxBaseGasPrice, provedWork)
+	if alreadyExecutable {
+		return true, nil, nil
 	}
-	return true, nil
+
+	// non executable -> executable: compute payer, cost and priority gas price
+	provedWork, err := o.ProvedWork(nextBlockNum, chain.GetBlockID)
+	if err != nil {
+		return false, nil, err
+	}
+	// normalize the base fee here, set to 0 to make the func EffectivePriorityFeePerGas return overallGasPrice for before GALACTICA txs
+	// before GALACTICA, the baseFeeCache.Get will return nil just like the Header.BaseFee
+	if baseFee == nil {
+		baseFee = big.NewInt(0)
+	}
+
+	return true, &txPricing{
+		payer:            &payer,
+		cost:             prepaid,
+		priorityGasPrice: o.EffectivePriorityFeePerGas(baseFee, legacyTxBaseGasPrice, provedWork),
+	}, nil
 }
 
 func sortTxObjsByPriorityGasPriceDesc(txObjs []*TxObject) {
 	slices.SortFunc(txObjs, func(a, b *TxObject) int {
-		if cmp := b.priorityGasPrice.Cmp(a.priorityGasPrice); cmp != 0 {
+		if cmp := b.priorityGasPrice().Cmp(a.priorityGasPrice()); cmp != 0 {
 			return cmp
 		}
 		if a.timeAdded < b.timeAdded {

--- a/txpool/tx_object.go
+++ b/txpool/tx_object.go
@@ -36,6 +36,12 @@ type txPricing struct {
 	// basic unit of tip price for the validator, before GALACTICA it's the overallGasPrice(provedWork included) and validator
 	// gets <reward-ratio>% of the tip, after GALACTICA it's the effective priority fee per gas and validator gets 100% of the tip
 	priorityGasPrice *big.Int
+
+	// base-fee-independent ceilings, cached so priorityGasPrice can be refreshed by pure
+	// arithmetic on a base-fee change (no ProvedWork / chain lookup). legacy: both equal
+	// OverallGasPrice(with provedWork); dynamic-fee: MaxFeePerGas / MaxPriorityFeePerGas.
+	feeCeiling      *big.Int
+	priorityCeiling *big.Int
 }
 
 type TxObject struct {
@@ -188,11 +194,56 @@ func (o *TxObject) Evaluate(
 		baseFee = big.NewInt(0)
 	}
 
+	var feeCeiling, priorityCeiling *big.Int
+	if o.Type() == tx.TypeLegacy {
+		ogp := o.OverallGasPrice(legacyTxBaseGasPrice, provedWork)
+		feeCeiling, priorityCeiling = ogp, ogp
+	} else {
+		feeCeiling, priorityCeiling = o.MaxFeePerGas(), o.MaxPriorityFeePerGas()
+	}
+	// pgp = min(feeCeiling - baseFee, priorityCeiling), equivalent to EffectivePriorityFeePerGas
+	pgp := new(big.Int).Sub(feeCeiling, baseFee)
+	if pgp.Cmp(priorityCeiling) > 0 {
+		pgp.Set(priorityCeiling)
+	}
 	return true, &txPricing{
 		payer:            &payer,
 		cost:             prepaid,
-		priorityGasPrice: o.EffectivePriorityFeePerGas(baseFee, legacyTxBaseGasPrice, provedWork),
+		priorityGasPrice: pgp,
+		feeCeiling:       feeCeiling,
+		priorityCeiling:  priorityCeiling,
 	}, nil
+}
+
+// refreshPriorityGasPrice recomputes priorityGasPrice for a base-fee change using the
+// cached base-fee-independent ceilings — no ProvedWork / chain lookup. For legacy txs,
+// once the proved work has expired (head advanced past refNum+MaxTxWorkDelay), the ceiling
+// drops to the no-work overall gas price, which is derived arithmetically (provedWork = 0).
+func (o *TxObject) refreshPriorityGasPrice(baseFee, legacyTxBaseGasPrice *big.Int, nextBlockNum uint32) {
+	cur := o.pricing.Load()
+	if cur == nil {
+		return
+	}
+	feeCeiling, priorityCeiling := cur.feeCeiling, cur.priorityCeiling
+	if feeCeiling == nil || priorityCeiling == nil {
+		return
+	}
+	// legacy proved-work expiry is a block-number event, independent of baseFee.
+	if o.Type() == tx.TypeLegacy && nextBlockNum-o.BlockRef().Number() > thor.MaxTxWorkDelay {
+		noWork := o.OverallGasPrice(legacyTxBaseGasPrice, new(big.Int)) // provedWork = 0, no chain access
+		feeCeiling, priorityCeiling = noWork, noWork
+	}
+	pgp := new(big.Int).Sub(feeCeiling, baseFee)
+	if pgp.Cmp(priorityCeiling) > 0 {
+		pgp.Set(priorityCeiling)
+	}
+	o.setPricing(&txPricing{
+		payer:            cur.payer,
+		cost:             cur.cost,
+		priorityGasPrice: pgp,
+		feeCeiling:       cur.feeCeiling, // keep the work-included ceilings cached
+		priorityCeiling:  cur.priorityCeiling,
+	})
 }
 
 func sortTxObjsByPriorityGasPriceDesc(txObjs []*TxObject) {

--- a/txpool/tx_object_map.go
+++ b/txpool/tx_object_map.go
@@ -39,7 +39,10 @@ func (m *txObjectMap) ContainsHash(txHash thor.Bytes32) bool {
 	return found
 }
 
-func (m *txObjectMap) Add(txObj *TxObject, limitPerAccount int, validatePayer func(payer thor.Address, needs *big.Int) error) error {
+func (m *txObjectMap) Add(
+	txObj *TxObject, executable bool, pricing *txPricing,
+	limitPerAccount int, validatePayer func(payer thor.Address, needs *big.Int) error,
+) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -52,7 +55,6 @@ func (m *txObjectMap) Add(txObj *TxObject, limitPerAccount int, validatePayer fu
 		metricAccountQuotaExceeded().AddWithLabel(1, map[string]string{"type": "account"})
 		return errors.New("account quota exceeded")
 	}
-
 	delegator := txObj.Delegator()
 	if delegator != nil {
 		if m.quota[*delegator] >= limitPerAccount {
@@ -61,21 +63,23 @@ func (m *txObjectMap) Add(txObj *TxObject, limitPerAccount int, validatePayer fu
 		}
 	}
 
+	if pricing != nil {
+		txObj.setPricing(pricing)
+	}
+	txObj.executable = executable // executable written under the lock
+
 	var (
 		cost  *big.Int
 		payer thor.Address
 	)
-
-	if txObj.Cost() != nil {
+	if executable && txObj.Cost() != nil {
 		payer = *txObj.Payer()
 		pending := m.cost[payer]
-
 		if pending == nil {
 			cost = new(big.Int).Set(txObj.Cost())
 		} else {
 			cost = new(big.Int).Add(pending, txObj.Cost())
 		}
-
 		if err := validatePayer(payer, cost); err != nil {
 			return err
 		}
@@ -85,11 +89,9 @@ func (m *txObjectMap) Add(txObj *TxObject, limitPerAccount int, validatePayer fu
 	if delegator != nil {
 		m.quota[*delegator]++
 	}
-
 	if cost != nil {
 		m.cost[payer] = cost
 	}
-
 	m.mapByHash[hash] = txObj
 	m.mapByID[txObj.ID()] = txObj
 	return nil
@@ -120,13 +122,18 @@ func (m *txObjectMap) RemoveByHash(txHash thor.Bytes32) bool {
 			}
 		}
 
-		// update the pending cost of payers
-		if payer := txObj.Payer(); payer != nil {
-			if pending := m.cost[*payer]; pending != nil {
-				if pending.Cmp(txObj.Cost()) <= 0 {
-					delete(m.cost, *payer)
-				} else {
-					m.cost[*payer] = new(big.Int).Sub(pending, txObj.Cost())
+		// only txs actually accounted (executable, with a committed cost) contribute;
+		// gating on executable (written under this lock) pairs add/sub exactly and never
+		// reads a cost that was not counted.
+		if txObj.executable {
+			if cost := txObj.Cost(); cost != nil {
+				payer := *txObj.Payer()
+				if pending := m.cost[payer]; pending != nil {
+					if pending.Cmp(cost) <= 0 {
+						delete(m.cost, payer)
+					} else {
+						m.cost[payer] = new(big.Int).Sub(pending, cost)
+					}
 				}
 			}
 		}
@@ -147,15 +154,29 @@ func (m *txObjectMap) PendingCostOf(payer thor.Address) *big.Int {
 	return new(big.Int)
 }
 
-func (m *txObjectMap) UpdatePendingCost(txObj *TxObject) {
+// promote marks a pooled tx executable and adds its cost to the payer's pending total,
+// but only if the tx is still present (promote-if-present). Returns false if the tx was
+// already removed. Idempotent for an already-executable tx. Requires the pricing to have
+// been published (via setPricing) beforehand.
+func (m *txObjectMap) promote(txObj *TxObject) bool {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-
-	if pending := m.cost[*txObj.Payer()]; pending != nil {
-		m.cost[*txObj.Payer()] = new(big.Int).Add(pending, txObj.Cost())
-	} else {
-		m.cost[*txObj.Payer()] = new(big.Int).Set(txObj.Cost())
+	if _, ok := m.mapByHash[txObj.Hash()]; !ok {
+		return false
 	}
+	if txObj.executable {
+		return true
+	}
+	txObj.executable = true
+	if cost := txObj.Cost(); cost != nil {
+		payer := *txObj.Payer()
+		if pending := m.cost[payer]; pending != nil {
+			m.cost[payer] = new(big.Int).Add(pending, cost)
+		} else {
+			m.cost[payer] = new(big.Int).Set(cost)
+		}
+	}
+	return true
 }
 
 func (m *txObjectMap) ToTxObjects() []*TxObject {

--- a/txpool/tx_object_map_test.go
+++ b/txpool/tx_object_map_test.go
@@ -34,9 +34,9 @@ func TestGetByID(t *testing.T) {
 
 	// Creating a new txObjectMap and adding transactions
 	m := newTxObjectMap()
-	assert.Nil(t, m.Add(txObj1, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
-	assert.Nil(t, m.Add(txObj2, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
-	assert.Nil(t, m.Add(txObj3, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj1, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj2, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj3, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
 
 	// Testing GetByID
 	retrievedTxObj1 := m.GetByID(txObj1.ID())
@@ -107,14 +107,14 @@ func TestTxObjMap(t *testing.T) {
 	m := newTxObjectMap()
 	assert.Zero(t, m.Len())
 
-	assert.Nil(t, m.Add(txObj1, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
-	assert.Nil(t, m.Add(txObj1, 1, func(_ thor.Address, _ *big.Int) error { return nil }), "should no error if exists")
+	assert.Nil(t, m.Add(txObj1, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj1, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }), "should no error if exists")
 	assert.Equal(t, 1, m.Len())
 
-	assert.Equal(t, errors.New("account quota exceeded"), m.Add(txObj2, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Equal(t, errors.New("account quota exceeded"), m.Add(txObj2, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
 	assert.Equal(t, 1, m.Len())
 
-	assert.Nil(t, m.Add(txObj3, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj3, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
 	assert.Equal(t, 2, m.Len())
 
 	assert.True(t, m.ContainsHash(tx1.Hash()))
@@ -141,13 +141,51 @@ func TestLimitByDelegator(t *testing.T) {
 	txObj3, _ := ResolveTx(tx3, false)
 
 	m := newTxObjectMap()
-	assert.Nil(t, m.Add(txObj1, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
-	assert.Nil(t, m.Add(txObj3, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj1, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj3, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
 
 	m = newTxObjectMap()
-	assert.Nil(t, m.Add(txObj2, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
-	assert.Equal(t, errors.New("delegator quota exceeded"), m.Add(txObj3, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
-	assert.Equal(t, errors.New("account quota exceeded"), m.Add(txObj1, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj2, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Equal(t, errors.New("delegator quota exceeded"), m.Add(txObj3, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Equal(t, errors.New("account quota exceeded"), m.Add(txObj1, false, nil, 1, func(_ thor.Address, _ *big.Int) error { return nil }))
+}
+
+func TestPromoteIfPresentAndRemove(t *testing.T) {
+	tchain, err := testchain.NewWithFork(&thor.SoloFork, 180)
+	assert.Nil(t, err)
+	tchain.MintBlock()
+	repo, stater, forkConfig := tchain.Repo(), tchain.Stater(), tchain.GetForkConfig()
+
+	trx := newTx(tx.TypeLegacy, repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), genesis.DevAccounts()[0])
+	txObj, err := ResolveTx(trx, false)
+	assert.Nil(t, err)
+
+	best := repo.BestBlockSummary()
+	state := stater.NewState(best.Root())
+	baseFee := galactica.CalcBaseFee(best.Header, forkConfig)
+	_, pricing, err := txObj.Evaluate(repo.NewBestChain(), state, best.Header, forkConfig, baseFee, false)
+	assert.Nil(t, err)
+	assert.NotNil(t, pricing)
+
+	m := newTxObjectMap()
+
+	// not in the pool yet: promote returns false and does not account
+	txObj.setPricing(pricing)
+	assert.False(t, m.promote(txObj))
+	assert.Nil(t, m.cost[genesis.DevAccounts()[0].Address])
+
+	// added as non-executable, then promote -> accounted
+	assert.Nil(t, m.Add(txObj, false, nil, 10, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.True(t, m.promote(txObj))
+	assert.Equal(t, txObj.Cost(), m.cost[genesis.DevAccounts()[0].Address])
+
+	// idempotent
+	assert.True(t, m.promote(txObj))
+	assert.Equal(t, txObj.Cost(), m.cost[genesis.DevAccounts()[0].Address])
+
+	// drained to zero after removal
+	assert.True(t, m.RemoveByHash(txObj.Hash()))
+	assert.Nil(t, m.cost[genesis.DevAccounts()[0].Address])
 }
 
 func TestPendingCost(t *testing.T) {
@@ -175,27 +213,24 @@ func TestPendingCost(t *testing.T) {
 	state := stater.NewState(best.Root())
 
 	baseFee := galactica.CalcBaseFee(best.Header, forkConfig)
-	exec1, err := txObj1.Executable(chain, state, best.Header, forkConfig, baseFee)
+	exec1, p1, err := txObj1.Evaluate(chain, state, best.Header, forkConfig, baseFee, false)
 	assert.Nil(t, err)
-	txObj1.executable = exec1
-	assert.True(t, txObj1.executable)
+	assert.True(t, exec1)
 
-	exec2, err := txObj2.Executable(chain, state, best.Header, forkConfig, baseFee)
+	exec2, p2, err := txObj2.Evaluate(chain, state, best.Header, forkConfig, baseFee, false)
 	assert.Nil(t, err)
-	txObj2.executable = exec2
-	assert.True(t, txObj2.executable)
+	assert.True(t, exec2)
 
-	exec3, err := txObj3.Executable(chain, state, best.Header, forkConfig, baseFee)
+	exec3, p3, err := txObj3.Evaluate(chain, state, best.Header, forkConfig, baseFee, false)
 	assert.Nil(t, err)
-	txObj3.executable = exec3
-	assert.True(t, txObj3.executable)
+	assert.True(t, exec3)
 
 	// Creating a new txObjectMap
 	m := newTxObjectMap()
 
-	m.Add(txObj1, 10, func(_ thor.Address, _ *big.Int) error { return nil })
-	m.Add(txObj2, 10, func(_ thor.Address, _ *big.Int) error { return nil })
-	m.Add(txObj3, 10, func(_ thor.Address, _ *big.Int) error { return nil })
+	assert.Nil(t, m.Add(txObj1, true, p1, 10, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj2, true, p2, 10, func(_ thor.Address, _ *big.Int) error { return nil }))
+	assert.Nil(t, m.Add(txObj3, true, p3, 10, func(_ thor.Address, _ *big.Int) error { return nil }))
 
 	assert.Equal(t, txObj1.Cost(), m.cost[genesis.DevAccounts()[0].Address])
 	// No cost for txObj2's origin, should be counted on the delegator

--- a/txpool/tx_object_test.go
+++ b/txpool/tx_object_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vechain/thor/v2/block"
+	"github.com/vechain/thor/v2/builtin"
 	"github.com/vechain/thor/v2/chain"
 	"github.com/vechain/thor/v2/consensus/upgrade/galactica"
 	"github.com/vechain/thor/v2/genesis"
@@ -63,6 +64,34 @@ func newDelegatedTx(
 		from.PrivateKey,
 		delegator.PrivateKey,
 	)
+}
+
+// mineLegacyTxWithWork builds and signs a legacy tx whose UnprovedWork() is at least
+// minWork. UnprovedWork() = MaxBig256/hash(txFields, nonce) is unpredictable from the
+// fields alone, so this brute-forces the nonce until the threshold is met. hashWithoutNonce
+// (and therefore the search) does not depend on the nonce field, so a single unsigned
+// builder can be reused across candidate nonces.
+func mineLegacyTxWithWork(
+	t *testing.T,
+	chainTag byte,
+	blockRef tx.BlockRef,
+	expiration uint32,
+	from genesis.DevAccount,
+	minWork *big.Int,
+) *tx.Transaction {
+	t.Helper()
+
+	builder := txBuilder(tx.TypeLegacy, chainTag, nil, 21000, blockRef, expiration, nil, tx.Features(0))
+	evalWork := builder.Build().EvaluateWork(from.Address)
+
+	const maxAttempts = 20_000_000
+	for nonce := uint64(0); nonce < maxAttempts; nonce++ {
+		if evalWork(nonce).Cmp(minWork) >= 0 {
+			return tx.MustSign(builder.Nonce(nonce).Build(), from.PrivateKey)
+		}
+	}
+	t.Fatalf("failed to mine a legacy tx nonce with work >= %v within %d attempts", minWork, maxAttempts)
+	return nil
 }
 
 func txBuilder(
@@ -283,12 +312,12 @@ func TestEvaluateAndPricingSnapshot(t *testing.T) {
 	assert.True(t, executable)
 	assert.NotNil(t, pricing)
 
-	// Evaluate 未发布,访问器仍为 nil
+	// Evaluate did not publish, so accessors still return nil
 	assert.Nil(t, txObj.Cost())
 	assert.Nil(t, txObj.Payer())
 	assert.Nil(t, txObj.priorityGasPrice())
 
-	// 发布后访问器读到快照
+	// after publishing, accessors read the snapshot
 	txObj.setPricing(pricing)
 	assert.Equal(t, pricing.cost, txObj.Cost())
 	assert.Equal(t, pricing.payer, txObj.Payer())
@@ -335,4 +364,83 @@ func TestExecutableRejectUnsupportedFeatures(t *testing.T) {
 		false,
 	)
 	assert.Nil(t, err)
+}
+
+func TestBaseFeeRefreshMatchesCanonical(t *testing.T) {
+	tchain, err := testchain.NewWithFork(&thor.SoloFork, 180)
+	assert.Nil(t, err)
+	tchain.MintBlock()
+	repo, stater, forkConfig := tchain.Repo(), tchain.Stater(), tchain.GetForkConfig()
+	best := repo.BestBlockSummary()
+	state := stater.NewState(best.Root())
+	chain := repo.NewBestChain()
+
+	// legacyTxBaseGasPrice must match the value Evaluate bakes into the cached legacy
+	// ceiling (the on-chain governance param), otherwise the oracle would be fed a
+	// different lbgp than the cache and legacy comparisons would be meaningless.
+	lbgp, err := builtin.Params.Native(state).Get(thor.KeyLegacyTxBaseGasPrice)
+	assert.Nil(t, err)
+	nextBlockNum := best.Header.Number() + 1
+
+	for _, txType := range []tx.Type{tx.TypeLegacy, tx.TypeDynamicFee} {
+		// For legacy txs, use a block ref that prefix-matches a real on-chain block
+		// (the best block itself) so ProvedWork returns a nonzero UnprovedWork() within
+		// the work window, exercising the work-included ceiling rather than always
+		// comparing no-work to no-work (see tx.TestProvedWork for the ProvedWork
+		// prefix-match semantics this relies on).
+		var trx *tx.Transaction
+		if txType == tx.TypeLegacy {
+			blockRef := tx.NewBlockRefFromID(best.Header.ID())
+			// A raw nonzero UnprovedWork() is not enough: workToGas() divides by
+			// workPerGas(=1000) and floors, so a "nonzero" work below that threshold
+			// still yields wgas=0 and collapses back to the no-work ceiling. Mine a
+			// nonce with comfortably large work so the work-included branch of
+			// OverallGasPrice actually kicks in.
+			trx = mineLegacyTxWithWork(t, repo.ChainTag(), blockRef, 100, genesis.DevAccounts()[0], big.NewInt(50000))
+		} else {
+			trx = newTx(txType, repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), genesis.DevAccounts()[0])
+		}
+		txObj, err := ResolveTx(trx, false)
+		assert.Nil(t, err)
+
+		baseFee0 := galactica.CalcBaseFee(best.Header, forkConfig)
+		_, pricing, err := txObj.Evaluate(chain, state, best.Header, forkConfig, baseFee0, false)
+		assert.Nil(t, err)
+		assert.NotNil(t, pricing)
+		txObj.setPricing(pricing)
+
+		provedWork, err := txObj.ProvedWork(nextBlockNum, chain.GetBlockID)
+		assert.Nil(t, err)
+		if txType == tx.TypeLegacy {
+			assert.Equal(t, 1, provedWork.Sign(), "legacy provedWork must be nonzero to exercise the work-included ceiling")
+		}
+
+		// At multiple baseFees, the refresh result must equal the canonical
+		// EffectivePriorityFeePerGas computed with the (possibly nonzero) provedWork.
+		for _, bf := range []*big.Int{big.NewInt(0), big.NewInt(1), new(big.Int).Set(baseFee0), new(big.Int).Mul(baseFee0, big.NewInt(3))} {
+			txObj.refreshPriorityGasPrice(bf, lbgp, nextBlockNum)
+			want := txObj.EffectivePriorityFeePerGas(bf, lbgp, provedWork)
+			assert.Equal(t, 0, want.Cmp(txObj.priorityGasPrice()), "type=%v baseFee=%v", txType, bf)
+		}
+
+		// Capture the non-expired (work-included, for legacy) ceiling at baseFee0.
+		txObj.refreshPriorityGasPrice(baseFee0, lbgp, nextBlockNum)
+		nonExpiredPGP := new(big.Int).Set(txObj.priorityGasPrice())
+		wantNonExpired := txObj.EffectivePriorityFeePerGas(baseFee0, lbgp, provedWork)
+		assert.Equal(t, 0, wantNonExpired.Cmp(nonExpiredPGP), "type=%v non-expired", txType)
+
+		// Once the proved work expires (head advances past refNum+MaxTxWorkDelay), the
+		// legacy ceiling must drop to the no-work overall gas price.
+		expiredBlockNum := txObj.BlockRef().Number() + thor.MaxTxWorkDelay + 1
+		txObj.refreshPriorityGasPrice(baseFee0, lbgp, expiredBlockNum)
+		expiredPGP := txObj.priorityGasPrice()
+		wantExpired := txObj.EffectivePriorityFeePerGas(baseFee0, lbgp, new(big.Int)) // provedWork=0
+		assert.Equal(t, 0, wantExpired.Cmp(expiredPGP), "type=%v expired", txType)
+
+		if txType == tx.TypeLegacy {
+			// The work-included and no-work ceilings must actually differ, proving the
+			// work->no-work transition (not no-work->no-work) is what's being observed.
+			assert.NotEqual(t, 0, nonExpiredPGP.Cmp(expiredPGP), "type=%v non-expired and expired legacy pgp must differ", txType)
+		}
+	}
 }

--- a/txpool/tx_object_test.go
+++ b/txpool/tx_object_test.go
@@ -123,7 +123,7 @@ func TestExecutableWithError(t *testing.T) {
 		// pass custom headID
 		chain := repo.NewChain(thor.Bytes32{0})
 
-		exe, err := txObj.Executable(chain, st, b1.Header(), fc, baseFee)
+		exe, _, err := txObj.Evaluate(chain, st, b1.Header(), fc, baseFee, false)
 		if tt.expectedErr != "" {
 			assert.Equal(t, tt.expectedErr, err.Error())
 		} else {
@@ -133,27 +133,33 @@ func TestExecutableWithError(t *testing.T) {
 	}
 }
 
+func newTestTxObj(priorityGasPrice *big.Int, timeAdded int64, payer *thor.Address) *TxObject {
+	o := &TxObject{timeAdded: timeAdded}
+	o.setPricing(&txPricing{priorityGasPrice: priorityGasPrice, payer: payer})
+	return o
+}
+
 func TestSort(t *testing.T) {
 	addr1 := thor.BytesToAddress([]byte("addr1"))
 	addr2 := thor.BytesToAddress([]byte("addr2"))
 	objs := []*TxObject{
-		{priorityGasPrice: big.NewInt(0)},
-		{priorityGasPrice: big.NewInt(10), timeAdded: 20, payer: &addr1},
-		{priorityGasPrice: big.NewInt(10), timeAdded: 3, payer: &addr2},
-		{priorityGasPrice: big.NewInt(20)},
-		{priorityGasPrice: big.NewInt(30)},
+		newTestTxObj(big.NewInt(0), 0, nil),
+		newTestTxObj(big.NewInt(10), 20, &addr1),
+		newTestTxObj(big.NewInt(10), 3, &addr2),
+		newTestTxObj(big.NewInt(20), 0, nil),
+		newTestTxObj(big.NewInt(30), 0, nil),
 	}
 	sortTxObjsByPriorityGasPriceDesc(objs)
 
-	assert.Equal(t, big.NewInt(30), objs[0].priorityGasPrice)
-	assert.Equal(t, big.NewInt(20), objs[1].priorityGasPrice)
-	assert.Equal(t, big.NewInt(10), objs[2].priorityGasPrice)
+	assert.Equal(t, big.NewInt(30), objs[0].priorityGasPrice())
+	assert.Equal(t, big.NewInt(20), objs[1].priorityGasPrice())
+	assert.Equal(t, big.NewInt(10), objs[2].priorityGasPrice())
 	assert.Equal(t, int64(20), objs[2].timeAdded)
-	assert.Equal(t, &addr1, objs[2].payer)
-	assert.Equal(t, big.NewInt(10), objs[3].priorityGasPrice)
+	assert.Equal(t, &addr1, objs[2].Payer())
+	assert.Equal(t, big.NewInt(10), objs[3].priorityGasPrice())
 	assert.Equal(t, int64(3), objs[3].timeAdded)
-	assert.Equal(t, &addr2, objs[3].payer)
-	assert.Equal(t, big.NewInt(0), objs[4].priorityGasPrice)
+	assert.Equal(t, &addr2, objs[3].Payer())
+	assert.Equal(t, big.NewInt(0), objs[4].priorityGasPrice())
 }
 
 func TestResolve(t *testing.T) {
@@ -208,7 +214,7 @@ func TestExecutable(t *testing.T) {
 		txObj, err := ResolveTx(tt.tx, false)
 		assert.Nil(t, err)
 
-		exe, err := txObj.Executable(repo.NewChain(b0.Header().ID()), st, b0.Header(), tchain.GetForkConfig(), baseFee)
+		exe, _, err := txObj.Evaluate(repo.NewChain(b0.Header().ID()), st, b0.Header(), tchain.GetForkConfig(), baseFee, false)
 		if tt.expectedErr != "" {
 			assert.Equal(t, tt.expectedErr, err.Error())
 		} else {
@@ -236,7 +242,7 @@ func TestExecutableRejectNonLegacyBeforeGalactica(t *testing.T) {
 	assert.Nil(t, err)
 
 	st := tchain.Stater().NewState(repo.BestBlockSummary().Root())
-	exe, err := txObj1.Executable(repo.NewBestChain(), st, repo.BestBlockSummary().Header, forkConfig, baseFee)
+	exe, _, err := txObj1.Evaluate(repo.NewBestChain(), st, repo.BestBlockSummary().Header, forkConfig, baseFee, false)
 	assert.False(t, exe)
 	assert.Equal(t, tx.ErrTxTypeNotSupported, err)
 
@@ -244,7 +250,7 @@ func TestExecutableRejectNonLegacyBeforeGalactica(t *testing.T) {
 	txObj2, err := ResolveTx(legacyTx, false)
 	assert.Nil(t, err)
 
-	exe, err = txObj2.Executable(repo.NewBestChain(), st, repo.BestBlockSummary().Header, forkConfig, baseFee)
+	exe, _, err = txObj2.Evaluate(repo.NewBestChain(), st, repo.BestBlockSummary().Header, forkConfig, baseFee, false)
 	assert.True(t, exe)
 	assert.Nil(t, err)
 
@@ -254,8 +260,39 @@ func TestExecutableRejectNonLegacyBeforeGalactica(t *testing.T) {
 	// recalculate the base fee since new block is added
 	baseFee = galactica.CalcBaseFee(repo.BestBlockSummary().Header, forkConfig)
 	st = tchain.Stater().NewState(repo.BestBlockSummary().Root())
-	_, err = txObj1.Executable(repo.NewBestChain(), st, repo.BestBlockSummary().Header, forkConfig, baseFee)
+	_, _, err = txObj1.Evaluate(repo.NewBestChain(), st, repo.BestBlockSummary().Header, forkConfig, baseFee, false)
 	assert.Nil(t, err)
+}
+
+func TestEvaluateAndPricingSnapshot(t *testing.T) {
+	tchain, err := testchain.NewWithFork(&thor.SoloFork, 180)
+	assert.Nil(t, err)
+	tchain.MintBlock()
+	repo, stater, forkConfig := tchain.Repo(), tchain.Stater(), tchain.GetForkConfig()
+
+	trx := newTx(tx.TypeLegacy, repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), genesis.DevAccounts()[0])
+	txObj, err := ResolveTx(trx, false)
+	assert.Nil(t, err)
+
+	best := repo.BestBlockSummary()
+	state := stater.NewState(best.Root())
+	baseFee := galactica.CalcBaseFee(best.Header, forkConfig)
+
+	executable, pricing, err := txObj.Evaluate(repo.NewBestChain(), state, best.Header, forkConfig, baseFee, false)
+	assert.Nil(t, err)
+	assert.True(t, executable)
+	assert.NotNil(t, pricing)
+
+	// Evaluate 未发布,访问器仍为 nil
+	assert.Nil(t, txObj.Cost())
+	assert.Nil(t, txObj.Payer())
+	assert.Nil(t, txObj.priorityGasPrice())
+
+	// 发布后访问器读到快照
+	txObj.setPricing(pricing)
+	assert.Equal(t, pricing.cost, txObj.Cost())
+	assert.Equal(t, pricing.payer, txObj.Payer())
+	assert.Equal(t, pricing.priorityGasPrice, txObj.priorityGasPrice())
 }
 
 func TestExecutableRejectUnsupportedFeatures(t *testing.T) {
@@ -274,12 +311,13 @@ func TestExecutableRejectUnsupportedFeatures(t *testing.T) {
 	assert.Nil(t, err)
 
 	st := tchain.Stater().NewState(repo.BestBlockSummary().Root())
-	exe, err := txObj1.Executable(
+	exe, _, err := txObj1.Evaluate(
 		repo.NewBestChain(),
 		st,
 		repo.BestBlockSummary().Header,
 		forkConfig,
 		galactica.CalcBaseFee(repo.BestBlockSummary().Header, forkConfig),
+		false,
 	)
 	assert.False(t, exe)
 	assert.ErrorContains(t, err, "unsupported features")
@@ -288,12 +326,13 @@ func TestExecutableRejectUnsupportedFeatures(t *testing.T) {
 	tchain.MintBlock()
 
 	st = tchain.Stater().NewState(repo.BestBlockSummary().Root())
-	_, err = txObj1.Executable(
+	_, _, err = txObj1.Evaluate(
 		repo.NewBestChain(),
 		st,
 		repo.BestBlockSummary().Header,
 		forkConfig,
 		galactica.CalcBaseFee(repo.BestBlockSummary().Header, forkConfig),
+		false,
 	)
 	assert.Nil(t, err)
 }

--- a/txpool/tx_object_test.go
+++ b/txpool/tx_object_test.go
@@ -85,7 +85,7 @@ func mineLegacyTxWithWork(
 	evalWork := builder.Build().EvaluateWork(from.Address)
 
 	const maxAttempts = 20_000_000
-	for nonce := uint64(0); nonce < maxAttempts; nonce++ {
+	for nonce := range uint64(maxAttempts) {
 		if evalWork(nonce).Cmp(minWork) >= 0 {
 			return tx.MustSign(builder.Nonce(nonce).Build(), from.PrivateKey)
 		}

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -579,20 +579,7 @@ func (p *TxPool) wash(
 
 		// Only recalculate the priority gas price when the base fee might be changed
 		if needPriorityGasPriceUpdate {
-			nextBlockNum := headSummary.Header.Number() + 1
-			provedWork, err := txObj.ProvedWork(nextBlockNum, chain.GetBlockID)
-			if err != nil {
-				toRemove = append(toRemove, txObj)
-				logger.Trace("tx washed out", "id", txObj.ID(), "err", err)
-				continue
-			}
-			cur := txObj.pricing.Load()
-			pgp := txObj.EffectivePriorityFeePerGas(baseFee, legacyTxBaseGasPrice, provedWork)
-			if cur != nil {
-				txObj.setPricing(&txPricing{payer: cur.payer, cost: cur.cost, priorityGasPrice: pgp})
-			} else {
-				txObj.setPricing(&txPricing{priorityGasPrice: pgp})
-			}
+			txObj.refreshPriorityGasPrice(baseFee, legacyTxBaseGasPrice, headSummary.Header.Number()+1)
 		}
 
 		if executable {

--- a/txpool/tx_pool.go
+++ b/txpool/tx_pool.go
@@ -293,8 +293,8 @@ func (p *TxPool) isBlocked(newTx *tx.Transaction) bool {
 // checkTxPriority checks if the new tx has higher priority than the bottom 10% of existing executable txs.
 // Since executables are sorted descending by price, the threshold at 90th percentile represents
 // the boundary where 90% have higher priority and 10% have lower priority.
-func (p *TxPool) checkTxPriority(txObj *TxObject, executable bool) bool {
-	if !executable {
+func (p *TxPool) checkTxPriority(executable bool, candidatePGP *big.Int) bool {
+	if !executable || candidatePGP == nil {
 		return false
 	}
 
@@ -309,8 +309,11 @@ func (p *TxPool) checkTxPriority(txObj *TxObject, executable bool) bool {
 	if thresholdTxObj == nil {
 		return false
 	}
-
-	return txObj.priorityGasPrice.Cmp(thresholdTxObj.priorityGasPrice) > 0
+	thresholdPGP := thresholdTxObj.priorityGasPrice()
+	if thresholdPGP == nil {
+		return false
+	}
+	return candidatePGP.Cmp(thresholdPGP) > 0
 }
 
 // addWhenSynced handles transaction addition when the chain is synced.
@@ -321,15 +324,17 @@ func (p *TxPool) addWhenSynced(
 	rejectNonExecutable bool,
 ) error {
 	state := p.stater.NewState(headSummary.Root())
-	executable, err := txObj.Executable(
-		p.repo.NewChain(headSummary.Header.ID()),
-		state,
-		headSummary.Header,
-		p.forkConfig,
-		p.baseFeeCache.Get(headSummary.Header),
+	executable, pricing, err := txObj.Evaluate(
+		p.repo.NewChain(headSummary.Header.ID()), state, headSummary.Header,
+		p.forkConfig, p.baseFeeCache.Get(headSummary.Header), false,
 	)
 	if err != nil {
 		return txRejectedError{err.Error()}
+	}
+
+	var candidatePGP *big.Int
+	if pricing != nil {
+		candidatePGP = pricing.priorityGasPrice
 	}
 
 	// Check pool limits and priority for remote transactions
@@ -337,7 +342,7 @@ func (p *TxPool) addWhenSynced(
 		if p.all.Len() >= p.options.Limit*15/10 {
 			return txRejectedError{"pool is full"}
 		} else if p.all.Len() >= p.options.Limit*12/10 {
-			if !p.checkTxPriority(txObj, executable) {
+			if !p.checkTxPriority(executable, candidatePGP) {
 				return txRejectedError{"pool is full"}
 			}
 		}
@@ -354,8 +359,7 @@ func (p *TxPool) addWhenSynced(
 		}
 	}
 
-	txObj.executable = executable
-	if err := p.all.Add(txObj, p.options.LimitPerAccount, func(payer thor.Address, needs *big.Int) error {
+	if err := p.all.Add(txObj, executable, pricing, p.options.LimitPerAccount, func(payer thor.Address, needs *big.Int) error {
 		// check payer's balance
 		balance, err := builtin.Energy.Native(state, headSummary.Header.Timestamp()+thor.BlockInterval()).Get(payer)
 		if err != nil {
@@ -388,7 +392,7 @@ func (p *TxPool) addWhenNotSynced(newTx *tx.Transaction, txObj *TxObject) error 
 	}
 
 	// skip pending cost check when chain is not synced
-	if err := p.all.Add(txObj, p.options.LimitPerAccount, func(_ thor.Address, _ *big.Int) error { return nil }); err != nil {
+	if err := p.all.Add(txObj, false, nil, p.options.LimitPerAccount, func(_ thor.Address, _ *big.Int) error { return nil }); err != nil {
 		return txRejectedError{err.Error()}
 	}
 
@@ -563,11 +567,14 @@ func (p *TxPool) wash(
 			continue
 		}
 		// settled, out of energy or dep broken
-		executable, err := txObj.Executable(chain, newState(), headSummary.Header, p.forkConfig, baseFee)
+		executable, pricing, err := txObj.Evaluate(chain, newState(), headSummary.Header, p.forkConfig, baseFee, txObj.executable)
 		if err != nil {
 			toRemove = append(toRemove, txObj)
 			logger.Trace("tx washed out", "id", txObj.ID(), "err", err)
 			continue
+		}
+		if pricing != nil {
+			txObj.setPricing(pricing) // lock-free publish
 		}
 
 		// Only recalculate the priority gas price when the base fee might be changed
@@ -579,7 +586,13 @@ func (p *TxPool) wash(
 				logger.Trace("tx washed out", "id", txObj.ID(), "err", err)
 				continue
 			}
-			txObj.priorityGasPrice = txObj.EffectivePriorityFeePerGas(baseFee, legacyTxBaseGasPrice, provedWork)
+			cur := txObj.pricing.Load()
+			pgp := txObj.EffectivePriorityFeePerGas(baseFee, legacyTxBaseGasPrice, provedWork)
+			if cur != nil {
+				txObj.setPricing(&txPricing{payer: cur.payer, cost: cur.cost, priorityGasPrice: pgp})
+			} else {
+				txObj.setPricing(&txPricing{priorityGasPrice: pgp})
+			}
 		}
 
 		if executable {
@@ -644,12 +657,15 @@ func (p *TxPool) wash(
 				logger.Trace("tx washed out", "id", obj.ID(), "err", "insufficient energy for overall pending cost")
 				continue
 			}
-			// removes the non-executable tx from the pool
-			addTxPoolMetric(obj, -1)
-			obj.executable = true
-			// re-counts the same tx as executable
-			addTxPoolMetric(obj, 1)
-			p.all.UpdatePendingCost(obj)
+			// the tx moves from non-executable to executable. Reflect the transition in
+			// the gauges around promote, which sets executable and accounts the pending
+			// cost atomically under the map lock (promote-if-present: a tx removed
+			// concurrently is skipped, leaving its removal to account its own -1).
+			addTxPoolMetric(obj, -1) // remove from the non-executable gauge
+			if !p.all.promote(obj) {
+				continue
+			}
+			addTxPoolMetric(obj, 1) // re-count as executable
 			toBroadcast = append(toBroadcast, obj.Transaction)
 		} else if obj.localSubmitted() {
 			// broadcast local submitted even it's already executable

--- a/txpool/tx_pool_benchmark_test.go
+++ b/txpool/tx_pool_benchmark_test.go
@@ -52,7 +52,7 @@ func benchAddRemove(b *testing.B, workers, perWorker int, withWash bool) {
 		go func() {
 			defer close(washDone)
 			for !stopWash.Load() {
-				_, _, _, _ = pool.wash(best, true)
+				_, _, _ = pool.wash(best, true)
 			}
 		}()
 	}

--- a/txpool/tx_pool_benchmark_test.go
+++ b/txpool/tx_pool_benchmark_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2018 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package txpool
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/vechain/thor/v2/thor"
+	"github.com/vechain/thor/v2/tx"
+)
+
+// newBenchPool creates a pool with generous limits so that Add is never
+// rejected due to quota/pool-full; the benchmark only measures the
+// concurrent read/write overhead of Add/Remove(+wash).
+func newBenchPool() *TxPool {
+	return newPool(1_000_000, 1_000_000, &thor.NoFork)
+}
+
+// genBenchTxs pre-signs a batch of transactions with distinct hashes (newTx
+// uses a random nonce, so even the same account yields distinct hashes).
+// Signing is ECDSA and expensive, so it must happen outside the timed region.
+func genBenchTxs(pool *TxPool, n, workerIdx int) []*tx.Transaction {
+	txs := make([]*tx.Transaction, n)
+	for i := 0; i < n; i++ {
+		from := devAccounts[(workerIdx+i)%len(devAccounts)]
+		txs[i] = newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), from)
+	}
+	return txs
+}
+
+func benchAddRemove(b *testing.B, workers, perWorker int, withWash bool) {
+	pool := newBenchPool()
+	defer pool.Close()
+
+	sets := make([][]*tx.Transaction, workers)
+	for w := 0; w < workers; w++ {
+		sets[w] = genBenchTxs(pool, perWorker, w)
+	}
+
+	var (
+		stopWash atomic.Bool
+		washDone chan struct{}
+	)
+	if withWash {
+		best := pool.repo.BestBlockSummary()
+		washDone = make(chan struct{})
+		go func() {
+			defer close(washDone)
+			for !stopWash.Load() {
+				_, _, _, _ = pool.wash(best, true)
+			}
+		}()
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var wg sync.WaitGroup
+	per := b.N / workers
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(set []*tx.Transaction) {
+			defer wg.Done()
+			for i := 0; i < per; i++ {
+				trx := set[i%len(set)]
+				_ = pool.Add(trx)                 // publishes pricing snapshot (atomic Store) + bookkeeping (map lock)
+				pool.Remove(trx.Hash(), trx.ID()) // reads Cost()/Payer() (atomic Load) + bookkeeping (map lock)
+			}
+		}(sets[w])
+	}
+	wg.Wait()
+
+	b.StopTimer()
+	if withWash {
+		stopWash.Store(true)
+		<-washDone
+	}
+}
+
+// BenchmarkPoolConcurrentAddRemove exercises pure concurrent Add/Remove.
+func BenchmarkPoolConcurrentAddRemove(b *testing.B) {
+	benchAddRemove(b, 8, 256, false)
+}
+
+// BenchmarkPoolConcurrentAddRemoveWithWash exercises Add/Remove concurrently
+// with a background wash: this directly stresses the atomic Store (wash
+// publishing pricing) vs. atomic Load (Remove reading pricing) path.
+func BenchmarkPoolConcurrentAddRemoveWithWash(b *testing.B) {
+	benchAddRemove(b, 8, 256, true)
+}

--- a/txpool/tx_pool_benchmark_test.go
+++ b/txpool/tx_pool_benchmark_test.go
@@ -26,7 +26,7 @@ func newBenchPool() *TxPool {
 // Signing is ECDSA and expensive, so it must happen outside the timed region.
 func genBenchTxs(pool *TxPool, n, workerIdx int) []*tx.Transaction {
 	txs := make([]*tx.Transaction, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		from := devAccounts[(workerIdx+i)%len(devAccounts)]
 		txs[i] = newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), from)
 	}
@@ -38,7 +38,7 @@ func benchAddRemove(b *testing.B, workers, perWorker int, withWash bool) {
 	defer pool.Close()
 
 	sets := make([][]*tx.Transaction, workers)
-	for w := 0; w < workers; w++ {
+	for w := range workers {
 		sets[w] = genBenchTxs(pool, perWorker, w)
 	}
 
@@ -62,11 +62,11 @@ func benchAddRemove(b *testing.B, workers, perWorker int, withWash bool) {
 
 	var wg sync.WaitGroup
 	per := b.N / workers
-	for w := 0; w < workers; w++ {
+	for w := range workers {
 		wg.Add(1)
 		go func(set []*tx.Transaction) {
 			defer wg.Done()
-			for i := 0; i < per; i++ {
+			for i := range per {
 				trx := set[i%len(set)]
 				_ = pool.Add(trx)                 // publishes pricing snapshot (atomic Store) + bookkeeping (map lock)
 				pool.Remove(trx.Hash(), trx.ID()) // reads Cost()/Payer() (atomic Load) + bookkeeping (map lock)

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -1478,7 +1478,13 @@ func TestWashPriorityGasPriceRecomputation(t *testing.T) {
 	// Test 1: Wash with headBlockChanged=false should not recompute priorityGasPrice
 	wrongPriorityGasPrice := new(big.Int).Mul(initialPriorityGasPrice, big.NewInt(999))
 	cur := txObj.pricing.Load()
-	txObj.setPricing(&txPricing{payer: cur.payer, cost: cur.cost, priorityGasPrice: wrongPriorityGasPrice})
+	txObj.setPricing(&txPricing{
+		payer:            cur.payer,
+		cost:             cur.cost,
+		priorityGasPrice: wrongPriorityGasPrice,
+		feeCeiling:       cur.feeCeiling,
+		priorityCeiling:  cur.priorityCeiling,
+	})
 
 	_, _, err = pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -662,7 +662,7 @@ func TestWashPromoteDrainsPendingCost(t *testing.T) {
 	}
 
 	// Trigger wash to promote (executable) and account pending cost under the map lock.
-	_, _, _, err := pool.wash(pool.repo.BestBlockSummary(), true)
+	_, _, err := pool.wash(pool.repo.BestBlockSummary(), true)
 	assert.Nil(t, err)
 
 	// Remove every object one by one; removal must drain the accounting exactly.

--- a/txpool/tx_pool_test.go
+++ b/txpool/tx_pool_test.go
@@ -633,16 +633,45 @@ func TestWashTxs(t *testing.T) {
 
 	tx2 := newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[1])
 	txObj2, _ := ResolveTx(tx2, false)
-	assert.Nil(t, pool.all.Add(txObj2, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })) // this tx will participate in the wash out.
+	assert.Nil(
+		t,
+		pool.all.Add(txObj2, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil }),
+	) // this tx will participate in the wash out.
 
 	tx3 := newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[2])
 	txObj3, _ := ResolveTx(tx3, false)
-	assert.Nil(t, pool.all.Add(txObj3, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })) // this tx will participate in the wash out.
+	assert.Nil(
+		t,
+		pool.all.Add(txObj3, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil }),
+	) // this tx will participate in the wash out.
 
 	txs, washed, err := pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(txs))
 	assert.Equal(t, 1, washed)
+}
+
+func TestWashPromoteDrainsPendingCost(t *testing.T) {
+	pool := newPool(LIMIT, LIMIT_PER_ACCOUNT, &thor.NoFork)
+	defer pool.Close()
+
+	// Add a batch of txs from distinct accounts so wash promotes and accounts them.
+	for i := range 3 {
+		trx := newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), devAccounts[i])
+		assert.Nil(t, pool.Add(trx))
+	}
+
+	// Trigger wash to promote (executable) and account pending cost under the map lock.
+	_, _, _, err := pool.wash(pool.repo.BestBlockSummary(), true)
+	assert.Nil(t, err)
+
+	// Remove every object one by one; removal must drain the accounting exactly.
+	for _, obj := range pool.all.ToTxObjects() {
+		assert.NotPanics(t, func() { pool.all.RemoveByHash(obj.Hash()) })
+	}
+
+	// No orphaned pending cost left behind.
+	assert.Equal(t, 0, len(pool.all.cost), "pending cost accounting must be fully drained")
 }
 
 func TestOrderTxsAfterGalacticaFork(t *testing.T) {
@@ -1196,7 +1225,7 @@ func TestBlocked(t *testing.T) {
 	// added into all, will be washed out
 	txObj, err := ResolveTx(trx, false)
 	assert.Nil(t, err)
-	pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+	pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 	pool.wash(pool.repo.BestBlockSummary(), false)
 	got := pool.Get(trx.ID())
@@ -1240,7 +1269,7 @@ func TestWash(t *testing.T) {
 
 				txObj, err := ResolveTx(trx, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				pool.wash(pool.repo.BestBlockSummary(), false)
 				got := pool.Get(trx.ID())
@@ -1277,11 +1306,11 @@ func TestWash(t *testing.T) {
 
 				txObj, err := ResolveTx(trx2, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				txObj, err = ResolveTx(trx3, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				pool.wash(pool.repo.BestBlockSummary(), false)
 				got := pool.Get(trx3.ID())
@@ -1328,11 +1357,11 @@ func TestWash(t *testing.T) {
 
 				txObj, err := ResolveTx(trx2, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				txObj, err = ResolveTx(trx3, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				pool.wash(pool.repo.BestBlockSummary(), false)
 				// all non executable should be washed out
@@ -1403,7 +1432,7 @@ func TestWashWithDynFeeTx(t *testing.T) {
 
 				txObj, err := ResolveTx(trx, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				pool.wash(pool.repo.BestBlockSummary(), false)
 				got := pool.Get(trx.ID())
@@ -1443,18 +1472,19 @@ func TestWashPriorityGasPriceRecomputation(t *testing.T) {
 
 	txObj := pool.all.GetByID(trx.ID())
 	assert.NotNil(t, txObj)
-	assert.NotNil(t, txObj.priorityGasPrice, "priorityGasPrice should be set after initial wash")
-	initialPriorityGasPrice := new(big.Int).Set(txObj.priorityGasPrice)
+	assert.NotNil(t, txObj.priorityGasPrice(), "priorityGasPrice should be set after initial wash")
+	initialPriorityGasPrice := new(big.Int).Set(txObj.priorityGasPrice())
 
 	// Test 1: Wash with headBlockChanged=false should not recompute priorityGasPrice
 	wrongPriorityGasPrice := new(big.Int).Mul(initialPriorityGasPrice, big.NewInt(999))
-	txObj.priorityGasPrice = wrongPriorityGasPrice
+	cur := txObj.pricing.Load()
+	txObj.setPricing(&txPricing{payer: cur.payer, cost: cur.cost, priorityGasPrice: wrongPriorityGasPrice})
 
 	_, _, err = pool.wash(pool.repo.BestBlockSummary(), false)
 	assert.Nil(t, err)
 	txObj = pool.all.GetByID(trx.ID())
 	assert.NotNil(t, txObj)
-	assert.Equal(t, wrongPriorityGasPrice.String(), txObj.priorityGasPrice.String(),
+	assert.Equal(t, wrongPriorityGasPrice.String(), txObj.priorityGasPrice().String(),
 		"priorityGasPrice should NOT be recomputed when headBlockChanged=false")
 
 	// Test 2: headBlockChanged=true with unchanged baseFee should not recompute
@@ -1485,7 +1515,7 @@ func TestWashPriorityGasPriceRecomputation(t *testing.T) {
 	assert.Nil(t, err)
 	txObj = pool.all.GetByID(trx.ID())
 	assert.NotNil(t, txObj)
-	assert.NotEqual(t, wrongPriorityGasPrice.String(), txObj.priorityGasPrice.String(),
+	assert.NotEqual(t, wrongPriorityGasPrice.String(), txObj.priorityGasPrice().String(),
 		"priorityGasPrice SHOULD be recomputed when baseFee changes")
 }
 
@@ -1543,11 +1573,11 @@ func TestWashWithDynFeeTxAndPoolLimit(t *testing.T) {
 
 				txObj, err := ResolveTx(trx2, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				txObj, err = ResolveTx(trx3, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				pool.wash(pool.repo.BestBlockSummary(), false)
 				got := pool.Get(trx3.ID())
@@ -1591,11 +1621,11 @@ func TestWashWithDynFeeTxAndPoolLimit(t *testing.T) {
 
 				txObj, err := ResolveTx(trx2, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				txObj, err = ResolveTx(trx3, false)
 				assert.Nil(t, err)
-				pool.all.Add(txObj, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
+				pool.all.Add(txObj, false, nil, LIMIT_PER_ACCOUNT, func(_ thor.Address, _ *big.Int) error { return nil })
 
 				pool.wash(pool.repo.BestBlockSummary(), false)
 				// all non executable should be washed out

--- a/txpool/tx_pool_wash_race_test.go
+++ b/txpool/tx_pool_wash_race_test.go
@@ -78,7 +78,7 @@ func TestConcurrentWashAddRemove(t *testing.T) {
 					return
 				default:
 				}
-				_, _, _, _ = pool.wash(best, true)
+				_, _, _ = pool.wash(best, true)
 			}
 		})
 	}

--- a/txpool/tx_pool_wash_race_test.go
+++ b/txpool/tx_pool_wash_race_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2018 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package txpool
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/vechain/thor/v2/thor"
+	"github.com/vechain/thor/v2/tx"
+)
+
+// TestConcurrentWashAddRemove drives wash concurrently with Add/Remove over a
+// churning pool; run with -race. It targets the historical data race between
+// wash publishing pricing/promoting txs and Add/Remove reading pricing and
+// mutating the pending-cost accounting (pool.all.cost).
+//
+// Assertions: no panic, no data race (detected by the race detector, not by
+// this test's logic), and the pending-cost map is fully drained once every
+// tx added by the workers has been removed and wash has stopped running.
+func TestConcurrentWashAddRemove(t *testing.T) {
+	// Generous limits so Add is never rejected purely on quota/pool-full;
+	// txs must actually enter the pool and get washed/promoted to exercise
+	// the accounting path.
+	pool := newPool(4000, 4000, &thor.NoFork)
+	defer pool.Close()
+
+	best := pool.repo.BestBlockSummary()
+
+	const numAddRemoveWorkers = 8
+	// Exactly one wash goroutine: production runs a single serial housekeeping
+	// washer (TxPool.housekeeping), and wash's lock-free reads of the plain
+	// executable field rely on that single-writer model. Spinning multiple
+	// washers would fabricate a race that cannot occur in production.
+	const numWashWorkers = 1
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Add/Remove workers: each spins signing and adding a fresh tx (random
+	// nonce guarantees a distinct hash), then immediately removes it. Every
+	// tx it successfully adds is also removed by the same goroutine, so by
+	// the time all workers join, every worker-added tx has had a matching
+	// Remove call (whether or not wash got to it first).
+	for w := 0; w < numAddRemoveWorkers; w++ {
+		wg.Add(1)
+		go func(workerIdx int) {
+			defer wg.Done()
+			i := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				acc := devAccounts[(workerIdx+i)%len(devAccounts)]
+				trx := newTx(tx.TypeLegacy, pool.repo.ChainTag(), nil, 21000, tx.BlockRef{}, 100, nil, tx.Features(0), acc)
+				_ = pool.Add(trx)
+				pool.Remove(trx.Hash(), trx.ID())
+				i++
+			}
+		}(w)
+	}
+
+	// Wash workers: repeatedly evaluate/evict/promote against the churning
+	// pool, exercising the lock-free pricing snapshot publish/read path.
+	for w := 0; w < numWashWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_, _, _, _ = pool.wash(best, true)
+			}
+		}()
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+
+	pool.all.lock.RLock()
+	remaining := len(pool.all.cost)
+	pool.all.lock.RUnlock()
+	assert.Zero(t, remaining, "pending cost map should be drained after all txs removed")
+}

--- a/txpool/tx_pool_wash_race_test.go
+++ b/txpool/tx_pool_wash_race_test.go
@@ -48,7 +48,7 @@ func TestConcurrentWashAddRemove(t *testing.T) {
 	// tx it successfully adds is also removed by the same goroutine, so by
 	// the time all workers join, every worker-added tx has had a matching
 	// Remove call (whether or not wash got to it first).
-	for w := 0; w < numAddRemoveWorkers; w++ {
+	for w := range numAddRemoveWorkers {
 		wg.Add(1)
 		go func(workerIdx int) {
 			defer wg.Done()
@@ -70,10 +70,8 @@ func TestConcurrentWashAddRemove(t *testing.T) {
 
 	// Wash workers: repeatedly evaluate/evict/promote against the churning
 	// pool, exercising the lock-free pricing snapshot publish/read path.
-	for w := 0; w < numWashWorkers; w++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numWashWorkers {
+		wg.Go(func() {
 			for {
 				select {
 				case <-stop:
@@ -82,7 +80,7 @@ func TestConcurrentWashAddRemove(t *testing.T) {
 				}
 				_, _, _, _ = pool.wash(best, true)
 			}
-		}()
+		})
 	}
 
 	time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
# Description

  - **Lock-free pricing parameter publication** — `payer`/`cost`/`priorityGasPrice` are published together via a single `atomic.Pointer[txPricing]` snapshot, so readers never observe a torn state.
  - **Cheaper base-fee refresh** — cache the base-fee-independent ceilings in the pricing snapshot and refresh `priorityGasPrice` as pure arithmetic (`min(feeCeiling-baseFee, priorityCeiling)`), avoiding a per-tx `ProvedWork` chain lookup on every base-fee change.

Below is the benchmark before and after the change:

```
  pkg: github.com/vechain/thor/v2/txpool
  cpu: Apple M5 Pro (arm64)

  sec/op                              before        after         delta
  PoolConcurrentAddRemove-18          6.247µ ± 7%   6.211µ ± 7%   ~ (p=0.937)
  PoolConcurrentAddRemoveWithWash-18  7.346µ ± 1%   7.507µ ± 2%   +2.18% (p=0.015)
  geomean                             6.774µ        6.828µ        +0.79%

  B/op
  PoolConcurrentAddRemove-18          19.96Ki       19.99Ki       +0.17%
  PoolConcurrentAddRemoveWithWash-18  25.78Ki       25.94Ki       +0.64%

  allocs/op
  PoolConcurrentAddRemove-18          351.0         352.0         +0.28%
  PoolConcurrentAddRemoveWithWash-18  446.5         450.0         +0.78%
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
