### PR TITLE
ci: extract Slack notification into reusable workflow

### DIFF
--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -1,0 +1,55 @@
+name: Notify Slack
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      unit-test-status:      { type: string, required: true }
+      docker-publish-status: { type: string, required: true }
+      e2e-test-status:       { type: string, required: true }
+      lint-status:           { type: string, required: true }
+      license-check-status:  { type: string, required: true }
+      module-check-status:   { type: string, required: true }
+    secrets:
+      SLACK_WEBHOOK_URL:
+        required: true
+  workflow_dispatch:
+    inputs:
+      unit-test-status:      { type: string, default: 'success' }
+      docker-publish-status: { type: string, default: 'success' }
+      e2e-test-status:       { type: string, default: 'success' }
+      lint-status:           { type: string, default: 'success' }
+      license-check-status:  { type: string, default: 'success' }
+      module-check-status:   { type: string, default: 'success' }
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Get the commit message
+        # Only the first line: a multi-line message breaks the JSON payload.
+        run: echo "commit_message=$(git show-branch --no-name HEAD)" >> "$GITHUB_ENV"
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "unit-test-status": "${{ inputs.unit-test-status != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
+              "docker-publish-status": "${{ inputs.docker-publish-status != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
+              "commit-message": "${{ env.commit_message }}",
+              "commit-url": "${{ github.event.head_commit.url }}",
+              "e2e-test-status": "${{ inputs.e2e-test-status != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
+              "branch": "${{ github.ref }}",
+              "repository": "${{ github.repository }}",
+              "commit-author": "${{ github.event.head_commit.author.name }}",
+              "lint-status": "${{ inputs.lint-status != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
+              "license-check": "${{ inputs.license-check-status != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
+              "module-check": "${{ inputs.module-check-status != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}"
+            }

--- a/.github/workflows/on-master-commit.yaml
+++ b/.github/workflows/on-master-commit.yaml
@@ -112,31 +112,13 @@ jobs:
       needs.thor-docker-test-suite.result != 'success' || 
       needs.license-check.result != 'success' || 
       needs.module-check.result != 'success')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Get the commit message
-        id: commit_message
-        # This is a workaround to get the first line of the commit message. Passing the entire message can cause the payload (JSON) to be invalid.
-        run: |
-          echo "commit_message=$(git show-branch --no-name HEAD)" >> "$GITHUB_ENV"
-      - name: Notify Slack
-        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: webhook-trigger
-          payload: |
-            {
-              "unit-test-status": "${{ needs.run-unit-tests.result != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
-              "docker-publish-status": "${{ needs.publish-docker-image.result != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
-              "commit-message": "${{ env.commit_message }}",
-              "commit-url": "${{ github.event.head_commit.url }}",
-              "e2e-test-status": "${{ needs.thor-docker-test-suite.result != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
-              "branch": "${{ github.ref }}",
-              "repository": "${{ github.repository }}",
-              "commit-author": "${{ github.event.head_commit.author.name }}",
-              "lint-status": "${{ needs.lint.result != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
-              "license-check": "${{ needs.license-check.result != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}",
-              "module-check": "${{ needs.module-check.result != 'success' && ':alert: Failure' || ':white_check_mark: Success' }}"
-            }
+    uses: ./.github/workflows/notify-slack.yaml
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    with:
+      unit-test-status: ${{ needs.run-unit-tests.result }}
+      docker-publish-status: ${{ needs.publish-docker-image.result }}
+      e2e-test-status: ${{ needs.thor-docker-test-suite.result }}
+      lint-status: ${{ needs.lint.result }}
+      license-check-status: ${{ needs.license-check.result }}
+      module-check-status: ${{ needs.module-check.result }}


### PR DESCRIPTION
Stacked on #1638.

Extracts the `notify-slack` job from `on-master-commit.yaml` into a reusable workflow (`.github/workflows/notify-slack.yaml`).

### Why
- **Reuse**: any workflow can now send the CI-status Slack message via `uses:`.
- **Testable**: adds a `workflow_dispatch` trigger, so the notification can be fired manually to verify the payload/webhook without waiting for a master failure.

### Notes
- Job status results are passed as `inputs`; `SLACK_WEBHOOK_URL` is passed explicitly via `secrets:`.
- Commit metadata (`github.event.head_commit.*`, `github.ref`) is read from the inherited `github` context, so it is unchanged on the `workflow_call` path. On manual `workflow_dispatch` runs those fields are empty (no push payload) — expected, that path is for verifying the webhook/payload wiring.
- The failure-only `if:` gate stays in the caller job.