### PR TITLE
ci: fall back to default ref when the external test-suite branch is absent

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -38,8 +38,9 @@ jobs:
             fi
           fi
 
-          # Verify if branch exists
-          if ! git ls-remote --heads https://github.com/vechain/thor-e2e-tests.git "$REF"; then
+          # Verify the branch exists. ls-remote exits 0 with empty output when the
+          # ref is absent, so test the output rather than the exit code.
+          if [ -z "$(git ls-remote --heads https://github.com/vechain/thor-e2e-tests.git "$REF")" ]; then
             echo "Branch does not exist, using default commit"
             echo "ref=$DEFAULT_COMMIT" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/test-rosetta.yaml
+++ b/.github/workflows/test-rosetta.yaml
@@ -46,8 +46,9 @@ jobs:
             fi
           fi
 
-          # Verify if branch exists
-          if ! git ls-remote --heads https://github.com/vechain/rosetta.git $REF; then
+          # Verify the branch exists. ls-remote exits 0 with empty output when the
+          # ref is absent, so test the output rather than the exit code.
+          if [ -z "$(git ls-remote --heads https://github.com/vechain/rosetta.git "$REF")" ]; then
             echo "Branch does not exist, using default branch"
             echo "ref=$DEFAULT_BRANCH" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -40,8 +40,9 @@ jobs:
             fi
           fi
 
-          # Verify if branch exists using GitHub API instead of git ls-remote
-          if curl -s -H "Authorization: token ${{ secrets.DRAUPNIR_TOKEN }}" \
+          # Verify the branch exists. -f makes curl exit non-zero on HTTP 404,
+          # so a missing branch falls through to the default commit.
+          if curl -sf -H "Authorization: token ${{ secrets.DRAUPNIR_TOKEN }}" \
           "https://api.github.com/repos/vechain/draupnir/branches/$REF" >/dev/null 2>&1; then
             echo "Branch $REF exists"
             echo "ref=$REF" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

The e2e, smoke and rosetta jobs pick the external test-suite ref (thor-e2e-tests / draupnir / rosetta) from the PR base branch, falling back to a default when that branch doesn't exist. The existence check tested the command's exit code, which is 0 even when the branch is missing (`git ls-remote` returns empty; `curl` without `-f` succeeds on 404), so the fallback never triggered and checkout failed on a nonexistent ref.

- e2e / rosetta: test whether `git ls-remote` output is empty instead of its exit code
- smoke: add `-f` so `curl` fails on HTTP 404

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing E2E tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code
