### PR TITLE
feat(p2p/discv5): add bootnode and node database persistence to disco

### DIFF
--- a/cmd/disco/flags.go
+++ b/cmd/disco/flags.go
@@ -33,6 +33,16 @@ var (
 		Usage:   "private key as hex",
 		Sources: envVar("KEYHEX"),
 	}
+	bootnodeFlag = &cli.StringSliceFlag{
+		Name:    "bootnode",
+		Usage:   "enode url of a bootnode to bootstrap the discovery from, can be repeated or comma separated",
+		Sources: envVar("BOOTNODE"),
+	}
+	nodeDBFlag = &cli.StringFlag{
+		Name:    "nodedb",
+		Usage:   "directory to persist the discovered peers, empty means in-memory only",
+		Sources: envVar("NODEDB"),
+	}
 	natFlag = &cli.StringFlag{
 		Name:    "nat",
 		Value:   "none",

--- a/cmd/disco/main.go
+++ b/cmd/disco/main.go
@@ -34,6 +34,8 @@ var (
 		addrFlag,
 		keyFileFlag,
 		keyHexFlag,
+		bootnodeFlag,
+		nodeDBFlag,
 		natFlag,
 		netRestrictFlag,
 		verbosityFlag,
@@ -66,6 +68,16 @@ func run(_ context.Context, ctx *cli.Command) error {
 		}
 	}
 
+	bootnodes, err := parseBootnodes(ctx.StringSlice(bootnodeFlag.Name))
+	if err != nil {
+		return errors.Wrap(err, "-bootnode")
+	}
+
+	nodeDBPath, err := resolveNodeDBPath(ctx.String(nodeDBFlag.Name))
+	if err != nil {
+		return errors.Wrap(err, "-nodedb")
+	}
+
 	netrestrict := ctx.String("netrestrict")
 	var restrictList *netutil.Netlist
 	if netrestrict != "" {
@@ -94,11 +106,20 @@ func run(_ context.Context, ctx *cli.Command) error {
 			realAddr = &net.UDPAddr{IP: ext, Port: realAddr.Port}
 		}
 	}
-	network, err := discv5.ListenUDP(key, conn, realAddr, "", restrictList)
+	network, err := discv5.ListenUDP(key, conn, realAddr, nodeDBPath, restrictList)
 	if err != nil {
 		return err
 	}
 	defer network.Close()
+	if len(bootnodes) > 0 {
+		if err := network.SetFallbackNodes(bootnodes); err != nil {
+			return errors.Wrap(err, "-bootnode")
+		}
+		fmt.Println("Bootstrapping from", len(bootnodes), "bootnode(s)")
+	}
+	if nodeDBPath != "" {
+		fmt.Println("Peers persisted at", nodeDBPath)
+	}
 	fmt.Println("Running", network.Self().String())
 
 	exitSignal := handleExitSignal()

--- a/cmd/disco/utils.go
+++ b/cmd/disco/utils.go
@@ -16,13 +16,16 @@ import (
 	"os/signal"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	ethlog "github.com/ethereum/go-ethereum/log"
 	"github.com/mattn/go-isatty"
+	"github.com/pkg/errors"
 
 	"github.com/vechain/thor/v2/log"
+	"github.com/vechain/thor/v2/p2p/discv5"
 )
 
 func initLogger(lvl int) *slog.LevelVar {
@@ -47,17 +50,17 @@ type ethLogger struct {
 func (h *ethLogger) Log(r *ethlog.Record) error {
 	switch r.Lvl {
 	case ethlog.LvlCrit:
-		h.logger.Crit(r.Msg)
+		h.logger.Crit(r.Msg, r.Ctx...)
 	case ethlog.LvlError:
-		h.logger.Error(r.Msg)
+		h.logger.Error(r.Msg, r.Ctx...)
 	case ethlog.LvlWarn:
-		h.logger.Warn(r.Msg)
+		h.logger.Warn(r.Msg, r.Ctx...)
 	case ethlog.LvlInfo:
-		h.logger.Info(r.Msg)
+		h.logger.Info(r.Msg, r.Ctx...)
 	case ethlog.LvlDebug:
-		h.logger.Debug(r.Msg)
+		h.logger.Debug(r.Msg, r.Ctx...)
 	case ethlog.LvlTrace:
-		h.logger.Trace(r.Msg)
+		h.logger.Trace(r.Msg, r.Ctx...)
 	default:
 		break
 	}
@@ -90,6 +93,40 @@ func loadOrGenerateKeyFile(keyFile string) (key *ecdsa.PrivateKey, err error) {
 		return nil, err
 	}
 	return key, nil
+}
+
+// parseBootnodes turns the raw enode urls into discovery nodes, blank entries
+// are skipped.
+func parseBootnodes(urls []string) ([]*discv5.Node, error) {
+	nodes := make([]*discv5.Node, 0, len(urls))
+	for _, url := range urls {
+		url = strings.TrimSpace(url)
+		if url == "" {
+			continue
+		}
+		node, err := discv5.ParseNode(url)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid bootnode %q", url)
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+// resolveNodeDBPath normalizes the path of the discovery node database.
+// An empty path keeps the discovered peers in memory only.
+func resolveNodeDBPath(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	if !filepath.IsAbs(path) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return "", err
+		}
+		path = abs
+	}
+	return path, nil
 }
 
 func defaultKeyFile() string {

--- a/cmd/disco/utils_test.go
+++ b/cmd/disco/utils_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"math"
+	"path/filepath"
 	"testing"
 )
 
@@ -35,5 +36,70 @@ func TestReadIntFromUInt64Flag_TooLarge(t *testing.T) {
 	val := uint64(math.MaxInt) + 1
 	if _, err := readIntFromUInt64Flag(val); err == nil {
 		t.Fatalf("expected error for value > MaxInt")
+	}
+}
+
+const testEnode = "enode://f0e93c6be07f15427a017d158498c7ca9397541d24b4efbd1bb368155f6de1ae07a9a2da81a7f116e60e86c26eb0c70f2cae4516c3b5b6cfe2e5f522252665cc@54.78.133.203:55555"
+
+func TestParseBootnodes_None(t *testing.T) {
+	nodes, err := parseBootnodes(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Fatalf("want no nodes, got %d", len(nodes))
+	}
+}
+
+func TestParseBootnodes_SkipsBlanks(t *testing.T) {
+	nodes, err := parseBootnodes([]string{" " + testEnode + " ", "", "   "})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("want 1 node, got %d", len(nodes))
+	}
+	if got := nodes[0].String(); got != testEnode {
+		t.Fatalf("want %q, got %q", testEnode, got)
+	}
+}
+
+func TestParseBootnodes_Invalid(t *testing.T) {
+	if _, err := parseBootnodes([]string{testEnode, "not-an-enode"}); err == nil {
+		t.Fatalf("expected error for malformed enode")
+	}
+}
+
+func TestResolveNodeDBPath_Empty(t *testing.T) {
+	got, err := resolveNodeDBPath("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("want empty path (in-memory), got %q", got)
+	}
+}
+
+func TestResolveNodeDBPath_Absolute(t *testing.T) {
+	abs := filepath.Join(t.TempDir(), "nodes")
+	got, err := resolveNodeDBPath(abs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != abs {
+		t.Fatalf("want %q, got %q", abs, got)
+	}
+}
+
+func TestResolveNodeDBPath_Relative(t *testing.T) {
+	got, err := resolveNodeDBPath("nodes")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Fatalf("want an absolute path, got %q", got)
+	}
+	if filepath.Base(got) != "nodes" {
+		t.Fatalf("want base 'nodes', got %q", got)
 	}
 }

--- a/docs/command_line_arguments.md
+++ b/docs/command_line_arguments.md
@@ -78,6 +78,8 @@ bin/disco -h
 | `--addr`        | The to listen on (default: ":55555").                                                   |
 | `--keyfile`     | The path to the private key file of the discovery node.                                 |
 | `--keyhex`      | The hex-encoded private key of the discovery node.                                      |
+| `--bootnode`    | Enode url of a bootnode to bootstrap the discovery from, repeatable or comma separated. |
+| `--nodedb`      | Directory to persist the discovered peers, empty means in-memory only.                  |
 | `--nat`         | The port mapping mechanism (any \| none \| upnp \| pmp \| extip:<IP>) (default: "none") |
 | `--netrestrict` | Restrict network communication to the given IP networks (CIDR masks)                    |
 | `--verbosity`   | The log level for the discovery node (0-9) (default: 2).                                |

--- a/p2p/discv5/net.go
+++ b/p2p/discv5/net.go
@@ -409,6 +409,12 @@ func (net *Network) loop() {
 
 	statsDump := time.NewTicker(10 * time.Second)
 
+	// Bring the peers left in the database by a previous run back into the
+	// table right away, instead of waiting for the first refresh tick.
+	if net.db != nil {
+		net.addSeeds(net.db.querySeeds(seedCount, seedMaxAge))
+	}
+
 loop:
 	for {
 		resetNextTicket()
@@ -677,37 +683,38 @@ loop:
 // Everything below runs on the Network.loop goroutine
 // and can modify Node, Table and Network at any time without locking.
 
+// addSeeds force-adds the given nodes to the table and starts verifying the
+// ones which are not known yet. Force-adding makes sure Lookup has something to
+// work with, unverifiable nodes are dropped again later on.
+func (net *Network) addSeeds(seeds []*Node) {
+	for _, n := range seeds {
+		age := "unknown"
+		if net.db != nil {
+			age = time.Since(net.db.lastPong(n.ID)).String()
+		}
+		log.Debug("Found seed node", "id", n.ID, "addr", n.addr(), "age", age)
+		n = net.internNodeFromDB(n)
+		if n.state == unknown {
+			net.transition(n, verifyinit)
+		}
+		net.tab.add(n)
+	}
+}
+
 func (net *Network) refresh(done chan<- struct{}) {
 	var seeds []*Node
 	if net.db != nil {
 		seeds = net.db.querySeeds(seedCount, seedMaxAge)
 	}
-	if len(seeds) == 0 {
-		seeds = net.nursery
-	}
+	// The fallback nodes are always kept, they are the only way back in when
+	// every peer of the previous run is gone.
+	seeds = append(seeds, net.nursery...)
 	if len(seeds) == 0 {
 		log.Trace("no seed nodes found")
 		time.AfterFunc(time.Second*10, func() { close(done) })
 		return
 	}
-	for _, n := range seeds {
-		log.Debug("", "msg", log.Lazy{Fn: func() string {
-			var age string
-			if net.db != nil {
-				age = time.Since(net.db.lastPong(n.ID)).String()
-			} else {
-				age = "unknown"
-			}
-			return fmt.Sprintf("seed node (age %s): %v", age, n)
-		}})
-		n = net.internNodeFromDB(n)
-		if n.state == unknown {
-			net.transition(n, verifyinit)
-		}
-		// Force-add the seed node so Lookup does something.
-		// It will be deleted again if verification fails.
-		net.tab.add(n)
-	}
+	net.addSeeds(seeds)
 	// Start self lookup to fill up the buckets.
 	go func() {
 		net.Lookup(net.tab.self.ID)
@@ -972,6 +979,9 @@ func init() {
 		enter: func(net *Network, n *Node) {
 			n.queryTimeouts = 0
 			n.startNextQuery(net)
+			// Persist the verified node, so that it can be used as a seed
+			// after a restart.
+			net.persistNode(n)
 			// Insert into the table and start revalidation of the last node
 			// in the bucket if it is full.
 			last := net.tab.add(n)
@@ -1142,6 +1152,22 @@ func (net *Network) handlePing(n *Node, pkt *ingressPacket) {
 	}
 	ticketToPong(t, pong)
 	net.conn.send(n, pongPacket, pong)
+}
+
+// persistNode saves a node which passed the endpoint verification into the node
+// database, along with the time it was last seen alive. It is a no-op when the
+// network runs without a database.
+func (net *Network) persistNode(n *Node) {
+	if net.db == nil {
+		return
+	}
+	if err := net.db.updateNode(n); err != nil {
+		log.Debug("Failed to persist node", "id", n.ID, "err", err)
+		return
+	}
+	if err := net.db.updateLastPong(n.ID, time.Now()); err != nil {
+		log.Debug("Failed to persist last pong", "id", n.ID, "err", err)
+	}
 }
 
 func (net *Network) handleKnownPong(n *Node, pkt *ingressPacket) error {

--- a/p2p/discv5/persist_test.go
+++ b/p2p/discv5/persist_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 The VeChainThor developers
+//
+// Distributed under the GNU Lesser General Public License v3.0 software license, see the accompanying
+// file LICENSE or <https://www.gnu.org/licenses/lgpl-3.0.html>
+
+package discv5
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func listenLocal(t *testing.T, dbPath string) *Network {
+	t.Helper()
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IP{127, 0, 0, 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	realaddr := conn.LocalAddr().(*net.UDPAddr)
+	network, err := ListenUDP(key, conn, realaddr, dbPath, nil)
+	if err != nil {
+		conn.Close()
+		t.Fatal(err)
+	}
+	return network
+}
+
+// TestSeedFromNodeDBAtStartup asserts that a node whose database holds peers
+// from a previous run starts talking to them right away, without any bootnode
+// configured.
+func TestSeedFromNodeDBAtStartup(t *testing.T) {
+	// the peer to be rediscovered, it records whoever verifies it
+	seed := listenLocal(t, filepath.Join(t.TempDir(), "seed-nodes"))
+	defer seed.Close()
+
+	// leave the database as a previous run would have left it
+	dbPath := filepath.Join(t.TempDir(), "nodes")
+	db, err := newNodeDB(dbPath, Version, NodeID{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.updateNode(seed.Self()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.updateLastPong(seed.Self().ID, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	db.close()
+
+	restarted := listenLocal(t, dbPath)
+	defer restarted.Close()
+
+	restartedID := restarted.Self().ID
+	deadline := time.Now().Add(20 * time.Second)
+	for seed.db.node(restartedID) == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("restarted node did not contact the peer persisted in its database")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestRefreshKeepsFallbackNodes asserts that the configured fallback nodes are
+// contacted even when the database already holds seeds from a previous run.
+func TestRefreshKeepsFallbackNodes(t *testing.T) {
+	persisted := listenLocal(t, filepath.Join(t.TempDir(), "persisted-nodes"))
+	defer persisted.Close()
+	fallback := listenLocal(t, filepath.Join(t.TempDir(), "fallback-nodes"))
+	defer fallback.Close()
+
+	dbPath := filepath.Join(t.TempDir(), "nodes")
+	db, err := newNodeDB(dbPath, Version, NodeID{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.updateNode(persisted.Self()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.updateLastPong(persisted.Self().ID, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	db.close()
+
+	restarted := listenLocal(t, dbPath)
+	defer restarted.Close()
+	if err := restarted.SetFallbackNodes([]*Node{fallback.Self()}); err != nil {
+		t.Fatal(err)
+	}
+
+	restartedID := restarted.Self().ID
+	deadline := time.Now().Add(20 * time.Second)
+	for persisted.db.node(restartedID) == nil || fallback.db.node(restartedID) == nil {
+		if time.Now().After(deadline) {
+			t.Fatalf("persisted seed reached: %t, fallback node reached: %t",
+				persisted.db.node(restartedID) != nil, fallback.db.node(restartedID) != nil)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestPersistVerifiedPeers asserts that a node running with a persistent node
+// database records the peers it verified, and hands them back as seeds after a
+// restart.
+func TestPersistVerifiedPeers(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "nodes")
+
+	bootnode := listenLocal(t, dbPath)
+	peer := listenLocal(t, "")
+	defer peer.Close()
+
+	if err := peer.SetFallbackNodes([]*Node{bootnode.Self()}); err != nil {
+		t.Fatal(err)
+	}
+
+	peerID := peer.Self().ID
+	deadline := time.Now().Add(20 * time.Second)
+	for bootnode.db.node(peerID) == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("bootnode did not persist the verified peer")
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if lastPong := bootnode.db.lastPong(peerID); lastPong.IsZero() {
+		t.Fatal("bootnode did not persist the last pong of the verified peer")
+	}
+	bootnode.Close()
+
+	// restart on the same database, the peer must come back as a seed
+	restarted := listenLocal(t, dbPath)
+	defer restarted.Close()
+
+	seeds := restarted.db.querySeeds(10, 24*time.Hour)
+	for _, seed := range seeds {
+		if seed.ID == peerID {
+			return
+		}
+	}
+	t.Fatalf("peer not returned as seed, got %d seeds", len(seeds))
+}


### PR DESCRIPTION
# Description

feat(p2p/discv5): add bootnode and node database persistence to disco.
- Two new flags:
    - `--bootnode`: Enode url of a bootnode to bootstrap the discovery from, repeatable or comma separated.
    - `--nodedb`: Directory to persist the discovered peers, empty means in-memory only.  

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also
list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:

* Go Version:
* Hardware:
* Docker Version:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
