### PR TITLE
feat: add offset limit to logs pagination and db metrics

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -24,7 +24,7 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           # Default fallback commit
-          DEFAULT_COMMIT="a51bdc9833d1a4641c2d7969414dbe23a4fa345e"
+          DEFAULT_COMMIT="c87b8c55ace0d48112a65e8a0659d3af4ef2f1cf"
           REF="$DEFAULT_COMMIT"
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
             # For pull_request events, we only look at the PR's base branch

--- a/api/events/events.go
+++ b/api/events/events.go
@@ -22,15 +22,17 @@ import (
 type Events struct {
 	repo             *chain.Repository
 	db               *logdb.LogDB
-	limit            uint64
+	maxLimit         uint64
+	maxOffset        uint64
 	maxCriteriaCount int
 }
 
-func New(repo *chain.Repository, db *logdb.LogDB, logsLimit uint64, maxCriteriaCount int) *Events {
+func New(repo *chain.Repository, db *logdb.LogDB, maxLimit uint64, maxOffset uint64, maxCriteriaCount int) *Events {
 	return &Events{
 		repo,
 		db,
-		logsLimit,
+		maxLimit,
+		maxOffset,
 		maxCriteriaCount,
 	}
 }
@@ -58,7 +60,7 @@ func (e *Events) handleFilter(w http.ResponseWriter, req *http.Request) error {
 	if err := restutil.ParseJSON(req.Body, &filter); err != nil {
 		return restutil.BadRequest(errors.WithMessage(err, "body"))
 	}
-	if err := filter.Options.Validate(e.limit); err != nil {
+	if err := filter.Options.Validate(e.maxLimit, e.maxOffset); err != nil {
 		return restutil.Forbidden(err)
 	}
 	if err := filter.Range.Validate(); err != nil {
@@ -83,7 +85,7 @@ func (e *Events) handleFilter(w http.ResponseWriter, req *http.Request) error {
 	if filter.Options.Limit == nil {
 		// if filter.Options.Limit is nil, set to the default limit +1
 		// to detect whether there are more logs than the default limit
-		limit := e.limit + 1
+		limit := e.maxLimit + 1
 		filter.Options.Limit = &limit
 	}
 
@@ -93,8 +95,8 @@ func (e *Events) handleFilter(w http.ResponseWriter, req *http.Request) error {
 	}
 
 	// ensure the result size is less than the configured limit
-	if len(fes) > int(e.limit) {
-		return restutil.Forbidden(fmt.Errorf("the number of filtered logs exceeds the maximum allowed value of %d, please use pagination", e.limit))
+	if len(fes) > int(e.maxLimit) {
+		return restutil.Forbidden(fmt.Errorf("the number of filtered logs exceeds the maximum allowed value of %d, please use pagination", e.maxLimit))
 	}
 
 	return restutil.WriteJSON(w, fes)

--- a/api/events/events_test.go
+++ b/api/events/events_test.go
@@ -28,7 +28,10 @@ import (
 	"github.com/vechain/thor/v2/tx"
 )
 
-const defaultLogLimit uint64 = 1000
+const (
+	defaultLogLimit  uint64 = 1000
+	defaultLogOffset uint64 = 100
+)
 
 var (
 	ts      *httptest.Server
@@ -36,7 +39,7 @@ var (
 )
 
 func TestEmptyEvents(t *testing.T) {
-	initEventServer(t, defaultLogLimit)
+	initEventServer(t, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 
 	tclient = thorclient.New(ts.URL)
@@ -49,7 +52,7 @@ func TestEmptyEvents(t *testing.T) {
 }
 
 func TestEvents(t *testing.T) {
-	thorChain := initEventServer(t, defaultLogLimit)
+	thorChain := initEventServer(t, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 
 	blocksToInsert := 5
@@ -59,7 +62,7 @@ func TestEvents(t *testing.T) {
 }
 
 func TestOptionalIndexes(t *testing.T) {
-	thorChain := initEventServer(t, defaultLogLimit)
+	thorChain := initEventServer(t, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 	insertBlocks(t, thorChain, 5)
 	tclient = thorclient.New(ts.URL)
@@ -109,7 +112,7 @@ func TestOptionalIndexes(t *testing.T) {
 }
 
 func TestEvents_WithOptionsNoLimit(t *testing.T) {
-	thorChain := initEventServer(t, defaultLogLimit)
+	thorChain := initEventServer(t, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 	insertBlocks(t, thorChain, 5)
 
@@ -133,7 +136,7 @@ func TestEvents_WithOptionsNoLimit(t *testing.T) {
 }
 
 func TestOption(t *testing.T) {
-	thorChain := initEventServer(t, 5)
+	thorChain := initEventServer(t, 5, defaultLogOffset)
 	defer ts.Close()
 	insertBlocks(t, thorChain, 5)
 
@@ -197,10 +200,27 @@ func TestOption(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 	assert.Equal(t, "number of criteria in criteriaSet: 11 cannot be greater than: 10\n", string(res))
+
+	filter = api.EventFilter{
+		CriteriaSet: make([]*api.EventCriteria, 0),
+		Range:       nil,
+		Options:     &api.Options{Offset: defaultLogOffset, Limit: new(uint64(0))},
+		Order:       logdb.DESC,
+	}
+
+	_, statusCode, err = tclient.RawHTTPClient().RawHTTPPost("/logs/event", filter)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	filter.Options.Offset = defaultLogOffset * 2
+	res, statusCode, err = tclient.RawHTTPClient().RawHTTPPost("/logs/event", filter)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, statusCode)
+	assert.Equal(t, "options.offset exceeds the maximum allowed value of 100", strings.Trim(string(res), "\n"))
 }
 
 func TestZeroFrom(t *testing.T) {
-	thorChain := initEventServer(t, 100)
+	thorChain := initEventServer(t, 100, defaultLogOffset)
 	defer ts.Close()
 	insertBlocks(t, thorChain, 5)
 
@@ -234,7 +254,7 @@ func TestZeroFrom(t *testing.T) {
 }
 
 func TestNullCriteriaSet(t *testing.T) {
-	initEventServer(t, defaultLogLimit)
+	initEventServer(t, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 
 	tclient = thorclient.New(ts.URL)
@@ -328,12 +348,12 @@ func testEventWithBlocks(t *testing.T, expectedBlocks int) {
 }
 
 // Init functions
-func initEventServer(t *testing.T, limit uint64) *testchain.Chain {
+func initEventServer(t *testing.T, limit uint64, offset uint64) *testchain.Chain {
 	thorChain, err := testchain.NewDefault()
 	require.NoError(t, err)
 
 	router := mux.NewRouter()
-	New(thorChain.Repo(), thorChain.LogDB(), limit, 10).Mount(router, "/logs/event")
+	New(thorChain.Repo(), thorChain.LogDB(), limit, offset, 10).Mount(router, "/logs/event")
 	ts = httptest.NewServer(router)
 
 	return thorChain

--- a/api/events_types.go
+++ b/api/events_types.go
@@ -7,7 +7,6 @@ package api
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 
@@ -73,15 +72,16 @@ type Options struct {
 	IncludeIndexes bool    `json:"includeIndexes,omitempty"`
 }
 
-func (o *Options) Validate(limit uint64) error {
+func (o *Options) Validate(limit uint64, offset uint64) error {
 	if o == nil {
 		return nil
 	}
 	if o.Limit != nil && *o.Limit > limit {
 		return fmt.Errorf("options.limit exceeds the maximum allowed value of %d", limit)
 	}
-	if o.Offset > math.MaxInt64 {
-		return fmt.Errorf("options.offset exceeds the maximum allowed value of %d", math.MaxInt64)
+
+	if o.Offset > offset {
+		return fmt.Errorf("options.offset exceeds the maximum allowed value of %d", offset)
 	}
 
 	return nil

--- a/api/transfers/transfers.go
+++ b/api/transfers/transfers.go
@@ -22,15 +22,17 @@ import (
 type Transfers struct {
 	repo             *chain.Repository
 	db               *logdb.LogDB
-	limit            uint64
+	maxLimit         uint64
+	maxOffset        uint64
 	maxCriteriaCount int
 }
 
-func New(repo *chain.Repository, db *logdb.LogDB, logsLimit uint64, maxCriteriaCount int) *Transfers {
+func New(repo *chain.Repository, db *logdb.LogDB, maxLimit uint64, maxOffset uint64, maxCriteriaCount int) *Transfers {
 	return &Transfers{
 		repo,
 		db,
-		logsLimit,
+		maxLimit,
+		maxOffset,
 		maxCriteriaCount,
 	}
 }
@@ -66,7 +68,7 @@ func (t *Transfers) handleFilterTransferLogs(w http.ResponseWriter, req *http.Re
 	if err := restutil.ParseJSON(req.Body, &filter); err != nil {
 		return restutil.BadRequest(errors.WithMessage(err, "body"))
 	}
-	if err := filter.Options.Validate(t.limit); err != nil {
+	if err := filter.Options.Validate(t.maxLimit, t.maxOffset); err != nil {
 		return restutil.Forbidden(err)
 	}
 	if err := filter.Range.Validate(); err != nil {
@@ -91,7 +93,7 @@ func (t *Transfers) handleFilterTransferLogs(w http.ResponseWriter, req *http.Re
 	if filter.Options.Limit == nil {
 		// if filter.Options.Limit is nil, set to the default limit +1
 		// to detect whether there are more logs than the default limit
-		limit := t.limit + 1
+		limit := t.maxLimit + 1
 		filter.Options.Limit = &limit
 	}
 
@@ -101,8 +103,8 @@ func (t *Transfers) handleFilterTransferLogs(w http.ResponseWriter, req *http.Re
 	}
 
 	// ensure the result size is less than the configured limit
-	if len(tLogs) > int(t.limit) {
-		return restutil.Forbidden(fmt.Errorf("the number of filtered logs exceeds the maximum allowed value of %d, please use pagination", t.limit))
+	if len(tLogs) > int(t.maxLimit) {
+		return restutil.Forbidden(fmt.Errorf("the number of filtered logs exceeds the maximum allowed value of %d, please use pagination", t.maxLimit))
 	}
 
 	return restutil.WriteJSON(w, tLogs)

--- a/api/transfers/transfers_test.go
+++ b/api/transfers/transfers_test.go
@@ -28,7 +28,10 @@ import (
 	"github.com/vechain/thor/v2/tx"
 )
 
-const defaultLogLimit uint64 = 1000
+const (
+	defaultLogLimit  uint64 = 1000
+	defaultLogOffset uint64 = 100
+)
 
 var (
 	ts      *httptest.Server
@@ -37,7 +40,7 @@ var (
 
 func TestEmptyTransfers(t *testing.T) {
 	db := createDb(t)
-	initTransferServer(t, db, defaultLogLimit)
+	initTransferServer(t, db, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 
 	tclient = thorclient.New(ts.URL)
@@ -47,7 +50,7 @@ func TestEmptyTransfers(t *testing.T) {
 
 func TestTransfers(t *testing.T) {
 	db := createDb(t)
-	initTransferServer(t, db, defaultLogLimit)
+	initTransferServer(t, db, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 
 	tclient = thorclient.New(ts.URL)
@@ -59,7 +62,7 @@ func TestTransfers(t *testing.T) {
 
 func TestOption(t *testing.T) {
 	db := createDb(t)
-	initTransferServer(t, db, 5)
+	initTransferServer(t, db, 5, 100)
 	defer ts.Close()
 	insertBlocks(t, db, 5)
 
@@ -100,11 +103,28 @@ func TestOption(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusForbidden, statusCode)
 	assert.Equal(t, "the number of filtered logs exceeds the maximum allowed value of 5, please use pagination", strings.Trim(string(res), "\n"))
+
+	filter = api.TransferFilter{
+		CriteriaSet: make([]*logdb.TransferCriteria, 0),
+		Range:       nil,
+		Options:     &api.Options{Offset: defaultLogOffset, Limit: new(uint64(0))},
+		Order:       logdb.DESC,
+	}
+
+	_, statusCode, err = tclient.RawHTTPClient().RawHTTPPost("/logs/transfer", filter)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	filter.Options.Offset = defaultLogOffset * 2
+	res, statusCode, err = tclient.RawHTTPClient().RawHTTPPost("/logs/transfer", filter)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusForbidden, statusCode)
+	assert.Equal(t, "options.offset exceeds the maximum allowed value of 100", strings.Trim(string(res), "\n"))
 }
 
 func TestOptionalData(t *testing.T) {
 	db := createDb(t)
-	initTransferServer(t, db, defaultLogLimit)
+	initTransferServer(t, db, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 	insertBlocks(t, db, 5)
 	tclient = thorclient.New(ts.URL)
@@ -155,7 +175,7 @@ func TestOptionalData(t *testing.T) {
 
 func TestNullCriteriaSet(t *testing.T) {
 	db := createDb(t)
-	initTransferServer(t, db, defaultLogLimit)
+	initTransferServer(t, db, defaultLogLimit, defaultLogOffset)
 	defer ts.Close()
 	tclient = thorclient.New(ts.URL)
 
@@ -265,12 +285,12 @@ func insertBlocks(t *testing.T, db *logdb.LogDB, n int) {
 	}
 }
 
-func initTransferServer(t *testing.T, logDb *logdb.LogDB, limit uint64) {
+func initTransferServer(t *testing.T, logDb *logdb.LogDB, limit uint64, offset uint64) {
 	thorChain, err := testchain.NewDefault()
 	require.NoError(t, err)
 
 	router := mux.NewRouter()
-	New(thorChain.Repo(), logDb, limit, 10).Mount(router, "/logs/transfer")
+	New(thorChain.Repo(), logDb, limit, offset, 10).Mount(router, "/logs/transfer")
 
 	ts = httptest.NewServer(router)
 }

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -108,7 +108,6 @@ var (
 	apiLogsMaxOffsetFlag = &cli.Uint64Flag{
 		Name:    "api-logs-max-offset",
 		Local:   true,
-		Hidden:  true,
 		Value:   100_000,
 		Usage:   "limit the maximum offset for /logs API",
 		Sources: envVar("API_LOGS_MAX_OFFSET"),

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -105,6 +105,14 @@ var (
 		Usage:   "limit the number of logs returned by /logs API",
 		Sources: envVar("API_LOGS_LIMIT"),
 	}
+	apiLogsMaxOffsetFlag = &cli.Uint64Flag{
+		Name:    "api-logs-max-offset",
+		Local:   true,
+		Hidden:  true,
+		Value:   100_000,
+		Usage:   "limit the maximum offset for /logs API",
+		Sources: envVar("API_LOGS_MAX_OFFSET"),
+	}
 	apiEnableDeprecatedFlag = &cli.BoolFlag{
 		Name:    "api-enable-deprecated",
 		Local:   true,
@@ -130,6 +138,14 @@ var (
 		Usage:   "enable creation of additional indexes on startup",
 		Sources: envVar("LOGDB_ADDITIONAL_INDEXES"),
 	}
+	logDbMaxReadConnsFlag = &cli.Uint64Flag{
+		Name:    "logdb-max-read-conns",
+		Local:   true,
+		Value:   64,
+		Usage:   "maximum number of read connections for the log database",
+		Sources: envVar("LOGDB_MAX_READ_CONNS"),
+	}
+
 	// priority fees API flags
 	apiPriorityFeesPercentageFlag = &cli.Uint64Flag{
 		Name:    "api-priority-fees-percentage",

--- a/cmd/thor/flags.go
+++ b/cmd/thor/flags.go
@@ -140,6 +140,7 @@ var (
 	logDbMaxReadConnsFlag = &cli.Uint64Flag{
 		Name:    "logdb-max-read-conns",
 		Local:   true,
+		Hidden:  true,
 		Value:   64,
 		Usage:   "maximum number of read connections for the log database",
 		Sources: envVar("LOGDB_MAX_READ_CONNS"),

--- a/cmd/thor/httpserver/api_server.go
+++ b/cmd/thor/httpserver/api_server.go
@@ -65,6 +65,7 @@ type APIConfig struct {
 	Timeout                    int
 	SlowQueriesThreshold       int
 	Log5XXErrors               bool
+	MaxLogsOffset              uint64
 }
 
 func StartAPIServer(
@@ -109,8 +110,8 @@ func StartAPIServer(
 
 	accounts.New(repo, stater, config.CallGasLimit, config.BatchDataMaxSize, forkConfig, bft, config.EnableDeprecated).Mount(router, "/accounts")
 	if !config.SkipLogs {
-		events.New(repo, logDB, config.LogsLimit, defaultMaxCriteriaCount).Mount(router, "/logs/event")
-		transfers.New(repo, logDB, config.LogsLimit, defaultMaxCriteriaCount).Mount(router, "/logs/transfer")
+		events.New(repo, logDB, config.LogsLimit, config.MaxLogsOffset, defaultMaxCriteriaCount).Mount(router, "/logs/event")
+		transfers.New(repo, logDB, config.LogsLimit, config.MaxLogsOffset, defaultMaxCriteriaCount).Mount(router, "/logs/transfer")
 	}
 	blocks.New(repo, bft).Mount(router, "/blocks")
 	transactions.New(repo, txPool).Mount(router, "/transactions")

--- a/cmd/thor/main.go
+++ b/cmd/thor/main.go
@@ -108,6 +108,7 @@ func main() {
 			apiEnableDeprecatedFlag,
 			enableAPILogsFlag,
 			apiLogsLimitFlag,
+			apiLogsMaxOffsetFlag,
 			apiPriorityFeesPercentageFlag,
 			apiSlowQueriesThresholdFlag,
 			apiLog5xxErrorsFlag,
@@ -121,6 +122,7 @@ func main() {
 			allowedPeersFlag,
 			skipLogsFlag,
 			logDbAdditionalIndexesFlag,
+			logDbMaxReadConnsFlag,
 			pprofFlag,
 			verifyLogsFlag,
 			disablePrunerFlag,
@@ -142,6 +144,7 @@ func main() {
 					dataDirFlag,
 					cacheFlag,
 					logDbAdditionalIndexesFlag,
+					logDbMaxReadConnsFlag,
 					apiTxpoolFlag,
 					apiAddrFlag,
 					apiCorsFlag,
@@ -154,6 +157,7 @@ func main() {
 					apiSlowQueriesThresholdFlag,
 					enableAPILogsFlag,
 					apiLogsLimitFlag,
+					apiLogsMaxOffsetFlag,
 					apiPriorityFeesPercentageFlag,
 					apiLog5xxErrorsFlag,
 					onDemandFlag,
@@ -252,9 +256,14 @@ func defaultAction(_ context.Context, ctx *cli.Command) error {
 	defer func() { log.Info("closing main database..."); mainDB.Close() }()
 
 	logDbAdditionalIndexes := ctx.Bool(logDbAdditionalIndexesFlag.Name)
-	logDB, err := openLogDB(instanceDir, logDbAdditionalIndexes)
+	logDbMaxReadConns := ctx.Uint64(logDbMaxReadConnsFlag.Name)
+
+	logDB, err := openLogDB(instanceDir, logDbAdditionalIndexes, logDbMaxReadConns)
 	if err != nil {
 		return err
+	}
+	if enableMetrics {
+		logDB.EnableMetrics()
 	}
 	defer func() { log.Info("closing log database..."); logDB.Close() }()
 
@@ -432,6 +441,8 @@ func soloAction(_ context.Context, ctx *cli.Command) error {
 	var instanceDir string
 
 	logDbAdditionalIndexes := ctx.Bool(logDbAdditionalIndexesFlag.Name)
+	logDbMaxReadConns := ctx.Uint64(logDbMaxReadConnsFlag.Name)
+
 	if ctx.Bool(persistFlag.Name) {
 		if instanceDir, err = makeInstanceDir(ctx.String(dataDirFlag.Name), gene, ctx.Bool(disablePrunerFlag.Name)); err != nil {
 			return err
@@ -444,8 +455,11 @@ func soloAction(_ context.Context, ctx *cli.Command) error {
 		}
 		defer func() { log.Info("closing main database..."); mainDB.Close() }()
 
-		if logDB, err = openLogDB(instanceDir, logDbAdditionalIndexes); err != nil {
+		if logDB, err = openLogDB(instanceDir, logDbAdditionalIndexes, logDbMaxReadConns); err != nil {
 			return err
+		}
+		if enableMetrics {
+			logDB.EnableMetrics()
 		}
 		defer func() { log.Info("closing log database..."); logDB.Close() }()
 	} else {
@@ -698,7 +712,7 @@ func reprocessAction(_ context.Context, ctx *cli.Command) error {
 	}
 	defer func() { log.Info("closing database..."); mainDB.Close() }()
 
-	logDB, err := openLogDB(instanceDir, true)
+	logDB, err := openLogDB(instanceDir, true, ctx.Uint64(logDbMaxReadConnsFlag.Name))
 	if err != nil {
 		return errors.Wrap(err, "open log database")
 	}

--- a/cmd/thor/utils.go
+++ b/cmd/thor/utils.go
@@ -277,6 +277,7 @@ func makeAPIConfig(ctx *cli.Command, logAPIRequests *atomic.Bool, enableTxPool *
 		Timeout:                    int(ctx.Uint64(apiTimeoutFlag.Name)),
 		SlowQueriesThreshold:       int(ctx.Uint64(apiSlowQueriesThresholdFlag.Name)),
 		Log5XXErrors:               ctx.Bool(apiLog5xxErrorsFlag.Name),
+		MaxLogsOffset:              ctx.Uint64(apiLogsMaxOffsetFlag.Name),
 	}
 }
 
@@ -387,9 +388,10 @@ func suggestFDCache() int {
 	return n
 }
 
-func openLogDB(dir string, createAdditionalIndexes bool) (*logdb.LogDB, error) {
+func openLogDB(dir string, createAdditionalIndexes bool, maxReadConns uint64) (*logdb.LogDB, error) {
 	path := filepath.Join(dir, "logs-v2.db")
-	db, err := logdb.New(path, createAdditionalIndexes)
+
+	db, err := logdb.New(path, createAdditionalIndexes, maxReadConns)
 	if err != nil {
 		return nil, errors.Wrapf(err, "open log database [%v]", path)
 	}

--- a/logdb/logdb.go
+++ b/logdb/logdb.go
@@ -12,9 +12,11 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/vechain/thor/v2/block"
 	"github.com/vechain/thor/v2/log"
+	"github.com/vechain/thor/v2/metrics"
 	"github.com/vechain/thor/v2/thor"
 	"github.com/vechain/thor/v2/tx"
 
@@ -42,10 +44,13 @@ type LogDB struct {
 	writeStmtCache *stmtCache
 	wconn          *sql.Conn
 	wconnSyncOff   *sql.Conn
+
+	// metricsUnregister releases the collector registered by EnableMetrics; nil if unset.
+	metricsUnregister func()
 }
 
 // New create or open log db at given path.
-func New(path string, createAdditionalIndexes bool) (logDB *LogDB, err error) {
+func New(path string, createAdditionalIndexes bool, maxReadConns uint64) (logDB *LogDB, err error) {
 	// writeDB for write operations with immediate transaction lock
 	writeDB, err := sql.Open("sqlite3", path+"?_journal=wal&_txlock=immediate")
 	if err != nil {
@@ -115,6 +120,10 @@ func New(path string, createAdditionalIndexes bool) (logDB *LogDB, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	readDB.SetMaxOpenConns(int(maxReadConns))     // set maximum number of read connections
+	readDB.SetMaxIdleConns(int(maxReadConns / 2)) // set maximum number of idle connections
+
 	defer func() {
 		if err != nil {
 			_ = readDB.Close()
@@ -189,6 +198,10 @@ func NewMem() (*LogDB, error) {
 
 // Close close the log db.
 func (db *LogDB) Close() (err error) {
+	if db.metricsUnregister != nil {
+		db.metricsUnregister()
+	}
+
 	// Close write connections first
 	err = db.wconn.Close()
 	if db.wconnSyncOff != db.wconn { // Don't double-close for in-memory DB
@@ -241,20 +254,19 @@ FROM (%v) e
 	)
 
 	if filter.Range != nil {
-		subQuery += " AND seq >= ?"
 		from, err := newSequence(filter.Range.From, 0, 0)
 		if err != nil {
 			return nil, err
 		}
-		args = append(args, from)
-		if filter.Range.To >= filter.Range.From {
-			subQuery += " AND seq <= ?"
-			to, err := newSequence(filter.Range.To, txIndexMask, logIndexMask)
-			if err != nil {
-				return nil, err
-			}
-			args = append(args, to)
+		to, err := newSequence(filter.Range.To, txIndexMask, logIndexMask)
+		if err != nil {
+			return nil, err
 		}
+		// Always bind both bounds. For an inverted range (To < From) this yields
+		// seq >= from AND seq <= to with to < from — an empty result — instead of
+		// silently dropping the upper bound and returning everything from `from` on.
+		subQuery += " AND seq >= ? AND seq <= ?"
+		args = append(args, from, to)
 	}
 
 	if len(filter.CriteriaSet) > 0 {
@@ -317,20 +329,19 @@ FROM (%v) t
 	)
 
 	if filter.Range != nil {
-		subQuery += " AND seq >= ?"
 		from, err := newSequence(filter.Range.From, 0, 0)
 		if err != nil {
 			return nil, err
 		}
-		args = append(args, from)
-		if filter.Range.To >= filter.Range.From {
-			subQuery += " AND seq <= ?"
-			to, err := newSequence(filter.Range.To, txIndexMask, logIndexMask)
-			if err != nil {
-				return nil, err
-			}
-			args = append(args, to)
+		to, err := newSequence(filter.Range.To, txIndexMask, logIndexMask)
+		if err != nil {
+			return nil, err
 		}
+		// Always bind both bounds. For an inverted range (To < From) this yields
+		// seq >= from AND seq <= to with to < from — an empty result — instead of
+		// silently dropping the upper bound and returning everything from `from` on.
+		subQuery += " AND seq >= ? AND seq <= ?"
+		args = append(args, from, to)
 	}
 
 	if len(filter.CriteriaSet) > 0 {
@@ -370,6 +381,20 @@ FROM (%v) t
 	return db.queryTransfers(ctx, transferQuery, args...)
 }
 
+// readDBStatsSampleInterval bounds how often the lock-guarded readDB.Stats() runs.
+const readDBStatsSampleInterval = 10 * time.Second
+
+// EnableMetrics registers a pull collector exporting the readDB connection pool
+// stats, sampled on scrape at most once per readDBStatsSampleInterval. No-op unless
+// Prometheus is initialized; call once per LogDB.
+func (db *LogDB) EnableMetrics() {
+	db.metricsUnregister = metrics.RegisterPullCollector(
+		"logdb",
+		readDBStatsSampleInterval,
+		func() []metrics.Sample { return readDBStatsSamples(db.readDB.Stats()) },
+	)
+}
+
 func (db *LogDB) queryEvents(ctx context.Context, query string, args ...any) ([]*Event, error) {
 	rows, err := db.readDB.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -379,11 +404,6 @@ func (db *LogDB) queryEvents(ctx context.Context, query string, args ...any) ([]
 
 	var events []*Event
 	for rows.Next() {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
 		var (
 			seq         sequence
 			blockID     []byte
@@ -446,11 +466,6 @@ func (db *LogDB) queryTransfers(ctx context.Context, query string, args ...any) 
 	defer func() { _ = rows.Close() }()
 	var transfers []*Transfer
 	for rows.Next() {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
 		var (
 			seq         sequence
 			blockID     []byte

--- a/logdb/logdb_bench_test.go
+++ b/logdb/logdb_bench_test.go
@@ -267,7 +267,7 @@ func createTempDB() (*LogDB, error) {
 		return nil, fmt.Errorf("failed to close temp file: %w", err)
 	}
 
-	db, err := New(tmpFile.Name(), true)
+	db, err := New(tmpFile.Name(), true, 64)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load logdb: %w", err)
 	}
@@ -280,5 +280,5 @@ func loadDBFromDisk(b *testing.B) (*LogDB, error) {
 		b.Fatal("Please provide a dbPath")
 	}
 
-	return New(dbPath, true)
+	return New(dbPath, true, 64)
 }

--- a/logdb/logdb_test.go
+++ b/logdb/logdb_test.go
@@ -215,6 +215,12 @@ func TestEvents(t *testing.T) {
 				&EventFilter{Range: &Range{From: 10, To: 20}, Order: DESC},
 				allEvents.Filter(func(ev *Event) bool { return ev.BlockNumber >= 10 && ev.BlockNumber <= 20 }).Reverse(),
 			},
+			{
+				// An inverted range (To < From) must yield no results, not everything from From onward.
+				"query events with inverted range",
+				&EventFilter{Range: &Range{From: 20, To: 10}},
+				nil,
+			},
 			{"query events with limit with desc", &EventFilter{Order: DESC, Options: &Options{Limit: 10}}, allEvents.Reverse()[0:10]},
 			{
 				"query all events with criteria",
@@ -280,6 +286,12 @@ func TestEvents(t *testing.T) {
 				"query transfers with range and desc",
 				&TransferFilter{Range: &Range{From: 10, To: 20}, Order: DESC},
 				allTransfers.Filter(func(tr *Transfer) bool { return tr.BlockNumber >= 10 && tr.BlockNumber <= 20 }).Reverse(),
+			},
+			{
+				// An inverted range (To < From) must yield no results, not everything from From onward.
+				"query transfers with inverted range",
+				&TransferFilter{Range: &Range{From: 20, To: 10}},
+				nil,
 			},
 			{"query transfers with limit with desc", &TransferFilter{Order: DESC, Options: &Options{Limit: 10}}, allTransfers.Reverse()[0:10]},
 			{

--- a/logdb/metrics.go
+++ b/logdb/metrics.go
@@ -6,6 +6,7 @@
 package logdb
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -23,6 +24,31 @@ var (
 		0, 5, 10, 25, 50, 100, 250, 500, 1000,
 	})
 )
+
+// readDBStatsSamples converts readDB pool stats into samples: InUse is a gauge;
+// the cumulative WaitCount and WaitDuration are counters.
+func readDBStatsSamples(stats sql.DBStats) []metrics.Sample {
+	return []metrics.Sample{
+		{
+			Name:  "readdb_in_use_connections",
+			Help:  "Number of readDB connections currently in use.",
+			Kind:  metrics.KindGauge,
+			Value: float64(stats.InUse),
+		},
+		{
+			Name:  "readdb_wait_count",
+			Help:  "Cumulative number of readDB connections waited for.",
+			Kind:  metrics.KindCounter,
+			Value: float64(stats.WaitCount),
+		},
+		{
+			Name:  "readdb_wait_duration_ms",
+			Help:  "Cumulative time (ms) blocked waiting for a readDB connection.",
+			Kind:  metrics.KindCounter,
+			Value: float64(stats.WaitDuration.Milliseconds()),
+		},
+	}
+}
 
 func metricsHandleEventsFilter(filter *EventFilter) {
 	metricsHandleCommonFilter(filter.Options, filter.Order, len(filter.CriteriaSet), "event")

--- a/logdb/metrics_test.go
+++ b/logdb/metrics_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package logdb
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/vechain/thor/v2/metrics"
+)
+
+func TestReadDBStatsSamples(t *testing.T) {
+	samples := readDBStatsSamples(sql.DBStats{
+		InUse:        3,
+		WaitCount:    7,
+		WaitDuration: 250 * time.Millisecond,
+	})
+	require.Len(t, samples, 3)
+
+	byName := make(map[string]metrics.Sample)
+	for _, s := range samples {
+		byName[s.Name] = s
+	}
+
+	require.Equal(t, metrics.KindGauge, byName["readdb_in_use_connections"].Kind)
+	require.Equal(t, float64(3), byName["readdb_in_use_connections"].Value)
+
+	require.Equal(t, metrics.KindCounter, byName["readdb_wait_count"].Kind)
+	require.Equal(t, float64(7), byName["readdb_wait_count"].Value)
+
+	require.Equal(t, metrics.KindCounter, byName["readdb_wait_duration_ms"].Kind)
+	require.Equal(t, float64(250), byName["readdb_wait_duration_ms"].Value)
+}
+
+func TestEnableMetricsExportsReadDBPoolStats(t *testing.T) {
+	metrics.InitializePrometheusMetrics()
+
+	db, err := NewMem()
+	require.NoError(t, err)
+	db.EnableMetrics()
+
+	gather := func() map[string]*dto.MetricFamily {
+		mfs, err := prometheus.DefaultGatherer.Gather()
+		require.NoError(t, err)
+		out := make(map[string]*dto.MetricFamily)
+		for _, mf := range mfs {
+			out[mf.GetName()] = mf
+		}
+		return out
+	}
+
+	m := gather()
+	require.Equal(t, dto.MetricType_GAUGE, m["thor_metrics_logdb_readdb_in_use_connections"].GetType())
+	require.Equal(t, dto.MetricType_COUNTER, m["thor_metrics_logdb_readdb_wait_count"].GetType())
+	require.Equal(t, dto.MetricType_COUNTER, m["thor_metrics_logdb_readdb_wait_duration_ms"].GetType())
+
+	// Closing the DB must release the collector.
+	require.NoError(t, db.Close())
+	_, present := gather()["thor_metrics_logdb_readdb_in_use_connections"]
+	require.False(t, present)
+}

--- a/metrics/pull.go
+++ b/metrics/pull.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2026 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package metrics
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// SampleKind identifies how a Sample's value should be exported.
+type SampleKind int
+
+const (
+	// KindGauge is a point-in-time value that can arbitrarily go up and down.
+	KindGauge SampleKind = iota
+	// KindCounter is a cumulative value that only increases (until process restart).
+	KindCounter
+)
+
+// Sample is a single metric data point produced by a pull-collector provider.
+type Sample struct {
+	Name   string            // metric name, scoped under namespace + subsystem
+	Help   string            // metric help text
+	Kind   SampleKind        // gauge or counter
+	Labels map[string]string // optional labels
+	Value  float64           // measured value
+}
+
+// RegisterPullCollector installs a Prometheus collector that samples provider on
+// scrape rather than on a schedule, at most once per minInterval (0 = every
+// scrape). This bounds an expensive data source (e.g. a lock-guarded DB Stats())
+// regardless of scrape frequency, with no background goroutine.
+//
+// provider is invoked once at registration to discover the metric set, so it must
+// return the same (name, label-keys) on every call; only values change.
+//
+// The returned unregister releases the collector (call it on Close). Registration
+// is skipped, and unregister is a no-op, when Prometheus is not initialized.
+func RegisterPullCollector(subsystem string, minInterval time.Duration, provider func() []Sample) (unregister func()) {
+	if _, ok := metrics.(*prometheusMetrics); !ok {
+		return func() {}
+	}
+
+	c := &pullCollector{
+		subsystem:   subsystem,
+		minInterval: minInterval,
+		provider:    provider,
+		descs:       make(map[string]*prometheus.Desc),
+	}
+	// Warm up to discover descriptors (making this a checked, and thus
+	// unregisterable, collector) and seed the cache.
+	c.refresh()
+
+	if err := prometheus.Register(c); err != nil {
+		logger.Warn("unable to register pull collector", "subsystem", subsystem, "err", err)
+		return func() {}
+	}
+	return func() { prometheus.Unregister(c) }
+}
+
+// pullCollector implements prometheus.Collector.
+type pullCollector struct {
+	subsystem   string
+	minInterval time.Duration
+	provider    func() []Sample
+
+	mu            sync.Mutex
+	descs         map[string]*prometheus.Desc // key: name + label keys, discovered at registration
+	cached        []Sample
+	lastSampledAt time.Time
+}
+
+// Describe implements prometheus.Collector.
+func (c *pullCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, d := range c.descs {
+		ch <- d
+	}
+}
+
+// Collect implements prometheus.Collector, emitting const metrics from the
+// (cached) samples with their declared value type.
+func (c *pullCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	if now.Sub(c.lastSampledAt) >= c.minInterval {
+		c.refreshLocked()
+	}
+
+	for i := range c.cached {
+		s := &c.cached[i]
+		names, values := sortedLabels(s.Labels)
+		desc, ok := c.descs[descKey(s.Name, names)]
+		if !ok {
+			// Emitting an undescribed metric would fail Gather on a checked collector.
+			logger.Warn("pull collector produced an undescribed metric", "name", s.Name)
+			continue
+		}
+		valueType := prometheus.GaugeValue
+		if s.Kind == KindCounter {
+			valueType = prometheus.CounterValue
+		}
+		metric, err := prometheus.NewConstMetric(desc, valueType, s.Value, values...)
+		if err != nil {
+			logger.Warn("unable to create pull metric", "name", s.Name, "err", err)
+			continue
+		}
+		ch <- metric
+	}
+}
+
+func (c *pullCollector) refresh() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.refreshLocked()
+}
+
+// refreshLocked samples the provider, refreshes the cache and records any new
+// descriptors. The caller must hold c.mu.
+func (c *pullCollector) refreshLocked() {
+	samples := c.provider()
+	c.cached = samples
+	c.lastSampledAt = time.Now()
+	for i := range samples {
+		s := &samples[i]
+		names, _ := sortedLabels(s.Labels)
+		key := descKey(s.Name, names)
+		if _, ok := c.descs[key]; !ok {
+			c.descs[key] = prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, c.subsystem, s.Name),
+				s.Help,
+				names,
+				nil,
+			)
+		}
+	}
+}
+
+// descKey identifies a descriptor by metric name and its sorted label keys.
+func descKey(name string, sortedLabelNames []string) string {
+	return name + "\x00" + strings.Join(sortedLabelNames, "\x00")
+}
+
+// sortedLabels returns label names (sorted) and their matching values.
+func sortedLabels(labels map[string]string) (names, values []string) {
+	if len(labels) == 0 {
+		return nil, nil
+	}
+	names = make([]string, 0, len(labels))
+	for k := range labels {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	values = make([]string, len(names))
+	for i, n := range names {
+		values[i] = labels[n]
+	}
+	return names, values
+}

--- a/metrics/pull_test.go
+++ b/metrics/pull_test.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package metrics
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func gatherByName(t *testing.T) map[string]*dto.MetricFamily {
+	t.Helper()
+	mfs, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	out := make(map[string]*dto.MetricFamily)
+	for _, mf := range mfs {
+		out[mf.GetName()] = mf
+	}
+	return out
+}
+
+func TestRegisterPullCollectorNoop(t *testing.T) {
+	metrics = defaultNoopMetrics() // force the no-op service
+
+	var calls atomic.Int64
+	unregister := RegisterPullCollector("pulltest_noop", 0, func() []Sample {
+		calls.Add(1)
+		return []Sample{{Name: "value", Kind: KindGauge, Value: 1}}
+	})
+	require.NotNil(t, unregister)
+
+	// Nothing should have been registered, and a scrape must not invoke the provider.
+	_, present := gatherByName(t)["thor_metrics_pulltest_noop_value"]
+	require.False(t, present)
+	require.Equal(t, int64(0), calls.Load())
+
+	require.NotPanics(t, unregister)
+}
+
+func TestPullCollectorTTLAndTypes(t *testing.T) {
+	InitializePrometheusMetrics()
+
+	var calls atomic.Int64
+	unregister := RegisterPullCollector("pulltest_ttl", time.Hour, func() []Sample {
+		n := calls.Add(1)
+		return []Sample{
+			{Name: "gauge_value", Kind: KindGauge, Value: float64(n)},
+			{Name: "counter_value", Kind: KindCounter, Value: float64(10 * n)},
+			{Name: "labelled", Kind: KindGauge, Labels: map[string]string{"k": "v"}, Value: float64(n)},
+		}
+	})
+	defer unregister()
+
+	// First scrape populates the cache.
+	m := gatherByName(t)
+	require.Equal(t, int64(1), calls.Load())
+	require.Equal(t, dto.MetricType_GAUGE, m["thor_metrics_pulltest_ttl_gauge_value"].GetType())
+	require.Equal(t, dto.MetricType_COUNTER, m["thor_metrics_pulltest_ttl_counter_value"].GetType())
+	require.Equal(t, float64(1), m["thor_metrics_pulltest_ttl_gauge_value"].Metric[0].GetGauge().GetValue())
+	require.Equal(t, float64(10), m["thor_metrics_pulltest_ttl_counter_value"].Metric[0].GetCounter().GetValue())
+
+	// Labels are preserved.
+	labelled := m["thor_metrics_pulltest_ttl_labelled"].Metric[0]
+	require.Equal(t, "k", labelled.Label[0].GetName())
+	require.Equal(t, "v", labelled.Label[0].GetValue())
+
+	// Second scrape within the TTL window must reuse the cache (provider not called again).
+	m = gatherByName(t)
+	require.Equal(t, int64(1), calls.Load())
+	require.Equal(t, float64(1), m["thor_metrics_pulltest_ttl_gauge_value"].Metric[0].GetGauge().GetValue())
+
+	// After unregister the metric disappears.
+	unregister()
+	_, present := gatherByName(t)["thor_metrics_pulltest_ttl_gauge_value"]
+	require.False(t, present)
+}
+
+func TestPullCollectorNoTTLRefreshesEveryScrape(t *testing.T) {
+	InitializePrometheusMetrics()
+
+	var calls atomic.Int64
+	unregister := RegisterPullCollector("pulltest_nottl", 0, func() []Sample {
+		n := calls.Add(1)
+		return []Sample{{Name: "value", Kind: KindGauge, Value: float64(n)}}
+	})
+	defer unregister()
+
+	// Registration warms up the provider once (call #1) to discover descriptors, so
+	// with no TTL each subsequent scrape increments the value by one.
+	m := gatherByName(t)
+	require.Equal(t, float64(2), m["thor_metrics_pulltest_nottl_value"].Metric[0].GetGauge().GetValue())
+	m = gatherByName(t)
+	require.Equal(t, float64(3), m["thor_metrics_pulltest_nottl_value"].Metric[0].GetGauge().GetValue())
+	require.Equal(t, int64(3), calls.Load())
+}

--- a/muxdb/metrics.go
+++ b/muxdb/metrics.go
@@ -15,18 +15,37 @@ import (
 	"github.com/vechain/thor/v2/metrics"
 )
 
-var (
-	metricCacheHitMiss = metrics.LazyLoadGaugeVec("cache_hit_miss_count", []string{"type", "event"})
-	metricCompaction   = metrics.LazyLoadGaugeVec("compaction_stats_gauge", []string{"level", "type"})
-)
+var metricCacheHitMiss = metrics.LazyLoadGaugeVec("cache_hit_miss_count", []string{"type", "event"})
 
-func registerCompactionMetrics(stats *leveldb.DBStats) {
+// compactionSamples converts LevelDB per-level compaction stats into samples:
+// tables/size are gauges, cumulative time/read/write are counters.
+func compactionSamples(stats *leveldb.DBStats) []metrics.Sample {
+	samples := make([]metrics.Sample, 0, len(stats.LevelDurations)*5)
 	for i := range stats.LevelDurations {
 		lvl := strconv.Itoa(i)
-		metricCompaction().SetWithLabel(int64(stats.LevelTablesCounts[i]), map[string]string{"level": lvl, "type": "tables"})
-		metricCompaction().SetWithLabel(stats.LevelSizes[i], map[string]string{"level": lvl, "type": "size"})
-		metricCompaction().SetWithLabel(int64(stats.LevelDurations[i].Seconds()), map[string]string{"level": lvl, "type": "time"})
-		metricCompaction().SetWithLabel(stats.LevelRead[i], map[string]string{"level": lvl, "type": "read"})
-		metricCompaction().SetWithLabel(stats.LevelWrite[i], map[string]string{"level": lvl, "type": "write"})
+		gauge := func(typ string, value int64) {
+			samples = append(samples, metrics.Sample{
+				Name:   "compaction_stats_gauge",
+				Help:   "LevelDB per-level compaction gauges (current tables count and size).",
+				Kind:   metrics.KindGauge,
+				Labels: map[string]string{"level": lvl, "type": typ},
+				Value:  float64(value),
+			})
+		}
+		counter := func(typ string, value int64) {
+			samples = append(samples, metrics.Sample{
+				Name:   "compaction_stats_total",
+				Help:   "LevelDB per-level cumulative compaction counters (time seconds, read/write bytes).",
+				Kind:   metrics.KindCounter,
+				Labels: map[string]string{"level": lvl, "type": typ},
+				Value:  float64(value),
+			})
+		}
+		gauge("tables", int64(stats.LevelTablesCounts[i]))
+		gauge("size", stats.LevelSizes[i])
+		counter("time", int64(stats.LevelDurations[i].Seconds()))
+		counter("read", stats.LevelRead[i])
+		counter("write", stats.LevelWrite[i])
 	}
+	return samples
 }

--- a/muxdb/metrics_test.go
+++ b/muxdb/metrics_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 The VeChainThor developers
+
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package muxdb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/syndtr/goleveldb/leveldb"
+
+	"github.com/vechain/thor/v2/metrics"
+)
+
+func TestCompactionSamples(t *testing.T) {
+	stats := &leveldb.DBStats{
+		LevelDurations:    []time.Duration{2 * time.Second, 4 * time.Second},
+		LevelTablesCounts: []int{5, 9},
+		LevelSizes:        []int64{100, 200},
+		LevelRead:         []int64{1000, 2000},
+		LevelWrite:        []int64{3000, 4000},
+	}
+
+	samples := compactionSamples(stats)
+	// 2 levels * 5 types.
+	require.Len(t, samples, 10)
+
+	// Index by level+type for assertions.
+	type key struct{ level, typ string }
+	byKey := make(map[key]metrics.Sample)
+	for _, s := range samples {
+		byKey[key{s.Labels["level"], s.Labels["type"]}] = s
+	}
+
+	// Point-in-time values are gauges in the compaction_stats_gauge family.
+	for _, typ := range []string{"tables", "size"} {
+		s := byKey[key{"0", typ}]
+		require.Equal(t, "compaction_stats_gauge", s.Name)
+		require.Equal(t, metrics.KindGauge, s.Kind)
+	}
+	// Cumulative values are counters in the compaction_stats_total family.
+	for _, typ := range []string{"time", "read", "write"} {
+		s := byKey[key{"0", typ}]
+		require.Equal(t, "compaction_stats_total", s.Name)
+		require.Equal(t, metrics.KindCounter, s.Kind)
+	}
+
+	require.Equal(t, float64(5), byKey[key{"0", "tables"}].Value)
+	require.Equal(t, float64(200), byKey[key{"1", "size"}].Value)
+	require.Equal(t, float64(2), byKey[key{"0", "time"}].Value) // 2s -> 2
+	require.Equal(t, float64(1000), byKey[key{"0", "read"}].Value)
+	require.Equal(t, float64(4000), byKey[key{"1", "write"}].Value)
+}

--- a/muxdb/muxdb.go
+++ b/muxdb/muxdb.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/vechain/thor/v2/kv"
 	"github.com/vechain/thor/v2/log"
+	"github.com/vechain/thor/v2/metrics"
 	"github.com/vechain/thor/v2/muxdb/engine"
 	"github.com/vechain/thor/v2/trie"
 )
@@ -65,7 +66,8 @@ type MuxDB struct {
 	engine      engine.Engine
 	trieBackend *backend
 
-	done chan struct{}
+	// metricsUnregister releases the collector registered by EnableMetrics; nil if unset.
+	metricsUnregister func()
 }
 
 // Open opens or creates DB at the given path.
@@ -120,7 +122,6 @@ func Open(path string, options *Options) (*MuxDB, error) {
 			DedupedPtnFactor: cfg.DedupedPtnFactor,
 			CachedNodeTTL:    options.TrieCachedNodeTTL,
 		},
-		done: make(chan struct{}),
 	}, nil
 }
 
@@ -139,13 +140,14 @@ func NewMem() *MuxDB {
 			DedupedPtnFactor: 1,
 			CachedNodeTTL:    32,
 		},
-		done: make(chan struct{}),
 	}
 }
 
 // Close closes the DB.
 func (db *MuxDB) Close() error {
-	close(db.done)
+	if db.metricsUnregister != nil {
+		db.metricsUnregister()
+	}
 	return db.engine.Close()
 }
 
@@ -174,32 +176,27 @@ func (db *MuxDB) IsNotFound(err error) bool {
 	return db.engine.IsNotFound(err)
 }
 
+// EnableMetrics registers a pull collector exporting LevelDB compaction stats,
+// sampled on scrape at most once per metricsSampleInterval. No-op unless Prometheus
+// is initialized; call once per MuxDB.
 func (db *MuxDB) EnableMetrics() {
-	go func() {
-		ticker := time.NewTicker(metricsSampleInterval)
-		defer ticker.Stop()
-
-		var (
-			stats leveldb.DBStats
-			err   error
-		)
-		for {
-			select {
-			case <-ticker.C:
-				// we only have one engine implementation for now, put the type assertion just for safety
-				lvl, ok := db.engine.(*engine.LevelEngine)
-				if ok {
-					err = lvl.Stats(&stats)
-					if err != nil {
-						logger.Warn("Failed to get LevelDB stats: %v", err)
-					}
-					registerCompactionMetrics(&stats)
-				}
-			case <-db.done:
-				return
+	db.metricsUnregister = metrics.RegisterPullCollector(
+		"",
+		metricsSampleInterval,
+		func() []metrics.Sample {
+			// only one engine implementation exists; assert defensively
+			lvl, ok := db.engine.(*engine.LevelEngine)
+			if !ok {
+				return nil
 			}
-		}
-	}()
+			var stats leveldb.DBStats
+			if err := lvl.Stats(&stats); err != nil {
+				logger.Warn("Failed to get LevelDB stats", "err", err)
+				return nil
+			}
+			return compactionSamples(&stats)
+		},
+	)
 }
 
 type config struct {

--- a/muxdb/muxdb_test.go
+++ b/muxdb/muxdb_test.go
@@ -42,7 +42,6 @@ func TestNewMuxDB(t *testing.T) {
 
 	assert.NotNil(t, db.engine)
 	assert.NotNil(t, db.trieBackend)
-	assert.NotNil(t, db.done)
 }
 
 func TestNewMemDB(t *testing.T) {

--- a/muxdb/trie_test.go
+++ b/muxdb/trie_test.go
@@ -262,7 +262,6 @@ func TestGetAfterPrune(t *testing.T) {
 	mux := &MuxDB{
 		engine:      engine,
 		trieBackend: back,
-		done:        make(chan struct{}),
 	}
 
 	key := thor.Blake2b([]byte("key")).Bytes()

--- a/test/testnode/node.go
+++ b/test/testnode/node.go
@@ -78,8 +78,8 @@ func (n *node) Start() error {
 	engine := bft.NewMockedEngine(repo.GenesisBlock().Header().ID())
 
 	accounts.New(repo, stater, 40_000_000, 5*1024*1024/2, forkConfig, engine, true).Mount(router, "/accounts")
-	events.New(repo, logDB, 1000, 10).Mount(router, "/logs/event")
-	transfers.New(repo, logDB, 1000, 10).Mount(router, "/logs/transfer")
+	events.New(repo, logDB, 1000, 100_000, 10).Mount(router, "/logs/event")
+	transfers.New(repo, logDB, 1000, 100_000, 10).Mount(router, "/logs/transfer")
 	blocks.New(repo, engine).Mount(router, "/blocks")
 	transactions.New(repo, n.txPool).Mount(router, "/transactions")
 	debug.New(repo, stater, forkConfig, engine,


### PR DESCRIPTION
# Description

feat: add offset limit to logs pagination and db metrics

- enforce max offset for events/transfers log queries
- add logdb/muxdb metrics and a metrics pull endpoint

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
