### PR TITLE
ci(gosec): use go.mod for Go version + add manual trigger

### DIFF
--- a/.github/workflows/gosec.yaml
+++ b/.github/workflows/gosec.yaml
@@ -1,5 +1,6 @@
 name: Gosec
 on:
+  workflow_dispatch:
   schedule:
   #   # This is meant to run every day at 8am
     - cron:  '0 8 * * 1-5'
@@ -19,7 +20,7 @@ jobs:
         uses: actions/checkout@v5
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.26.x'
+          go-version-file: 'go.mod'
           cache: false
       - name: Run Gosec
         id: gosec-run


### PR DESCRIPTION
Scheduled Gosec scanned 0 packages: setup-go's `1.26.x` resolved older than go.mod's `1.26.5` and `GOTOOLCHAIN=local` blocked the download. Read the version from go.mod so it can't drift, and add `workflow_dispatch`.